### PR TITLE
TorrentRowListView 筛选bug 以及季集选项排序

### DIFF
--- a/src/views/discover/TorrentRowListView.vue
+++ b/src/views/discover/TorrentRowListView.vue
@@ -71,6 +71,42 @@ function initOptions(data: Context) {
   optionValue(resolutionFilterOptions.value, meta_info?.resource_pix)
 }
 
+
+// 对季过滤选项进行排序
+const sortSeasonFilterOptions = computed(() => {
+  return seasonFilterOptions.value.sort((a, b) => {
+    // 按季,集降序排序
+    const parseSeasonEpisode = (str: string) => {
+      const seasonRangeMatch = str.match(/S(\d+)(?:-S(\d+))?/)
+      const episodeRangeMatch = str.match(/E(\d+)(?:-E(\d+))?/)
+      return {
+        seasonStart: seasonRangeMatch?.[1] ? parseInt(seasonRangeMatch[1]) : 0,
+        seasonEnd: seasonRangeMatch?.[2] ? parseInt(seasonRangeMatch[2]) : 0,
+        episodeStart: episodeRangeMatch?.[1] ? parseInt(episodeRangeMatch[1]) : 0,
+        episodeEnd: episodeRangeMatch?.[2] ? parseInt(episodeRangeMatch[2]) : 0,
+      }
+    }
+    const parsedA = parseSeasonEpisode(a)
+    const parsedB = parseSeasonEpisode(b)
+    // 先按季降序排序
+    if (parsedB.seasonStart !== parsedA.seasonStart) {
+      return parsedB.seasonStart - parsedA.seasonStart
+    }
+    if (parsedB.seasonEnd !== parsedA.seasonEnd) {
+      return parsedB.seasonEnd - parsedA.seasonEnd
+    }
+    // 按集降序排序
+    if (parsedB.episodeStart !== parsedA.episodeStart) {
+      return parsedB.episodeStart - parsedA.episodeStart
+    }
+    if (parsedB.episodeEnd !== parsedA.episodeEnd) {
+      return parsedB.episodeEnd - parsedA.episodeEnd
+    }
+    // 兜底
+    return b.localeCompare(a)
+  })
+})
+
 // 排序
 watchEffect(() => {
   const list = dataList.value
@@ -141,7 +177,7 @@ onMounted(() => {
           "
         >
           <template #default="{ item }">
-            <TorrentItem :torrent="item" :key="`${item.torrent_info.title}_${item.torrent_info.site}`" />
+            <TorrentItem :torrent="item" :key="`${item.torrent_info.page_url}`" />
           </template>
         </VVirtualScroll>
       </VList>
@@ -261,7 +297,7 @@ onMounted(() => {
         <VListItem>
           <VChipGroup v-model="filterForm.season" column multiple>
             <VChip
-              v-for="season in seasonFilterOptions"
+              v-for="season in sortSeasonFilterOptions"
               :key="season"
               :color="filterForm.season.includes(season) ? 'primary' : ''"
               filter


### PR DESCRIPTION
修复搜索页筛选显示bug以及过滤选项季集排序。与TorrentCardListView 保持一致。


Help:
1.  TorrentRowListView 和TorrentCardListView 都有个一模一样的sortSeasonFilterOptions 的方法和需求。需要提取到某个utils文件里吗？

2.  TorrentCardListView 如果数据内容多，显示会卡顿。需要优化。奈何能力有限,v-infinite-scroll 死活没法弄成功。大佬找个懂的人看下呗。我没学过前端以及Vue，很头疼。

```vue
<div class="grid gap-3 grid-torrent-card items-start">
    <div v-for="(item) in dataList" :key="`${item.torrent_info.page_url}`">
      <TorrentCard :torrent="item" :more="item.more" />
    </div>
  </div>
```
