### PR TITLE
fix(rulesSettings): 修复移动时，异常复制新导入的所有规则

### DIFF
--- a/src/components/dialog/ImportCodeDialog.vue
+++ b/src/components/dialog/ImportCodeDialog.vue
@@ -2,17 +2,18 @@
 // 输入参数
 const props = defineProps({
   title: String,
+  dataType: String,
 })
-
-// 定义事件
-const emit = defineEmits(['update:modelValue', 'close'])
 
 // 代码
 const codeString = ref('')
 
+// 定义事件
+const emit = defineEmits(['close', 'save'])
+
 // 导入
 function handleImport() {
-  emit('update:modelValue', codeString.value)
+  emit('save', props.dataType, codeString)
   emit('close')
 }
 </script>


### PR DESCRIPTION
- 修复移动时，异常复制新导入的所有规则；
- 增加一个简单的对导入值的判断，解决 规则组 与 规则 之间数据，可互相导入的问题，避免出现误传的情况；
- 修改 `ImportCodeDialog` 组件，增加 `dataType`，提高复用率，单个文件中可根据 `dataType` 区分处理返回的值；修复直接传递 `codeString` 时，导致组件使用时，需要嵌套多一层 `VDialog` 的问题。