### PR TITLE
修复插件市场重复的问题

### DIFF
--- a/src/views/plugin/PluginCardListView.vue
+++ b/src/views/plugin/PluginCardListView.vue
@@ -392,7 +392,7 @@ watch([marketList, filterForm, activeSort], () => {
   }
 
   // 显示前20个
-  displayUninstalledList.value = sortedUninstalledList.value.slice(0, 20)
+  displayUninstalledList.value = sortedUninstalledList.value.splice(0, 20)
 })
 
 // 标签转换


### PR DESCRIPTION
看起来应该是一处笔误，导致在加载更多插件时会重复显示前面20个插件