### PR TITLE
fix(api): update subscribe endpoint URL to include trailing slash

### DIFF
--- a/src/components/dialog/SubscribeHistoryDialog.vue
+++ b/src/components/dialog/SubscribeHistoryDialog.vue
@@ -86,7 +86,7 @@ async function reSubscribe(item: Subscribe) {
   else progressText.value = `正在重新订阅 ${item.name} 第 ${item.season} 季 ...`
   progressDialog.value = true
   try {
-    const result: { [key: string]: any } = await api.post('subscribe', item)
+    const result: { [key: string]: any } = await api.post('subscribe/', item)
     if (result.success) {
       emit('save')
     }


### PR DESCRIPTION
- 修复了重新订阅历史失效的问题