### PR TITLE
feat: ace-editor support python

### DIFF
--- a/src/ace-config.ts
+++ b/src/ace-config.ts
@@ -10,6 +10,8 @@ import modeYamlUrl from 'ace-builds/src-noconflict/mode-yaml?url'
 
 import modeCssUrl from 'ace-builds/src-noconflict/mode-css?url'
 
+import modePythonUrl from 'ace-builds/src-noconflict/mode-python?url'
+
 import themeGithubUrl from 'ace-builds/src-noconflict/theme-github?url'
 
 import themeChromeUrl from 'ace-builds/src-noconflict/theme-chrome?url'
@@ -38,6 +40,8 @@ import snippetsJsonUrl from 'ace-builds/src-noconflict/snippets/json?url'
 
 import snippertsCssUrl from 'ace-builds/src-noconflict/snippets/css?url'
 
+import snippetsPythonUrl from 'ace-builds/src-noconflict/snippets/python?url'
+
 import 'ace-builds/src-noconflict/ext-language_tools'
 
 ace.config.setModuleUrl('ace/mode/json', modeJsonUrl)
@@ -45,6 +49,7 @@ ace.config.setModuleUrl('ace/mode/javascript', modeJavascriptUrl)
 ace.config.setModuleUrl('ace/mode/html', modeHtmlUrl)
 ace.config.setModuleUrl('ace/mode/yaml', modeYamlUrl)
 ace.config.setModuleUrl('ace/mode/css', modeCssUrl)
+ace.config.setModuleUrl('ace/mode/python', modePythonUrl)
 ace.config.setModuleUrl('ace/theme/github', themeGithubUrl)
 ace.config.setModuleUrl('ace/theme/chrome', themeChromeUrl)
 ace.config.setModuleUrl('ace/theme/monokai', themeMonokaiUrl)
@@ -59,5 +64,6 @@ ace.config.setModuleUrl('ace/snippets/javascript', snippetsJsUrl)
 ace.config.setModuleUrl('ace/snippets/javascript', snippetsYamlUrl)
 ace.config.setModuleUrl('ace/snippets/json', snippetsJsonUrl)
 ace.config.setModuleUrl('ace/snippets/css', snippertsCssUrl)
+ace.config.setModuleUrl('ace/snippets/python', snippetsPythonUrl)
 
 ace.require('ace/ext/language_tools')


### PR DESCRIPTION
- ace-editor 支持 `Python` 语法高亮
- 由于官方暂未支持 `Python Worker`，这里没有添加，参考资料  [Syntax-validation](https://github.com/ajaxorg/ace/wiki/Syntax-validation)

![image](https://github.com/user-attachments/assets/f3cc6bea-517a-449c-9a47-96a1efd1e1c6)
