### PR TITLE
fix: 从qbt后台的返回值来更新下载状态

### DIFF
--- a/src/components/cards/DownloadingCard.vue
+++ b/src/components/cards/DownloadingCard.vue
@@ -23,6 +23,11 @@ function getSpeedText() {
 // 下载状态
 const isDownloading = ref(props.info?.state === 'downloading')
 
+// 监听props.info?.state的变化
+watch(() => props.info?.state, (newValue) => {
+  isDownloading.value = newValue === 'downloading';
+});
+
 // 图片是否加载完成
 const imageLoaded = ref(false)
 


### PR DESCRIPTION
之前下载状态只有第一次进页面，以及点击操作后才会更新下载状态
如果后台qbittorrent进行了操作就会出现状态不一致的情况。

现在的能周期性同步qbittorrent的下载或暂停的状态。