### PR TITLE
fix(user): bug

### DIFF
--- a/src/components/cards/UserCard.vue
+++ b/src/components/cards/UserCard.vue
@@ -84,18 +84,6 @@ function editUser() {
   userEditDialog.value = true
 }
 
-// 计算是否有用户编辑权限
-const canEditUser = computed(() => {
-  if (store.state.auth.superUser && props.user.name !== currentLoginUser) return true
-  return false
-})
-
-// 计算是否有用户管理权限
-const canManageUser = computed(() => {
-  if (props.user.name == currentLoginUser) return false
-  return canEditUser
-})
-
 // 用户重新完成时
 function onUserUpdate() {
   userEditDialog.value = false
@@ -169,8 +157,20 @@ onMounted(() => {
       </VList>
     </VCardText>
     <VCardText class="flex flex-row justify-center">
-      <VBtn v-if="canEditUser" color="primary" class="me-4" @click="editUser">编辑</VBtn>
-      <VBtn v-if="canManageUser" color="error" variant="outlined" @click="removeUser"> 删除 </VBtn>
+      <VBtn
+        color="primary"
+        class="me-4"
+        @click="editUser"
+      >
+        编辑
+      </VBtn>
+      <VBtn
+        v-if="store.state.auth.superUser && !(props.user.name === currentLoginUser)"
+        color="error" variant="outlined"
+        @click="removeUser"
+      >
+        删除
+      </VBtn>
     </VCardText>
   </VCard>
   <!-- 用户编辑弹窗 -->

--- a/src/components/cards/UserCard.vue
+++ b/src/components/cards/UserCard.vue
@@ -81,7 +81,6 @@ async function removeUser() {
 
 // 编辑用户
 function editUser() {
-  $toast.info(`编辑用户, id是 ${currentLoginUserId.value}`)
   userEditDialog.value = true
 }
 

--- a/src/components/cards/UserCard.vue
+++ b/src/components/cards/UserCard.vue
@@ -22,7 +22,7 @@ const props = defineProps({
 })
 
 // 当前用户名称
-const currentLoginUser = store.state.auth.userName
+const currentLoginUserId = computed(() => store.state.auth.userID)
 
 // 定义触发的自定义事件
 const emit = defineEmits(['remove', 'save'])
@@ -57,7 +57,7 @@ async function fetchSubscriptions() {
 
 // 删除用户
 async function removeUser() {
-  if (props.user.name == currentLoginUser) {
+  if (props.user.id === currentLoginUserId.value) {
     $toast.error('不能删除当前登录用户！')
     return
   }
@@ -81,6 +81,7 @@ async function removeUser() {
 
 // 编辑用户
 function editUser() {
+  $toast.info(`编辑用户, id是 ${currentLoginUserId.value}`)
   userEditDialog.value = true
 }
 
@@ -165,7 +166,7 @@ onMounted(() => {
         编辑
       </VBtn>
       <VBtn
-        v-if="store.state.auth.superUser && !(props.user.name === currentLoginUser)"
+        v-if="!(props.user.id === currentLoginUserId)"
         color="error" variant="outlined"
         @click="removeUser"
       >

--- a/src/pages/login.vue
+++ b/src/pages/login.vue
@@ -171,6 +171,7 @@ function login() {
       // 获取token
       const token = response.access_token
       const superUser = response.super_user
+      const userID = response.user_id
       const userName = response.user_name
       const avatar = response.avatar
       const level = response.level
@@ -178,7 +179,7 @@ function login() {
       const permissions = response.permissions
 
       // 更新token和remember状态到Vuex Store
-      store.dispatch('auth/login', { token, remember, superUser, userName, avatar, level, permissions })
+      store.dispatch('auth/login', { token, remember, superUser, userID, userName, avatar, level, permissions })
 
       // 登录后处理
       afterLogin(superUser)

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -5,6 +5,7 @@ interface AuthState {
   token: string | null
   remember: boolean
   superUser: boolean
+  userID: number | null
   userName: string
   avatar: string
   originalPath: string | null
@@ -24,6 +25,7 @@ const authModule: Module<AuthState, RootState> = {
     token: null, // 用户令牌
     remember: false, // 记住我
     superUser: false, // 超级管理员
+    userID: null, // 用户ID
     userName: '', // 用户名
     avatar: '', // 头像
     originalPath: null, // 原始路径
@@ -46,6 +48,9 @@ const authModule: Module<AuthState, RootState> = {
     setUserName(state, userName: string) {
       state.userName = userName
     },
+    setUserID(state, userID: number) {
+      state.userID = userID
+    },
     setAvatar(state, avatar: string) {
       state.avatar = avatar
     },
@@ -60,10 +65,11 @@ const authModule: Module<AuthState, RootState> = {
     },
   },
   actions: {
-    login({ commit }, { token, remember, superUser, userName, avatar, level, permissions }) {
+    login({ commit }, { token, remember, superUser, userID, userName, avatar, level, permissions }) {
       commit('setToken', token)
       commit('setRemember', remember)
       commit('setSuperUser', superUser)
+      commit('setUserID', userID)
       commit('setUserName', userName)
       commit('setAvatar', avatar)
       commit('setLevel', level)
@@ -78,6 +84,7 @@ const authModule: Module<AuthState, RootState> = {
     getToken: state => state.token,
     getRemember: state => state.remember,
     getSuperUser: state => state.superUser,
+    getUserID: state => state.userID,
     getUserName: state => state.userName,
     getAvatar: state => state.avatar,
     getOriginalPath: state => state.originalPath,


### PR DESCRIPTION
- 修复 `删除` 按钮错误显示。
- 登录返回增加 `userID` ，并缓存到本地- 登录返回增加 `userID` ，并缓存到本地。
- 替换 `删除` 按钮显示的判断逻辑，改为使用 `userID` 判断。解决原来在提交时，因为 `name` 出现变化， `删除` 存在短暂的显示。