### PR TITLE
解决路由回跳缺陷

### DIFF
--- a/src/layouts/components/UserProfile.vue
+++ b/src/layouts/components/UserProfile.vue
@@ -23,7 +23,8 @@ const progressDialog = ref(false)
 function logout() {
   // 清除登录状态信息
   store.dispatch('auth/clearToken')
-
+  // 主动登出时清除路由标记
+  store.state.auth.originalPath = null
   // 重定向到登录页面或其他适当的页面
   router.push('/login')
 }

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -159,10 +159,11 @@ const router = createRouter({
 
 // 路由导航守卫
 router.beforeEach((to, from, next) => {
+  // 总是记录非login路由
+  if (to.fullPath != '/login') store.state.auth.originalPath = to.fullPath
   const isAuthenticated = store.state.auth.token !== null
 
   if (to.meta.requiresAuth && !isAuthenticated) {
-    store.state.auth.originalPath = to.fullPath
     next('/login')
   }
   else {


### PR DESCRIPTION
1、手动退出后重新登录会错误地回到上次丢失认证时记录的路由页面；
2、后端接口403时会错误地回到上次丢失认证时记录的路由页面而不是触发403时的当前页面；