### PR TITLE
feat(user): UserSettings function adjustment.

### DIFF
--- a/src/components/cards/UserCard.vue
+++ b/src/components/cards/UserCard.vue
@@ -115,7 +115,7 @@ onMounted(() => {
         </VAvatar>
         <div>
           <div class="text-h6">{{ movieSubscriptions }}</div>
-          <div class="text-sm">电影订阅</div>
+          <div class="text-sm text-no-wrap">电影订阅</div>
         </div>
       </div>
       <div class="d-flex align-center">
@@ -124,7 +124,7 @@ onMounted(() => {
         </VAvatar>
         <div>
           <div class="text-h6">{{ tvShowSubscriptions }}</div>
-          <div class="text-sm">电视剧订阅</div>
+          <div class="text-sm text-no-wrap">电视剧订阅</div>
         </div>
       </div>
     </VCardText>

--- a/src/components/dialog/UserAddEditDialog.vue
+++ b/src/components/dialog/UserAddEditDialog.vue
@@ -184,6 +184,11 @@ onMounted(() => {
     fetchUserInfo()
   }
 })
+
+// 监听 localStorage 中的头像变化
+watch(() => store.state.auth.avatar, () => {
+  nowAvatar.value = store.state.auth.avatar
+})
 </script>
 
 <template>

--- a/src/components/dialog/UserAddEditDialog.vue
+++ b/src/components/dialog/UserAddEditDialog.vue
@@ -22,8 +22,11 @@ const props = defineProps({
   oper: String,
 })
 
-// 当前用户名称
+// 当前登录用户名称
 const currentUser = store.state.auth.userName
+
+// 用户名
+const userName = ref('')
 
 // 当前头像缓存
 const nowAvatar = ref(avatar1)
@@ -93,6 +96,7 @@ async function fetchUserInfo() {
     if (userForm.value) {
       userForm.value.avatar = userForm.value.avatar || avatar1
       nowAvatar.value = userForm.value.avatar
+      userName.value = userForm.value.name
     }
   } catch (error) {
     console.error(error)
@@ -170,7 +174,7 @@ const canControl = computed(() => {
     return true
   } else {
     // 调用isCurrentUser函数判断是否为当前用户
-    return isCurrentUser.value
+    return !(isCurrentUser.value)
   }
 })
 
@@ -194,7 +198,7 @@ watch(() => store.state.auth.avatar, () => {
 <template>
   <VDialog scrollable :close-on-back="false" persistent eager max-width="50rem" :fullscreen="!display.mdAndUp.value">
     <VCard
-      :title="`${props.oper === 'add' ? '新增' : '编辑'}用户${props.oper !== 'add' ? ` - ${userForm.name}` : ''}`"
+      :title="`${props.oper === 'add' ? '新增' : '编辑'}用户${props.oper !== 'add' ? ` - ${userName}` : ''}`"
       class="rounded-t"
     >
       <DialogCloseBtn @click="emit('close')" />
@@ -236,10 +240,15 @@ watch(() => store.state.auth.avatar, () => {
           </VDivider>
           <VRow>
             <VCol md="6" cols="12" v-if="props.oper === 'add'">
-              <VTextField v-model="userForm.name" density="comfortable" label="用户名" />
+              <VTextField  v-model="userForm.name" density="comfortable" label="用户名" />
             </VCol>
             <VCol cols="12" md="6">
-              <VTextField v-model="userForm.email" density="comfortable" label="邮箱" type="email" />
+              <VTextField
+                v-model="userForm.email"
+                density="comfortable"
+                clearable
+                label="邮箱"
+                type="email" />
             </VCol>
             <VCol cols="12" md="6">
               <VTextField
@@ -247,6 +256,7 @@ watch(() => store.state.auth.avatar, () => {
                 density="comfortable"
                 :type="isNewPasswordVisible ? 'text' : 'password'"
                 :append-inner-icon="isNewPasswordVisible ? 'mdi-eye-off-outline' : 'mdi-eye-outline'"
+                clearable
                 label="密码"
                 autocomplete=""
                 @click:append-inner="isNewPasswordVisible = !isNewPasswordVisible"
@@ -259,6 +269,7 @@ watch(() => store.state.auth.avatar, () => {
                 density="comfortable"
                 :type="isConfirmPasswordVisible ? 'text' : 'password'"
                 :append-inner-icon="isConfirmPasswordVisible ? 'mdi-eye-off-outline' : 'mdi-eye-outline'"
+                clearable
                 label="确认密码"
                 @click:append-inner="isConfirmPasswordVisible = !isConfirmPasswordVisible"
               />
@@ -279,21 +290,38 @@ watch(() => store.state.auth.avatar, () => {
           </VDivider>
           <VRow>
             <VCol cols="12" md="6">
-              <VTextField v-model="userForm.settings.wechat_userid" density="comfortable" label="微信用户" />
+              <VTextField
+                v-model="userForm.settings.wechat_userid"
+                density="comfortable"
+                clearable
+                label="微信用户" />
             </VCol>
             <VCol cols="12" md="6">
-              <VTextField v-model="userForm.settings.telegram_userid" density="comfortable" label="Telegram用户" />
+              <VTextField
+                v-model="userForm.settings.telegram_userid"
+                density="comfortable"
+                clearable
+                label="Telegram用户" />
             </VCol>
             <VCol cols="12" md="6">
-              <VTextField v-model="userForm.settings.slack_userid" density="comfortable" label="Slack用户" />
+              <VTextField
+                v-model="userForm.settings.slack_userid"
+                density="comfortable"
+                clearable
+                label="Slack用户" />
             </VCol>
             <VCol cols="12" md="6">
-              <VTextField v-model="userForm.settings.vocechat_userid" density="comfortable" label="VoceChat用户" />
+              <VTextField
+                v-model="userForm.settings.vocechat_userid"
+                density="comfortable"
+                clearable
+                label="VoceChat用户" />
             </VCol>
             <VCol cols="12" md="6">
               <VTextField
                 v-model="userForm.settings.synologychat_userid"
                 density="comfortable"
+                clearable
                 label="SynologyChat用户"
               />
             </VCol>

--- a/src/views/user/UserProfileView.vue
+++ b/src/views/user/UserProfileView.vue
@@ -202,6 +202,11 @@ onMounted(() => {
   loadAccountInfo()
   loadAllUsers()
 })
+
+// 监听 localStorage 中的用户头像变化
+watch(() => store.state.auth.avatar, () => {
+  nowAvatar.value = store.state.auth.avatar
+})
 </script>
 
 <template>


### PR DESCRIPTION
- 增加更新头像时，立刻同步更新 `localStorage` ；解决当前头像替换后，必须重新登录才能刷新 `localStorage` 的问题。（右上角用户头像圆标）
- 删除通过 `个人信息` 上传新头像时，立刻触发更新的功能，改为统一点击保存后再触发更新。
- 增加 `还原当前头像` 按钮，允许 `上传新头像` 、 `重置默认头像` 后，进行回退；解决重置后后悔了，但其他参数已经填写时，必须刷新页面才能还原当前头像的问题。
- 禁止 `电影订阅` 与 `电视剧订阅` 名称在不同的设备比例下，会出现换行的情况。