### PR TITLE
修复搜索页筛选显示bug

### DIFF
--- a/src/views/discover/TorrentCardListView.vue
+++ b/src/views/discover/TorrentCardListView.vue
@@ -249,7 +249,7 @@ watchEffect(() => {
     </VRow>
   </VCard>
   <div class="grid gap-3 grid-torrent-card items-start">
-    <div v-for="(item, index) in dataList" :key="`${index}_${item.torrent_info.title}_${item.torrent_info.site}`">
+    <div v-for="(item) in dataList" :key="`${item.torrent_info.page_url}`">
       <TorrentCard :torrent="item" :more="item.more" />
     </div>
   </div>


### PR DESCRIPTION
index，torrent_info.title，torrent_info.site
这三个值的组成的Key存在重复。会导致dataList更新的时候，出现不可预估的问题。
比如我选了过滤第九集，传入的dataList也是第九集的数据，但是因为key相同， 第一个显示成了第一次加载时候的内容。

![image](https://github.com/jxxghp/MoviePilot-Frontend/assets/9531643/9c67dcf4-45c5-4eb0-9c69-d447144c9ff8)

用page_url作为key应该是唯一的。