### PR TITLE
add: 首页仪表盘配置持久化与用户绑定

### DIFF
--- a/src/pages/dashboard.vue
+++ b/src/pages/dashboard.vue
@@ -9,6 +9,7 @@ import AnalyticsMemory from '@/views/dashboard/AnalyticsMemory.vue'
 import MediaServerLatest from '@/views/dashboard/MediaServerLatest.vue'
 import MediaServerLibrary from '@/views/dashboard/MediaServerLibrary.vue'
 import MediaServerPlaying from '@/views/dashboard/MediaServerPlaying.vue'
+import api from '@/api'
 
 // 仪表盘配置
 const dashboard_names = {
@@ -40,146 +41,109 @@ const default_config = {
   playing: true,
   latest: true,
 }
+
+// 更新数据库
+const updateDashboardConfig = () => {
+  api
+    .put('/config/dashboard', config.value)
+    .then((response: any) => {
+      console.log(response)
+    })
+    .catch((error: any) => {
+      // todo: 应使用通知组件
+      console.log(error)
+    })
+}
+
 const config = ref(JSON.parse(localStorage.getItem('MP_DASHBOARD') || '{}'))
+
+// 从数据库中获取数据
+const fetchDashboardConfig = () => {
+  api
+    .get('/config/dashboard')
+    .then((response: any) => {
+      config.value = response
+    })
+    .catch((error: any) => {
+      // todo: 应使用通知组件
+      console.log(error)
+    })
+}
+fetchDashboardConfig()
+
+// 如果localStorage中没有数据，则使用默认数据并缓存
 if (Object.keys(config.value).length === 0) {
   config.value = default_config
-  localStorage.setItem('MP_DASHBOARD', JSON.stringify(config.value))
+  setDashboardConfig()
 }
 
 // 设置项目
 function setDashboardConfig() {
   localStorage.setItem('MP_DASHBOARD', JSON.stringify(config.value))
+  updateDashboardConfig()
   dialog.value = false
 }
 </script>
 
 <template>
   <!-- 底部操作按钮 -->
-  <VFab
-    icon="mdi-view-dashboard-edit"
-    location="bottom end"
-    size="x-large"
-    fixed
-    app
-    appear
-    @click="dialog = true"
-  />
+  <VFab icon="mdi-view-dashboard-edit" location="bottom end" size="x-large" fixed app appear @click="dialog = true" />
   <VRow class="match-height">
-    <VCol
-      v-if="config.storage"
-      cols="12"
-      md="4"
-    >
+    <VCol v-if="config.storage" cols="12" md="4">
       <AnalyticsStorage />
     </VCol>
 
-    <VCol
-      v-if="config.mediaStatistic"
-      cols="12"
-      md="8"
-    >
+    <VCol v-if="config.mediaStatistic" cols="12" md="8">
       <AnalyticsMediaStatistic />
     </VCol>
 
-    <VCol
-      v-if="config.weeklyOverview"
-      cols="12"
-      md="4"
-    >
+    <VCol v-if="config.weeklyOverview" cols="12" md="4">
       <AnalyticsWeeklyOverview />
     </VCol>
 
-    <VCol
-      v-if="config.speed"
-      cols="12"
-      md="4"
-    >
+    <VCol v-if="config.speed" cols="12" md="4">
       <AnalyticsSpeed />
     </VCol>
 
-    <VCol
-      v-if="config.scheduler"
-      cols="12"
-      md="4"
-    >
+    <VCol v-if="config.scheduler" cols="12" md="4">
       <AnalyticsScheduler />
     </VCol>
 
-    <VCol
-      v-if="config.cpu"
-      cols="12"
-      md="6"
-    >
+    <VCol v-if="config.cpu" cols="12" md="6">
       <AnalyticsCpu />
     </VCol>
 
-    <VCol
-      v-if="config.memory"
-      cols="12"
-      md="6"
-    >
+    <VCol v-if="config.memory" cols="12" md="6">
       <AnalyticsMemory />
     </VCol>
 
-    <VCol
-      v-if="config.library"
-      cols="12"
-    >
+    <VCol v-if="config.library" cols="12">
       <MediaServerLibrary />
     </VCol>
 
-    <VCol
-      v-if="config.playing"
-      cols="12"
-    >
+    <VCol v-if="config.playing" cols="12">
       <MediaServerPlaying />
     </VCol>
 
-    <VCol
-      v-if="config.latest"
-      cols="12"
-    >
+    <VCol v-if="config.latest" cols="12">
       <MediaServerLatest />
     </VCol>
   </VRow>
   <!-- 弹窗，根据配置生成选项 -->
-  <VDialog
-    v-model="dialog"
-    max-width="600"
-    scrollable
-  >
+  <VDialog v-model="dialog" max-width="600" scrollable>
     <VCard title="设置仪表板">
       <VCardText>
         <VRow>
-          <VCol
-            v-for="(item, key) in dashboard_names"
-            :key="key"
-            cols="12"
-            md="4"
-          >
-            <VCheckbox
-              v-model="config[key]"
-              :label="dashboard_names[key]"
-            />
+          <VCol v-for="(item, key) in dashboard_names" :key="key" cols="12" md="4">
+            <VCheckbox v-model="config[key]" :label="dashboard_names[key]" />
           </VCol>
         </VRow>
       </VCardText>
       <VCardActions>
-        <VBtn
-          color="primary"
-          @click="dialog = false"
-        >
-          取消
-        </VBtn>
+        <VBtn color="primary" @click="dialog = false"> 取消 </VBtn>
         <VSpacer />
-        <VBtn
-          color="primary"
-          variant="tonal"
-          @click="setDashboardConfig"
-        >
-          保存
-        </VBtn>
+        <VBtn color="primary" variant="tonal" @click="setDashboardConfig"> 保存 </VBtn>
       </VCardActions>
     </VCard>
-  </vdialog>
+  </VDialog>
 </template>


### PR DESCRIPTION
解决：https://github.com/jxxghp/MoviePilot/issues/1862

保留从浏览器localstorage读取配置选项，增加从接口获取仪表盘配置功能
 
请与后端一并部署