### PR TITLE
fix: toast message not visible

### DIFF
--- a/src/views/plugin/PluginCardListView.vue
+++ b/src/views/plugin/PluginCardListView.vue
@@ -105,6 +105,7 @@ onBeforeMount(() => {
     fullscreen
     scrollable
     :scrim="false"
+    :z-index="1010"
     transition="dialog-bottom-transition"
   >
     <!-- Dialog Activator -->


### PR DESCRIPTION
When install plugin failed, `z-index` of toast is `1090` while `v-dialog` is `2400`.