### PR TITLE
手动整理中`整理方式`增加`自动`

### DIFF
--- a/src/api/constants.ts
+++ b/src/api/constants.ts
@@ -73,6 +73,7 @@ export const storageDict = storageOptions.reduce((dict, item) => {
 }, {} as Record<string, string>)
 
 export const transferTypeOptions = [
+  { title: '自动', value: '' },
   { title: '复制', value: 'copy' },
   { title: '移动', value: 'move' },
   { title: '硬链接', value: 'link' },

--- a/src/api/constants.ts
+++ b/src/api/constants.ts
@@ -73,7 +73,6 @@ export const storageDict = storageOptions.reduce((dict, item) => {
 }, {} as Record<string, string>)
 
 export const transferTypeOptions = [
-  { title: '自动', value: '' },
   { title: '复制', value: 'copy' },
   { title: '移动', value: 'move' },
   { title: '硬链接', value: 'link' },

--- a/src/components/dialog/ReorganizeDialog.vue
+++ b/src/components/dialog/ReorganizeDialog.vue
@@ -114,11 +114,19 @@ watch(
       const directory = directories.value.find(item => item.library_path === newPath)
       if (directory) {
         transferForm.target_storage = directory.library_storage ?? 'local'
-        transferForm.transfer_type = directory.transfer_type ?? ''
+        transferForm.transfer_type = transferForm.transfer_type || directory.transfer_type
         transferForm.scrape = directory.scraping ?? false
         transferForm.library_category_folder = directory.library_category_folder ?? false
         transferForm.library_type_folder = directory.library_type_folder ?? false
+      } else {
+        transferForm.transfer_type = transferForm.transfer_type || 'copy'
+        transferForm.scrape = false
+        transferForm.library_category_folder = false
+        transferForm.library_type_folder = false
       }
+    } else {
+      // 路径为空时, 整理方式留空(自动)
+      transferForm.transfer_type = ''
     }
   }
 )
@@ -225,8 +233,11 @@ onMounted(() => {
                 label="整理方式"
                 :items="transferTypeOptions"
                 hint="文件操作整理方式"
-                persistent-hint
-              />
+                persistent-hint>
+                <template v-slot:selection="{ item }">
+                  {{ transferForm.transfer_type === '' ? '自动' : item.title }}
+                </template>
+              </VSelect>
             </VCol>
             <VCol cols="12">
               <VCombobox

--- a/src/components/dialog/ReorganizeDialog.vue
+++ b/src/components/dialog/ReorganizeDialog.vue
@@ -75,7 +75,7 @@ const transferForm = reactive({
   doubanid: null,
   season: null,
   type_name: '',
-  transfer_type: 'copy',
+  transfer_type: '',
   episode_format: '',
   episode_detail: '',
   episode_part: '',


### PR DESCRIPTION
已包含 #252
- 仅当`目的路径`为空时，才会设为`自动`
- 已选择`整理方式`后, 再选择配置的`媒体库目录`整理方式不再改变
- `自定义路径`:
- - `整理方式`为`自动`时，会修改为`复制`,请注意
- - `整理方式`不为`自动`时, 不会改变

清空`目的路径` `整理方式`将恢复为`自动`