### PR TITLE
fix 部署后插件页面刷新403问题

### DIFF
--- a/src/layouts/components/DefaultLayoutWithVerticalNav.vue
+++ b/src/layouts/components/DefaultLayoutWithVerticalNav.vue
@@ -138,7 +138,7 @@ import UserProfile from '@/layouts/components/UserProfile.vue'
         :item="{
           title: '插件',
           icon: 'mdi-apps',
-          to: '/plugin',
+          to: '/plugins',
         }"
       />
       <VerticalNavLink

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -77,7 +77,7 @@ const router = createRouter({
           },
         },
         {
-          path: 'plugin',
+          path: 'plugins',
           component: () => import('../pages/plugin.vue'),
           meta: {
             requiresAuth: true,


### PR DESCRIPTION
就改了个路径

因为部署打包完public下有个plugin文件夹放的图片

然而之前插件页面路由也是plugin，nginx直接反代请求plugin文件夹了。