### PR TITLE
fix: 修改`目录`配置后, `folder`相关属性未传递给后端的问题

### DIFF
--- a/src/views/setting/AccountSettingDirectory.vue
+++ b/src/views/setting/AccountSettingDirectory.vue
@@ -136,6 +136,19 @@ onMounted(() => {
   loadStorages()
   loadMediaCategories()
 })
+// 侦听`类型/类别`变化
+watch(directories, (newDirectories) => {
+  newDirectories.forEach(directory => {
+    if (directory.media_type) {
+      directory.download_type_folder = false;
+      directory.library_type_folder = false;
+    }
+    if (directory.media_category) {
+      directory.download_category_folder = false;
+      directory.library_category_folder = false;
+    }
+  });
+}, { deep: true }); // 深度观察
 </script>
 
 <template>

--- a/src/views/setting/AccountSettingDirectory.vue
+++ b/src/views/setting/AccountSettingDirectory.vue
@@ -136,19 +136,18 @@ onMounted(() => {
   loadStorages()
   loadMediaCategories()
 })
-// 侦听`类型/类别`变化
-watch(directories, (newDirectories) => {
-  newDirectories.forEach(directory => {
-    if (directory.media_type) {
-      directory.download_type_folder = false;
-      directory.library_type_folder = false;
-    }
-    if (directory.media_category) {
-      directory.download_category_folder = false;
-      directory.library_category_folder = false;
-    }
+// 侦听`media_type`和`media_category`变化
+directories.value.forEach(directory => {
+  watch(() => directory.media_type, (newValue) => {
+    directory.download_type_folder = false;
+    directory.library_type_folder = false;
   });
-}, { deep: true }); // 深度观察
+
+  watch(() => directory.media_category, (newValue) => {
+    directory.download_category_folder = false;
+    directory.library_category_folder = false;
+  });
+});
 </script>
 
 <template>


### PR DESCRIPTION
在初始配置为：
- 媒体类型/媒体类别：全部
- 按类型分类/按类别分类：启用
再次配置媒体类型/媒体类别为具体类型。
由于按类型分类/按类别分类选项在界面上被隐藏，未将修改后的属性传递给后端。
导致创建`一级/二级目录`时仍使用首次配置的属性，从而产生`多层目录`的问题。