### PR TITLE
低版本safari主菜单样式兼容性处理

### DIFF
--- a/src/@layouts/components/VerticalNavLink.vue
+++ b/src/@layouts/components/VerticalNavLink.vue
@@ -34,6 +34,10 @@ defineProps<{
     display: flex;
     align-items: center;
     cursor: pointer;
+    padding-left: 1.375rem;
+    padding-right: 1rem;
+    margin-right: 1.125em;
+    border-radius: 0 3.125rem 3.125rem 0 !important;
   }
 }
 </style>

--- a/src/@layouts/components/VerticalNavSectionTitle.vue
+++ b/src/@layouts/components/VerticalNavSectionTitle.vue
@@ -18,3 +18,12 @@ defineProps<{
     </div>
   </li>
 </template>
+
+<style lang="scss">
+.layout-vertical-nav {
+  .nav-section-title {
+    padding-left: 1.375rem;
+    padding-right: 1rem;
+  }
+}
+</style>


### PR DESCRIPTION
低版本safari不支持margin-inline、padding-inline、border-start-end-radius等新样式