### PR TITLE
feat(settings): cloneDeep

### DIFF
--- a/src/components/dialog/PluginMarketSettingDialog.vue
+++ b/src/components/dialog/PluginMarketSettingDialog.vue
@@ -2,11 +2,6 @@
 import api from '@/api'
 import { useToast } from 'vue-toast-notification'
 
-// 输入参数
-const props = defineProps({
-  title: String,
-})
-
 const $toast = useToast()
 
 // 插件仓库设置字符串
@@ -55,6 +50,7 @@ onMounted(() => {
           placeholder="格式：https://github.com/jxxghp/MoviePilot-Plugins/,https://github.com/xxxx/xxxxxx/"
           hint="多个地址使用逗号分隔，仅支持Github仓库"
           persistent-hint
+          clearable
         />
       </VCardText>
       <VCardActions>

--- a/src/components/dialog/SubscribeEditDialog.vue
+++ b/src/components/dialog/SubscribeEditDialog.vue
@@ -453,7 +453,6 @@ onMounted(() => {
                       label="优先级规则组"
                       hint="按选定的过滤规则组对订阅进行过滤"
                       persistent-hint
-                      clearable
                     />
                   </VCol>
                   <VCol cols="12" md="6" v-if="!props.default">

--- a/src/components/dialog/SubscribeEditDialog.vue
+++ b/src/components/dialog/SubscribeEditDialog.vue
@@ -429,6 +429,7 @@ onMounted(() => {
                       label="包含（关键字、正则式）"
                       hint="包含规则，支持正则表达式"
                       persistent-hint
+                      clearable
                     />
                   </VCol>
                   <VCol cols="12" md="6">
@@ -437,6 +438,7 @@ onMounted(() => {
                       label="排除（关键字、正则式）"
                       hint="排除规则，支持正则表达式"
                       persistent-hint
+                      clearable
                     />
                   </VCol>
                 </VRow>
@@ -451,6 +453,7 @@ onMounted(() => {
                       label="优先级规则组"
                       hint="按选定的过滤规则组对订阅进行过滤"
                       persistent-hint
+                      clearable
                     />
                   </VCol>
                   <VCol cols="12" md="6" v-if="!props.default">
@@ -468,6 +471,7 @@ onMounted(() => {
                       label="自定义保存路径"
                       hint="指定该订阅的下载保存路径，留空自动使用设定的下载目录"
                       persistent-hint
+                      clearable
                     />
                   </VCol>
                 </VRow>
@@ -478,6 +482,7 @@ onMounted(() => {
                       label="自定义识别词"
                       hint="只对该订阅使用的识别词"
                       persistent-hint
+                      clearable
                       placeholder="屏蔽词
 被替换词 => 替换词
 前定位词 <> 后定位词 >> 集偏移量（EP）

--- a/src/views/setting/AccountSettingSearch.vue
+++ b/src/views/setting/AccountSettingSearch.vue
@@ -219,6 +219,7 @@ onMounted(() => {
                 placeholder="MOVIEPILOT"
                 hint="MoviePilot添加的下载任务标签"
                 persistent-hint
+                clearable
               />
             </VCol>
             <VCol cols="12" md="6">
@@ -228,6 +229,7 @@ onMounted(() => {
                 placeholder="用户ID1,用户ID2"
                 hint="使用Telegram、微信等搜索时是否自动下载，使用逗号分割，设置为 all 代表所有用户自动择优下载"
                 persistent-hint
+                clearable
               />
             </VCol>
             <VCol cols="12" md="6">

--- a/src/views/setting/AccountSettingSite.vue
+++ b/src/views/setting/AccountSettingSite.vue
@@ -156,6 +156,7 @@ onMounted(() => {
                   :disabled="siteSetting.CookieCloud.COOKIECLOUD_ENABLE_LOCAL"
                   hint="远端CookieCloud服务地址，格式：https://movie-pilot.org/cookiecloud"
                   persistent-hint
+                  clearable
                 />
               </VCol>
               <VCol cols="12" md="6">
@@ -164,6 +165,7 @@ onMounted(() => {
                   label="用户KEY"
                   hint="CookieCloud浏览器插件生成的用户KEY"
                   persistent-hint
+                  clearable
                 />
               </VCol>
               <VCol cols="12" md="6">
@@ -175,6 +177,7 @@ onMounted(() => {
                   label="端对端加密密码"
                   hint="CookieCloud浏览器插件生成的端对端加密密码"
                   persistent-hint
+                  clearable
                 />
               </VCol>
               <VCol cols="12" md="6">
@@ -193,6 +196,7 @@ onMounted(() => {
                   placeholder="多个域名,分割"
                   hint="CookieCloud同步域名黑名单，多个域名,分割"
                   persistent-hint
+                  clearable
                 />
               </VCol>
               <VCol cols="12" md="6">
@@ -201,6 +205,7 @@ onMounted(() => {
                   label="浏览器User-Agent"
                   hint="CookieCloud插件所在的浏览器的User-Agent"
                   persistent-hint
+                  clearable
                 />
               </VCol>
             </VRow>

--- a/src/views/setting/AccountSettingSystem.vue
+++ b/src/views/setting/AccountSettingSystem.vue
@@ -8,6 +8,7 @@ import { DownloaderConf, MediaServerConf } from '@/api/types'
 import DownloaderCard from '@/components/cards/DownloaderCard.vue'
 import MediaServerCard from '@/components/cards/MediaServerCard.vue'
 import { copyToClipboard } from '@/@core/utils/navigator'
+import { cloneDeep } from 'lodash'
 
 // 系统设置项
 const SystemSettings = ref<any>({
@@ -63,6 +64,10 @@ const $toast = useToast()
 // 高级设置对话框
 const advancedDialog = ref(false)
 
+// 高级设置深复制
+const AdvancedSettings = ref(cloneDeep(SystemSettings.value.Advanced))
+
+// 当前激活的Tab
 const activeTab = ref('system')
 
 // 调用API查询下载器设置
@@ -154,7 +159,15 @@ async function loadSystemSettings() {
       // 将API返回的值赋值给SystemSettings
       for (const sectionKey of Object.keys(SystemSettings.value) as Array<keyof typeof SystemSettings.value>) {
         Object.keys(SystemSettings.value[sectionKey]).forEach((key: string) => {
-          if (result.data.hasOwnProperty(key)) (SystemSettings.value[sectionKey] as any)[key] = result.data[key]
+          let v: any
+          if (result.data.hasOwnProperty(key)) {
+            v = result.data[key]
+            // 空字符串转为null，避免空字符串导致前端显示问题，如：VCombobox
+            if (v === '') {
+              v = null
+            }
+            (SystemSettings.value[sectionKey] as any)[key] = v
+          }
         })
       }
     }
@@ -186,8 +199,16 @@ async function saveBasicSettings() {
   }
 }
 
+// 打开高级设置详情
+function openAdvancedDialog() {
+  AdvancedSettings.value = cloneDeep(SystemSettings.value.Advanced)
+  advancedDialog.value = true
+}
+
 // 高级设置变化，等待保存
 async function saveAdvancedSettings() {
+  // 将AdvancedSettings的值赋值给SystemSettings
+  SystemSettings.value.Advanced = AdvancedSettings.value
   if (await saveSystemSetting(SystemSettings.value.Advanced)) {
     advancedDialog.value = false
     $toast.success('高级设置保存成功')
@@ -195,6 +216,11 @@ async function saveAdvancedSettings() {
   } else {
     $toast.error('高级设置保存失败！')
   }
+}
+
+// 打开URL
+function openURL(url: string) {
+  if (url) window.open(url)
 }
 
 // 快捷复制到剪贴板
@@ -329,6 +355,10 @@ onDeactivated(() => {
                   placeholder="格式：http(s)://domain:port"
                   hint="用于发送通知时，添加快捷跳转地址"
                   persistent-hint
+                  :appendInnerIcon="SystemSettings.Basic.APP_DOMAIN ? 'mdi-content-copy' : ''"
+                  prependInnerIcon="mdi-share"
+                  @click:appendInner="copyValue(SystemSettings.Basic.APP_DOMAIN)"
+                  @click:prependInner="openURL(SystemSettings.Basic.APP_DOMAIN)"
                 />
               </VCol>
               <VCol cols="12" md="3">
@@ -364,6 +394,7 @@ onDeactivated(() => {
                   hint="设置外部请求MoviePilot API时使用的token值"
                   placeholder="不能小于16位字符"
                   persistent-hint
+                  clearable
                   prependInnerIcon="mdi-reload"
                   :appendInnerIcon="SystemSettings.Basic.API_TOKEN ? 'mdi-content-copy' : ''"
                   @click:prependInner="createRandomString"
@@ -378,16 +409,21 @@ onDeactivated(() => {
                   placeholder="ghp_**** 或 github_pat_****"
                   hint="用于提高插件等访问Github API时的限流阈值"
                   persistent-hint
+                  clearable
+                  :appendInnerIcon="SystemSettings.Basic.GITHUB_TOKEN ? 'mdi-content-copy' : ''"
+                  @click:appendInner="copyValue(SystemSettings.Basic.GITHUB_TOKEN)"
                 >
                 </VTextField>
               </VCol>
               <VCol cols="12" md="6">
-                <VTextField
+                <VCombobox
                   v-model="SystemSettings.Basic.OCR_HOST"
                   label="验证码识别服务器"
                   placeholder="https://movie-pilot.org"
-                  hint="用于站点签到、更新站点Cookie等识别验证码"
+                  hint="用于站点签到、更新站点Cookie等识别验证码，可替换为自定义识别服务器"
                   persistent-hint
+                  clearable
+                  :items="['https://movie-pilot.org']"
                 />
               </VCol>
             </VRow>
@@ -398,7 +434,7 @@ onDeactivated(() => {
             <div class="d-flex flex-wrap gap-4 mt-4">
               <VBtn type="submit" @click="saveBasicSettings"> 保存 </VBtn>
               <VSpacer />
-              <VBtn color="warning" @click="advancedDialog = true" append-icon="mdi-dots-horizontal"> 高级设置 </VBtn>
+              <VBtn color="warning" @click="openAdvancedDialog" append-icon="mdi-dots-horizontal"> 高级设置 </VBtn>
             </div>
           </VForm>
         </VCardText>
@@ -534,7 +570,7 @@ onDeactivated(() => {
               <VRow>
                 <VCol cols="12" md="6">
                   <VSwitch
-                    v-model="SystemSettings.Advanced.AUXILIARY_AUTH_ENABLE"
+                    v-model="AdvancedSettings.AUXILIARY_AUTH_ENABLE"
                     label="用户辅助认证"
                     hint="允许外部服务进行登录认证以及自动创建用户"
                     persistent-hint
@@ -542,7 +578,7 @@ onDeactivated(() => {
                 </VCol>
                 <VCol cols="12" md="6">
                   <VSwitch
-                    v-model="SystemSettings.Advanced.GLOBAL_IMAGE_CACHE"
+                    v-model="AdvancedSettings.GLOBAL_IMAGE_CACHE"
                     label="全局图片缓存"
                     hint="将媒体图片缓存到本地，提升图片加载速度"
                     persistent-hint
@@ -550,7 +586,7 @@ onDeactivated(() => {
                 </VCol>
                 <VCol cols="12" md="6">
                   <VSwitch
-                    v-model="SystemSettings.Advanced.SUBSCRIBE_STATISTIC_SHARE"
+                    v-model="AdvancedSettings.SUBSCRIBE_STATISTIC_SHARE"
                     label="分享订阅数据"
                     hint="分享订阅统计数据到热门订阅，供其他MPer参考"
                     persistent-hint
@@ -558,7 +594,7 @@ onDeactivated(() => {
                 </VCol>
                 <VCol cols="12" md="6">
                   <VSwitch
-                    v-model="SystemSettings.Advanced.PLUGIN_STATISTIC_SHARE"
+                    v-model="AdvancedSettings.PLUGIN_STATISTIC_SHARE"
                     label="上报插件安装数据"
                     hint="上报插件安装数据给服务器，用于统计展示插件安装情况"
                     persistent-hint
@@ -566,7 +602,7 @@ onDeactivated(() => {
                 </VCol>
                 <VCol cols="12" md="6">
                   <VSwitch
-                    v-model="SystemSettings.Advanced.BIG_MEMORY_MODE"
+                    v-model="AdvancedSettings.BIG_MEMORY_MODE"
                     label="大内存模式"
                     hint="使用更大的内存缓存数据，提升系统性能"
                     persistent-hint
@@ -580,43 +616,47 @@ onDeactivated(() => {
               <VRow>
                 <VCol cols="12" md="6">
                   <VCombobox
-                    v-model="SystemSettings.Advanced.TMDB_API_DOMAIN"
+                    v-model="AdvancedSettings.TMDB_API_DOMAIN"
                     label="TMDB API服务地址"
                     placeholder="api.themoviedb.org"
                     hint="自定义themoviedb API域名或代理地址"
                     persistent-hint
+                    clearable
                     :items="['api.themoviedb.org']"
                     :rules="[(v: string) => !!v || '请输入TMDB API域名']"
                   />
                 </VCol>
                 <VCol cols="12" md="6">
                   <VCombobox
-                    v-model="SystemSettings.Advanced.TMDB_IMAGE_DOMAIN"
+                    v-model="AdvancedSettings.TMDB_IMAGE_DOMAIN"
                     label="TMDB 图片服务地址"
                     placeholder="image.tmdb.org"
                     hint="自定义themoviedb图片服务域名或代理地址"
                     persistent-hint
+                    clearable
                     :items="['image.tmdb.org', 'static-mdb.v.geilijiasu.com']"
                     :rules="[(v: string) => !!v || '请输入图片服务域名']"
                   />
                 </VCol>
                 <VCol cols="12" md="6">
                   <VTextField
-                    v-model="SystemSettings.Advanced.META_CACHE_EXPIRE"
+                    v-model="AdvancedSettings.META_CACHE_EXPIRE"
                     label="媒体元数据缓存过期时间"
                     hint="识别元数据本地缓存时间，为 0 时使用内置默认值"
                     persistent-hint
                     min="0"
                     type="number"
                     suffix="小时"
-                    :rules="[(v: any) => v === 0 || !!v || '请输入元数据缓存时间', (v: any) => v >= 0 || '元数据缓存时间必须大于等于0']"
+                    :rules="[
+                      (v: any) => v === 0 || !!v || '请输入元数据缓存时间',
+                      (v: any) => v >= 0 || '元数据缓存时间必须大于等于0']"
                   />
                 </VCol>
               </VRow>
               <VRow>
                 <VCol cols="12" md="6">
                   <VSwitch
-                    v-model="SystemSettings.Advanced.SCRAP_FOLLOW_TMDB"
+                    v-model="AdvancedSettings.SCRAP_FOLLOW_TMDB"
                     label="跟随TMDB识别整理"
                     hint="关闭时以整理历史记录为准（如有），避免TMDB数据在订阅中途修改"
                     persistent-hint
@@ -624,7 +664,7 @@ onDeactivated(() => {
                 </VCol>
                 <VCol cols="12" md="6">
                   <VSwitch
-                    v-model="SystemSettings.Advanced.FANART_ENABLE"
+                    v-model="AdvancedSettings.FANART_ENABLE"
                     label="Fanart图片数据源"
                     hint="使用 fanart.tv 的图片数据"
                     persistent-hint
@@ -638,21 +678,23 @@ onDeactivated(() => {
               <VRow>
                 <VCol cols="12" md="6">
                   <VCombobox
-                    v-model="SystemSettings.Advanced.GITHUB_PROXY"
+                    v-model="AdvancedSettings.GITHUB_PROXY"
                     label="Github加速代理"
                     placeholder="https://mirror.ghproxy.com/"
                     hint="使用代理加速Github访问速度"
                     persistent-hint
+                    clearable
                     :items="githubMirrorsItems"
                   />
                 </VCol>
                 <VCol cols="12" md="6">
                   <VCombobox
-                    v-model="SystemSettings.Advanced.PIP_PROXY"
+                    v-model="AdvancedSettings.PIP_PROXY"
                     label="PIP加速代理"
                     placeholder="https://pypi.tuna.tsinghua.edu.cn/simple"
                     hint="使用代理加速插件等pip库安装速度"
                     persistent-hint
+                    clearable
                     :items="pipMirrorsItems"
                   />
                 </VCol>
@@ -660,28 +702,30 @@ onDeactivated(() => {
               <VRow>
                 <VCol cols="12" md="6">
                   <VSwitch
-                    v-model="SystemSettings.Advanced.DOH_ENABLE"
+                    v-model="AdvancedSettings.DOH_ENABLE"
                     label="DNS Over HTTPS"
                     hint="使用DOH对特定域名进行解析，以防止DNS污染"
                     persistent-hint
                   />
                 </VCol>
-                <VCol cols="12" v-show="SystemSettings.Advanced.DOH_ENABLE">
+                <VCol cols="12" v-show="AdvancedSettings.DOH_ENABLE">
                   <VTextarea
                     v-model="SystemSettings.Advanced.DOH_RESOLVERS"
                     label="DOH 服务器"
                     placeholder="https://dns.google/dns-query,1.1.1.1"
                     hint="DNS解析服务器地址，多个地址使用逗号分隔"
                     persistent-hint
+                    clearable
                   />
                 </VCol>
-                <VCol cols="12" v-show="SystemSettings.Advanced.DOH_ENABLE">
+                <VCol cols="12" v-show="AdvancedSettings.DOH_ENABLE">
                   <VTextarea
-                    v-model="SystemSettings.Advanced.DOH_DOMAINS"
+                    v-model="AdvancedSettings.DOH_DOMAINS"
                     label="DOH 域名"
                     placeholder="example.com,example2.com"
                     hint="使用DOH解析的域名，多个域名使用逗号分隔"
                     persistent-hint
+                    clearable
                   />
                 </VCol>
               </VRow>
@@ -693,7 +737,7 @@ onDeactivated(() => {
               <VRow>
                 <VCol cols="12" md="6">
                   <VSwitch
-                    v-model="SystemSettings.Advanced.DEBUG"
+                    v-model="AdvancedSettings.DEBUG"
                     label="DEBUG日志"
                     hint="显示DEBUG级别日志，方便排查问题"
                     persistent-hint
@@ -701,7 +745,7 @@ onDeactivated(() => {
                 </VCol>
                 <VCol cols="12" md="6">
                   <VSwitch
-                    v-model="SystemSettings.Advanced.PLUGIN_AUTO_RELOAD"
+                    v-model="AdvancedSettings.PLUGIN_AUTO_RELOAD"
                     label="插件热加载"
                     hint="修改插件文件后自动重新加载，开发插件时使用"
                     persistent-hint

--- a/src/views/setting/AccountSettingSystem.vue
+++ b/src/views/setting/AccountSettingSystem.vue
@@ -159,15 +159,7 @@ async function loadSystemSettings() {
       // 将API返回的值赋值给SystemSettings
       for (const sectionKey of Object.keys(SystemSettings.value) as Array<keyof typeof SystemSettings.value>) {
         Object.keys(SystemSettings.value[sectionKey]).forEach((key: string) => {
-          let v: any
-          if (result.data.hasOwnProperty(key)) {
-            v = result.data[key]
-            // 空字符串转为null，避免空字符串导致前端显示问题，如：VCombobox
-            if (v === '') {
-              v = null
-            }
-            (SystemSettings.value[sectionKey] as any)[key] = v
-          }
+          if (result.data.hasOwnProperty(key)) (SystemSettings.value[sectionKey] as any)[key] = result.data[key]
         })
       }
     }


### PR DESCRIPTION
- 改用深复制进行传参，解决高级设置直接对全局SystemSettings进行修改，导致点击close时，值会被缓存，重新打开后还是上次已修改但未保存值的问题；
- `APP_DOMAIN` 增加 快捷跳转访问，用来检查输入的值是否可以访问；
- `APP_DOMAIN` 、`GITHUB_TOKEN` 增加快捷复制；
- `OCR_HOST` 调整为 `VCombobox` 组件，增加预选项菜单。