### PR TITLE
fix 安卓手机端hover事件被VCard click事件覆盖的问题

### DIFF
--- a/src/components/cards/MediaCard.vue
+++ b/src/components/cards/MediaCard.vue
@@ -364,14 +364,16 @@ function getExistText(season: number) {
 }
 
 // 打开详情页
-function goMediaDetail() {
-  router.push({
-    path: '/media',
-    query: {
-      mediaid: getMediaId(),
-      type: props.media?.type,
-    },
-  })
+function goMediaDetail(isHovering = false) {
+  if (isHovering) {
+    router.push({
+      path: '/media',
+      query: {
+        mediaid: getMediaId(),
+        type: props.media?.type,
+      },
+    })
+  }
 }
 
 // 开始搜索
@@ -440,7 +442,7 @@ function getYear(airDate: string) {
           'transition transform-cpu duration-300 scale-105 shadow-lg': hover.isHovering,
           'ring-1': isImageLoaded,
         }"
-        @click.stop="goMediaDetail"
+        @click.stop="goMediaDetail(hover.isHovering)"
       >
         <VImg
           aspect-ratio="2/3"


### PR DESCRIPTION
加了一个判断条件，只有在isHovering 为true的时候，点击才会去跳转。

我测试了安卓上的 Chrome， Edge，夸克，UC，QQ浏览器。都是正常的。
苹果这边我没法测试。