### PR TITLE
捷径新增插件数据页选择器

### DIFF
--- a/src/layouts/components/ShortcutBar.vue
+++ b/src/layouts/components/ShortcutBar.vue
@@ -5,6 +5,7 @@ import LoggingView from '@/views/system/LoggingView.vue'
 import RuleTestView from '@/views/system/RuleTestView.vue'
 import ModuleTestView from '@/views/system/ModuleTestView.vue'
 import MessageView from '@/views/system/MessageView.vue'
+import PluginPageSelector from '@/views/plugin/PluginPageSelector.vue'
 import store from '@/store'
 import api from '@/api'
 import { useDisplay } from 'vuetify'
@@ -32,6 +33,9 @@ const systemTestDialog = ref(false)
 
 // 消息中心弹窗
 const messageDialog = ref(false)
+
+// 插件数据页选择器弹窗
+const pluginPageSelectorDialog = ref(false)
 
 // 输入消息
 const user_message = ref('')
@@ -82,7 +86,7 @@ onMounted(() => {
   <VMenu
     v-model="appsMenu"
     max-width="600"
-    width="340"
+    width="440"
     max-height="560"
     location="top end"
     origin="top end"
@@ -107,7 +111,7 @@ onMounted(() => {
       </VCardItem>
       <div class="ps ps--active-y">
         <VRow class="ma-0 mt-n1">
-          <VCol cols="6" class="text-center cursor-pointer pa-0 shortcut-icon border-e">
+          <VCol cols="4" class="text-center cursor-pointer pa-0 shortcut-icon border">
             <VListItem class="pa-4" @click="nameTestDialog = true">
               <VAvatar size="48" variant="tonal">
                 <VIcon icon="mdi-text-recognition" />
@@ -116,7 +120,7 @@ onMounted(() => {
               <span class="text-sm">名称识别测试</span>
             </VListItem>
           </VCol>
-          <VCol cols="6" class="text-center cursor-pointer pa-0 shortcut-icon border-e" @click="() => {}">
+          <VCol cols="4" class="text-center cursor-pointer pa-0 shortcut-icon border" @click="() => {}">
             <VListItem class="pa-4" @click="ruleTestDialog = true">
               <VAvatar size="48" variant="tonal">
                 <VIcon icon="mdi-filter-cog-outline" />
@@ -125,9 +129,7 @@ onMounted(() => {
               <span class="text-sm">优先级规则测试</span>
             </VListItem>
           </VCol>
-        </VRow>
-        <VRow class="ma-0 mt-n1 border-t">
-          <VCol cols="6" class="text-center cursor-pointer pa-0 shortcut-icon border-e" @click="() => {}">
+          <VCol cols="4" class="text-center cursor-pointer pa-0 shortcut-icon border" @click="() => {}">
             <VListItem class="pa-4" @click="loggingDialog = true">
               <VAvatar size="48" variant="tonal">
                 <VIcon icon="mdi-file-document-outline" />
@@ -136,7 +138,7 @@ onMounted(() => {
               <span class="text-sm">实时日志</span>
             </VListItem>
           </VCol>
-          <VCol cols="6" class="text-center cursor-pointer pa-0 shortcut-icon" @click="() => {}">
+          <VCol cols="4" class="text-center cursor-pointer pa-0 shortcut-icon border" @click="() => {}">
             <VListItem class="pa-4" @click="netTestDialog = true">
               <VAvatar size="48" variant="tonal">
                 <VIcon icon="mdi-network-outline" />
@@ -145,9 +147,7 @@ onMounted(() => {
               <span class="text-sm">网速连通性测试</span>
             </VListItem>
           </VCol>
-        </VRow>
-        <VRow class="ma-0 mt-n1 border-t">
-          <VCol cols="6" class="text-center cursor-pointer pa-0 shortcut-icon border-e" @click="() => {}">
+          <VCol cols="4" class="text-center cursor-pointer pa-0 shortcut-icon border" @click="() => {}">
             <VListItem class="pa-4" @click="systemTestDialog = true">
               <VAvatar size="48" variant="tonal">
                 <VIcon icon="mdi-cog-outline" />
@@ -156,13 +156,22 @@ onMounted(() => {
               <span class="text-sm">健康检查</span>
             </VListItem>
           </VCol>
-          <VCol cols="6" class="text-center cursor-pointer pa-0 shortcut-icon border-e" @click="() => {}">
+          <VCol cols="4" class="text-center cursor-pointer pa-0 shortcut-icon border" @click="() => {}">
             <VListItem class="pa-4" @click="messageDialog = true">
               <VAvatar size="48" variant="tonal">
                 <VIcon icon="mdi-message-outline" />
               </VAvatar>
               <h6 class="text-base font-weight-medium mt-2 mb-0">消息</h6>
               <span class="text-sm">消息中心</span>
+            </VListItem>
+          </VCol>
+          <VCol cols="4" class="text-center cursor-pointer pa-0 shortcut-icon border" @click="() => {}">
+            <VListItem class="pa-4" @click="pluginPageSelectorDialog = true">
+              <VAvatar size="48" variant="tonal">
+                <VIcon icon="mdi-apps" />
+              </VAvatar>
+              <h6 class="text-base font-weight-medium mt-2 mb-0">插件数据</h6>
+              <span class="text-sm">打开插件数据页</span>
             </VListItem>
           </VCol>
         </VRow>
@@ -265,5 +274,14 @@ onMounted(() => {
         </VTextField>
       </VCardItem>
     </VCard>
+  </VDialog>
+  <!--插件数据页选择-->
+  <VDialog
+    v-if="pluginPageSelectorDialog"
+    v-model="pluginPageSelectorDialog"
+    max-width="65rem"
+    height="calc(100% - 15rem)"
+  >
+    <PluginPageSelector></PluginPageSelector>
   </VDialog>
 </template>

--- a/src/views/plugin/PluginPageSelector.vue
+++ b/src/views/plugin/PluginPageSelector.vue
@@ -1,0 +1,37 @@
+<script lang="ts" setup>
+import type { Plugin } from '@/api/types'
+import api from '@/api'
+import PluginPageSelectorItem from '@/views/plugin/PluginPageSelectorItem.vue'
+
+
+// 已安装插件
+const installedPlugins = ref<Plugin[]>([])
+
+// 获取已安装并且有页面的插件数据
+async function fetchInstalledPlugins() {
+  try {
+    installedPlugins.value = await api.get('plugin/', {
+      params: {
+        state: 'installed',
+      },
+    })
+    installedPlugins.value = installedPlugins.value?.filter(plugin => plugin?.has_page)
+  } catch (error) {
+    console.error(error)
+  }
+}
+
+// 加载时获取数据
+onBeforeMount(async () => {
+  await fetchInstalledPlugins()
+})
+</script>
+<template>
+  <div style="overflow: hidden auto; block-size: calc(100% - 10px);">
+    <VRow>
+      <VCol v-for="item in installedPlugins" cols="12" md="2" sm="3">
+        <PluginPageSelectorItem :plugin="item" />
+      </VCol>
+    </VRow>
+  </div>
+</template>

--- a/src/views/plugin/PluginPageSelectorItem.vue
+++ b/src/views/plugin/PluginPageSelectorItem.vue
@@ -1,0 +1,84 @@
+<script lang="ts" setup>
+import type { Plugin } from '@/api/types'
+import noImage from '@images/logos/plugin.png'
+import api from '@/api'
+import { useDisplay } from 'vuetify'
+import PageRender from '@/components/render/PageRender.vue'
+
+
+// 显示器宽度
+const display = useDisplay()
+
+// 输入参数
+const props = defineProps({
+  plugin: Object as PropType<Plugin>
+})
+
+// 插件数据页面配置项
+let pluginPageItems = ref([])
+
+// 图片是否加载完成
+const isImageLoaded = ref(false)
+
+// 图片是否加载失败
+const imageLoadError = ref(false)
+
+// 插件数据页面
+const pluginPageDialog = ref(false)
+
+// 计算图标路径
+const iconPath: Ref<string> = computed(() => {
+  if (!props.plugin?.plugin_icon || imageLoadError.value) return noImage
+  // 如果是网络图片则使用代理后返回
+  if (props.plugin?.plugin_icon?.startsWith('http'))
+    return `${import.meta.env.VITE_API_BASE_URL}system/img/1?imgurl=${encodeURIComponent(props.plugin?.plugin_icon)}`
+  return `./plugin_icon/${props.plugin?.plugin_icon}`
+})
+
+// 调用API读取数据页面
+async function loadPluginPage() {
+  try {
+    const result: [] = await api.get(`plugin/page/${props.plugin?.id}`)
+    if (result) pluginPageItems.value = result
+  } catch (error) {
+    console.error(error)
+  }
+}
+
+// 显示插件数据页
+async function showPluginPage() {
+  // 加载数据
+  await loadPluginPage()
+  pluginPageDialog.value = true
+}
+</script>
+<template>
+  <div class="text-center">
+    <VAvatar size="6rem" @click="showPluginPage" class="cursor-pointer">
+      <VImg
+        ref="imageRef"
+        :src="iconPath"
+        aspect-ratio="4/3"
+        cover
+        :class="{ shadow: isImageLoaded }"
+        @error="imageLoadError = true"
+      />
+    </VAvatar>
+    <div style="padding-block-start: 10px;">
+      <VChip
+        :text="props.plugin?.plugin_name"
+        size="small"
+        @click="showPluginPage"
+      />
+    </div>
+  </div>
+  <!-- 插件数据页面 -->
+  <VDialog v-model="pluginPageDialog" scrollable max-width="80rem" :fullscreen="!display.mdAndUp.value">
+    <VCard :title="`${props.plugin?.plugin_name}`" class="rounded-t">
+      <DialogCloseBtn v-model="pluginPageDialog" />
+      <VCardText class="min-h-40">
+        <PageRender v-for="(item, index) in pluginPageItems" :key="index" :config="item" />
+      </VCardText>
+    </VCard>
+  </VDialog>
+</template>


### PR DESCRIPTION
@jxxghp 大佬先别合，可不可以先帮我调试一下啊，交互方面还有瑕疵，实在是搞不定了。期望的效果是通过捷径中新增的【插件数据】按钮展开一个类似于群晖 DSM v6.x.x 主菜单的一个插件菜单视图，展示的都是已安装并且has_page的插件，点击插件图标就打开该插件的数据页。有些场景需要用到，比如在资源搜索结果页面，可以通过该功能快速查看站点上传流量以便抉择下载站点。