### PR TITLE
资源搜索里的季集下拉列表，从字符串排序改成按季集排序

### DIFF
--- a/src/views/discover/TorrentCardListView.vue
+++ b/src/views/discover/TorrentCardListView.vue
@@ -71,7 +71,34 @@ function initOptions(data: Context) {
 // 对季过滤选项进行排序
 const sortSeasonFilterOptions = computed(() => {
   return seasonFilterOptions.value.sort((a, b) => {
-    // 按字符串降序排序
+    // 按季,集降序排序
+    const parseSeasonEpisode = (str: string) => {
+      const seasonRangeMatch = str.match(/S(\d+)(?:-S(\d+))?/);
+      const episodeRangeMatch = str.match(/E(\d+)(?:-E(\d+))?/);
+      return {
+        seasonStart  : seasonRangeMatch?.[1] ? parseInt(seasonRangeMatch[1]) : 0,
+        seasonEnd    : seasonRangeMatch?.[2] ? parseInt(seasonRangeMatch[2]) : 0,
+        episodeStart : episodeRangeMatch?.[1] ? parseInt(episodeRangeMatch[1]) : 0,
+        episodeEnd   : episodeRangeMatch?.[2] ? parseInt(episodeRangeMatch[2]) : 0
+      }
+    }
+    const parsedA = parseSeasonEpisode(a)
+    const parsedB = parseSeasonEpisode(b)
+    // 先按季降序排序
+    if (parsedB.seasonStart !== parsedA.seasonStart) {
+      return parsedB.seasonStart - parsedA.seasonStart
+    }
+    if (parsedB.seasonEnd !== parsedA.seasonEnd) {
+      return parsedB.seasonEnd - parsedA.seasonEnd
+    }
+    // 按集降序排序
+    if (parsedB.episodeStart !== parsedA.episodeStart) {
+      return parsedB.episodeStart - parsedA.episodeStart
+    }
+    if (parsedB.episodeEnd !== parsedA.episodeEnd) {
+      return parsedB.episodeEnd - parsedA.episodeEnd
+    }
+    // 兜底
     return b.localeCompare(a)
   })
 })
@@ -112,7 +139,10 @@ watchEffect(() => {
   groupedDataList.value?.forEach(value => {
     if (value.length > 0) {
       const matchData = value.filter(data => {
-        const { meta_info, torrent_info } = data
+        const {
+          meta_info,
+          torrent_info,
+        } = data
         // 季、制作组、视频编码
         return (
           // 站点过滤


### PR DESCRIPTION
原始逻辑是按字符串排序，这排序会出现下面这种问题：

![{960BF86D-B642-4d90-9C1B-DA845987F13E}](https://github.com/jxxghp/MoviePilot-Frontend/assets/9531643/06c81ed7-05b5-40ac-b8b8-6a0d003cdeb7)

新逻辑用正则表达式解析后分别比较季、集进行排序。