### PR TITLE
改进手动整理`类型/类别`可选逻辑

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1051,7 +1051,7 @@ export interface TransferDirectoryConf {
   // 监控模式 fast/compatibility
   monitor_mode?: string
   // 整理方式 move/copy/link/softlink
-  transfer_type?: string
+  transfer_type: string
   // 文件覆盖模式 always/size/never/latest
   overwrite_mode?: string
   // 整理到媒体库目录
@@ -1138,4 +1138,43 @@ export interface SubscrbieInfo {
   subscribe: Subscribe
   // 集信息 {集号: {download: 文件路径，library: 文件路径, backdrop: url, title: 标题, description: 描述}}
   episodes: Record<number, SubscribeEpisodeInfo>
+}
+
+export interface TransferForm {
+  // 文件项
+  fileitem: FileItem
+  // 历史ID
+  logid: number
+  // 目标存储
+  target_storage: string
+  // 目标路径
+  target_path: string
+  // TMDB ID
+  tmdbid?: number
+  // 豆瓣 ID
+  doubanid?: string
+  // 季号
+  season?: number
+  // 类型
+  type_name?: string
+  // 整理方式
+  transfer_type: string
+  // 自定义格式
+  episode_format?: string
+  // 指定集数
+  episode_detail?: string
+  // 指定PART
+  episode_part?: string
+  // 集数偏移
+  episode_offset?: string
+  // 最小文件大小
+  min_filesize: number
+  // 刮削
+  scrape: boolean
+  // 复用历史识别信息
+  from_history: boolean
+  // 媒体库类型子目录
+  library_type_folder?: boolean
+  // 媒体库类别子目录
+  library_category_folder?: boolean
 }

--- a/src/components/dialog/ReorganizeDialog.vue
+++ b/src/components/dialog/ReorganizeDialog.vue
@@ -6,7 +6,7 @@ import { storageOptions, transferTypeOptions } from '@/api/constants'
 import { numberValidator } from '@/@validators'
 import { useDisplay } from 'vuetify'
 import ProgressDialog from './ProgressDialog.vue'
-import { FileItem, TransferDirectoryConf } from '@/api/types'
+import { FileItem, TransferDirectoryConf, TransferForm } from '@/api/types'
 
 // 显示器宽度
 const display = useDisplay()
@@ -66,30 +66,19 @@ const dialogTitle = computed(() => {
 })
 
 // 表单
-const transferForm = reactive({
-  fileitem: {},
+const transferForm = reactive<TransferForm>({
+  fileitem: {} as FileItem,
   logid: 0,
   target_storage: props.target_storage ?? 'local',
-  target_path: props.target_path ?? null,
-  tmdbid: null,
-  doubanid: null,
-  season: null,
-  type_name: '',
   transfer_type: '',
-  episode_format: '',
-  episode_detail: '',
-  episode_part: '',
-  episode_offset: null,
+  target_path: '',
   min_filesize: 0,
   scrape: false,
   from_history: false,
-  library_type_folder: false,
-  library_category_folder: false,
 })
 
 // 所有媒体库目录
 const directories = ref<TransferDirectoryConf[]>([])
-
 // 查询目录
 async function loadDirectories() {
   try {
@@ -125,8 +114,10 @@ watch(
         transferForm.library_type_folder = false
       }
     } else {
-      // 路径为空时, 整理方式留空(自动)
+      // 路径为空时, 恢复到`自动`条件
       transferForm.transfer_type = ''
+      transferForm.library_type_folder = undefined
+      transferForm.library_category_folder = undefined
     }
   }
 )
@@ -195,7 +186,7 @@ async function handleTransfer(item: FileItem) {
 // 整理日志
 async function handleTransferLog(logid: number) {
   transferForm.logid = logid
-  transferForm.fileitem = {}
+  transferForm.fileitem = {} as FileItem
   try {
     const result: { [key: string]: any } = await api.post('transfer/manual', transferForm)
     if (!result.success) $toast.error(`历史记录 ${logid} 重新整理失败：${result.message}！`)
@@ -350,7 +341,7 @@ onMounted(() => {
             </VCol>
           </VRow>
           <VRow>
-            <VCol cols="12" md="6">
+            <VCol cols="12" md="6" v-if="transferForm.target_path">
               <VSwitch
                 v-model="transferForm.library_type_folder"
                 label="按类型分类"
@@ -358,7 +349,7 @@ onMounted(() => {
                 persistent-hint
               />
             </VCol>
-            <VCol cols="12" md="6">
+            <VCol cols="12" md="6" v-if="transferForm.target_path">
               <VSwitch
                 v-model="transferForm.library_category_folder"
                 label="按类别分类"


### PR DESCRIPTION
在`手动整理`文件时，如果`目的路径`留空并且选择了`多个文件项`，分别匹配到`目录配置`，会导致`子目录`创建出现错误：
表现为:
- 需要创建子目录的文件项没有创建子目录。
- 不需要创建子目录的文件项却创建了子目录。