### PR TITLE
修复使用带subpath的反向代理时api可能无法访问的问题

### DIFF
--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -10,7 +10,7 @@ cleanupOutdatedCaches()
 precacheAndRoute(self.__WB_MANIFEST)
 
 // to allow work offline
-registerRoute(new NavigationRoute(createHandlerBoundToURL('index.html'), { denylist: [/^\/api/] }))
+registerRoute(new NavigationRoute(createHandlerBoundToURL('index.html'), { denylist: [/^(\/[\w-]+)*\/api/] }))
 
 // 通知选项
 const options = {


### PR DESCRIPTION
扩展正则表达式以适配nginx反向代理中使用了subpath的情况，可修复 #155 描述的api无法访问的问题