### PR TITLE
fix(log): add LOG_FILE_FORMAT

### DIFF
--- a/src/views/setting/AccountSettingSystem.vue
+++ b/src/views/setting/AccountSettingSystem.vue
@@ -48,6 +48,7 @@ const SystemSettings = ref<any>({
     LOG_LEVEL: 'INFO',
     LOG_MAX_FILE_SIZE: '5',
     LOG_BACKUP_COUNT: '3',
+    LOG_FILE_FORMAT: '【%(levelname)s】%(asctime)s - %(message)s',
     // 实验室
     PLUGIN_AUTO_RELOAD: false,
     ENCODING_DETECTION_PERFORMANCE_MODE: true,
@@ -193,8 +194,10 @@ async function saveBasicSettings() {
   }
 }
 
-// 高级设置变化，等待保存
+// 保存高级设置
 async function saveAdvancedSettings() {
+  cleanEmptyFields(SystemSettings.value.Advanced, ['LOG_FILE_FORMAT'])
+
   if (await saveSystemSetting(SystemSettings.value.Advanced)) {
     advancedDialog.value = false
     $toast.success('高级设置保存成功')
@@ -202,6 +205,15 @@ async function saveAdvancedSettings() {
   } else {
     $toast.error('高级设置保存失败！')
   }
+}
+
+// 当字段为空时，将其设置为 null 提交，以便后端恢复为默认值
+function cleanEmptyFields(settings: any, fields: string[]) {
+  fields.forEach(field => {
+    if (settings[field]?.trim?.() === '') {
+      settings[field] = null
+    }
+  })
 }
 
 // 快捷复制到剪贴板
@@ -765,6 +777,14 @@ onDeactivated(() => {
                     min="1"
                     type="number"
                     :rules="[(v: any) => v === 0 || !!v || '请输入日志文件最大备份数量', (v: any) => v >= 1 || '日志文件最大备份数量必须大于等于1']"
+                  />
+                </VCol>
+                <VCol cols="12">
+                  <VTextField
+                    v-model="SystemSettings.Advanced.LOG_FILE_FORMAT"
+                    label="日志文件格式"
+                    hint="设置日志文件的输出格式，用于自定义日志的显示内容"
+                    persistent-hint
                   />
                 </VCol>
               </VRow>

--- a/src/views/setting/AccountSettingSystem.vue
+++ b/src/views/setting/AccountSettingSystem.vue
@@ -729,8 +729,8 @@ onDeactivated(() => {
                 <VCol cols="12" md="6">
                   <VSwitch
                     v-model="SystemSettings.Advanced.DEBUG"
-                    label="全局DEBUG日志"
-                    hint="全局强制使用DEBUG级别日志，方便排查问题"
+                    label="调试模式"
+                    hint="启用调试模式后，日志将以DEBUG级别记录，以便排查问题"
                     persistent-hint
                   />
                 </VCol>
@@ -738,8 +738,8 @@ onDeactivated(() => {
                   <VSelect
                     v-if="!SystemSettings.Advanced.DEBUG"
                     v-model="SystemSettings.Advanced.LOG_LEVEL"
-                    label="全局日志等级"
-                    hint="设置日志记录的级别，方便控制日志记录量"
+                    label="日志等级"
+                    hint="设置日志记录的级别，用于控制日志输出量"
                     persistent-hint
                     :items="logLevelItems"
                   />
@@ -748,7 +748,7 @@ onDeactivated(() => {
                   <VTextField
                     v-model="SystemSettings.Advanced.LOG_MAX_FILE_SIZE"
                     label="日志文件最大容量(MB)"
-                    hint="限制单个日志文件最大保存容量，用于分割日志体积"
+                    hint="限制单个日志文件的最大容量，超出后将自动分割日志"
                     persistent-hint
                     min="1"
                     type="number"
@@ -760,7 +760,7 @@ onDeactivated(() => {
                   <VTextField
                     v-model="SystemSettings.Advanced.LOG_BACKUP_COUNT"
                     label="日志文件最大备份数量"
-                    hint="每个模块的日志文件的最多储存的个数，用于控制日文件数量"
+                    hint="设置每个模块日志文件的最大备份数量，超过后将覆盖旧日志"
                     persistent-hint
                     min="1"
                     type="number"


### PR DESCRIPTION
- 添加 `LOG_FILE_FORMAT` 配置项，用于修改日志文件格式化内容
- 添加 `cleanEmptyFields` 用于传递后端 `NULL`，以便后端重置为默认值
- 调整了日志的 hint 描述