### PR TITLE
将 VSelect 组件替换为 VAutocomplete组件，以支持搜索待选项

### DIFF
--- a/src/components/cards/DirectoryCard.vue
+++ b/src/components/cards/DirectoryCard.vue
@@ -277,7 +277,7 @@ watch(
             />
           </VCol>
           <VCol cols="4">
-            <VSelect
+            <VAutocomplete
               v-model="props.directory.library_storage"
               variant="underlined"
               :items="libraryStorageOptions"

--- a/src/components/cards/DirectoryCard.vue
+++ b/src/components/cards/DirectoryCard.vue
@@ -214,7 +214,7 @@ watch(
       <VForm>
         <VRow>
           <VCol cols="6">
-            <VSelect
+            <VAutocomplete
               v-model="props.directory.media_type"
               variant="underlined"
               :items="typeItems"
@@ -223,7 +223,7 @@ watch(
             />
           </VCol>
           <VCol cols="6">
-            <VSelect
+            <VAutocomplete
               v-model="props.directory.media_category"
               variant="underlined"
               :items="getCategories"
@@ -231,7 +231,7 @@ watch(
             />
           </VCol>
           <VCol cols="4">
-            <VSelect
+            <VAutocomplete
               v-model="props.directory.storage"
               variant="underlined"
               :items="resourceStorageOptions"

--- a/src/components/cards/FilterRuleCard.vue
+++ b/src/components/cards/FilterRuleCard.vue
@@ -56,7 +56,7 @@ onMounted(() => {
       <VCardTitle>{{ t('filterRule.priority') }} {{ props.pri }}</VCardTitle>
       <VRow>
         <VCol>
-          <VSelect
+          <VAutocomplete
             v-model="props.rules"
             variant="underlined"
             :items="selectFilterOptions"

--- a/src/components/cards/FilterRuleGroupCard.vue
+++ b/src/components/cards/FilterRuleGroupCard.vue
@@ -247,7 +247,7 @@ function onClose() {
               />
             </VCol>
             <VCol cols="6" md="3">
-              <VSelect
+              <VAutocomplete
                 v-model="groupInfo.media_type"
                 :label="t('filterRule.mediaType')"
                 :items="mediaTypeItems"
@@ -258,7 +258,7 @@ function onClose() {
               />
             </VCol>
             <VCol cols="6" md="3">
-              <VSelect
+              <VAutocomplete
                 v-model="groupInfo.category"
                 :items="getCategories"
                 :label="t('filterRule.category')"

--- a/src/components/cards/MediaServerCard.vue
+++ b/src/components/cards/MediaServerCard.vue
@@ -273,7 +273,7 @@ onMounted(() => {
                 />
               </VCol>
               <VCol cols="12">
-                <VSelect
+                <VAutocomplete
                   v-model="mediaServerInfo.sync_libraries"
                   :label="t('mediaserver.syncLibraries')"
                   :items="librariesOptions"
@@ -334,7 +334,7 @@ onMounted(() => {
                 />
               </VCol>
               <VCol cols="12">
-                <VSelect
+                <VAutocomplete
                   v-model="mediaServerInfo.sync_libraries"
                   :label="t('mediaserver.syncLibraries')"
                   :items="librariesOptions"
@@ -402,7 +402,7 @@ onMounted(() => {
                 />
               </VCol>
               <VCol cols="12">
-                <VSelect
+                <VAutocomplete
                   v-model="mediaServerInfo.sync_libraries"
                   :label="t('mediaserver.syncLibraries')"
                   :items="librariesOptions"
@@ -463,7 +463,7 @@ onMounted(() => {
                 />
               </VCol>
               <VCol cols="12">
-                <VSelect
+                <VAutocomplete
                   v-model="mediaServerInfo.sync_libraries"
                   :label="t('mediaserver.syncLibraries')"
                   :items="librariesOptions"

--- a/src/components/cards/NotificationChannelCard.vue
+++ b/src/components/cards/NotificationChannelCard.vue
@@ -165,7 +165,7 @@ function onClose() {
                 <VSwitch v-model="notificationInfo.enabled" :label="t('notification.enabled')" />
               </VCol>
               <VCol cols="12">
-                <VSelect
+                <VAutocomplete
                   v-model="notificationInfo.switchs"
                   :items="notificationTypes"
                   :label="t('notification.type')"

--- a/src/components/dialog/SiteAddEditDialog.vue
+++ b/src/components/dialog/SiteAddEditDialog.vue
@@ -172,7 +172,7 @@ onMounted(async () => {
               />
             </VCol>
             <VCol cols="6" md="3">
-              <VSelect
+              <VAutocomplete
                 v-model="siteForm.pri"
                 :label="t('site.fields.priority')"
                 :items="priorityItems"
@@ -213,7 +213,7 @@ onMounted(async () => {
               />
             </VCol>
             <VCol cols="6" md="3">
-              <VSelect
+              <VAutocomplete
                 v-model="siteForm.downloader"
                 :label="t('site.fields.downloader')"
                 :items="downloaderOptions"

--- a/src/components/dialog/SubscribeEditDialog.vue
+++ b/src/components/dialog/SubscribeEditDialog.vue
@@ -346,7 +346,7 @@ onMounted(() => {
                 </VRow>
                 <VRow>
                   <VCol cols="12" md="4">
-                    <VSelect
+                    <VAutocomplete
                       v-model="subscribeForm.quality"
                       :label="t('dialog.subscribeEdit.quality')"
                       :items="qualityOptions"
@@ -356,7 +356,7 @@ onMounted(() => {
                     />
                   </VCol>
                   <VCol cols="12" md="4">
-                    <VSelect
+                    <VAutocomplete
                       v-model="subscribeForm.resolution"
                       :label="t('dialog.subscribeEdit.resolution')"
                       :items="resolutionOptions"
@@ -366,7 +366,7 @@ onMounted(() => {
                     />
                   </VCol>
                   <VCol cols="12" md="4">
-                    <VSelect
+                    <VAutocomplete
                       v-model="subscribeForm.effect"
                       :label="t('dialog.subscribeEdit.effect')"
                       :items="effectOptions"
@@ -378,7 +378,7 @@ onMounted(() => {
                 </VRow>
                 <VRow>
                   <VCol cols="12">
-                    <VSelect
+                    <VAutocomplete
                       v-model="subscribeForm.sites"
                       :items="selectSitesOptions"
                       chips
@@ -393,7 +393,7 @@ onMounted(() => {
                 </VRow>
                 <VRow>
                   <VCol cols="12" md="6">
-                    <VSelect
+                    <VAutocomplete
                       v-model="subscribeForm.downloader"
                       :items="downloaderOptions"
                       :label="t('dialog.subscribeEdit.downloader')"
@@ -465,7 +465,7 @@ onMounted(() => {
                 </VRow>
                 <VRow>
                   <VCol cols="12">
-                    <VSelect
+                    <VAutocomplete
                       v-model="subscribeForm.filter_groups"
                       :items="filterRuleGroupOptions"
                       chips
@@ -478,7 +478,7 @@ onMounted(() => {
                     />
                   </VCol>
                   <VCol v-if="!props.default && subscribeForm.type === '电视剧'" cols="12" md="6">
-                    <VSelect
+                    <VAutocomplete
                       v-model="subscribeForm.episode_group"
                       :items="episodeGroupOptions"
                       :item-props="episodeGroupItemProps"
@@ -489,7 +489,7 @@ onMounted(() => {
                     />
                   </VCol>
                   <VCol v-if="!props.default && subscribeForm.type === '电视剧'" cols="12" md="6">
-                    <VSelect
+                    <VAutocomplete
                       v-model="subscribeForm.season"
                       :items="seasonItems"
                       :label="t('dialog.subscribeEdit.season')"

--- a/src/views/setting/AccountSettingCache.vue
+++ b/src/views/setting/AccountSettingCache.vue
@@ -276,7 +276,7 @@ onMounted(() => {
           />
         </VCol>
         <VCol cols="6">
-          <VSelect
+          <VAutocomplete
             v-model="siteFilter"
             :label="t('setting.cache.filterBySite')"
             :items="siteOptions"

--- a/src/views/setting/AccountSettingSearch.vue
+++ b/src/views/setting/AccountSettingSearch.vue
@@ -209,7 +209,7 @@ onMounted(() => {
               />
             </VCol>
             <VCol cols="12" md="6">
-              <VSelect
+              <VAutocomplete
                 v-model="selectedFilterGroup"
                 multiple
                 clearable

--- a/src/views/setting/AccountSettingSubscribe.vue
+++ b/src/views/setting/AccountSettingSubscribe.vue
@@ -231,7 +231,7 @@ onMounted(() => {
                 />
               </VCol>
               <VCol cols="12" md="6">
-                <VSelect
+                <VAutocomplete
                   v-model="selectedFilterRuleGroup"
                   :items="filterRuleGroupOptions"
                   chips
@@ -244,7 +244,7 @@ onMounted(() => {
                 />
               </VCol>
               <VCol cols="12" md="6">
-                <VSelect
+                <VAutocomplete
                   v-model="selectedBestVersionRuleGroup"
                   :items="filterRuleGroupOptions"
                   chips


### PR DESCRIPTION
- 在多个组件中将 VSelect 组件替换为 VAutocomplete 组件，以支持搜索待选项
- 此更改可以提供更丰富的用户交互体验和更好的性能

涉及页面
* 订阅规则配置页
  - 订阅资源质量
  - 订阅资源分辨率
  - 订阅资源特效
  - 订阅的站点
  - 下载器
  - 优先级过滤规则组
  - 指定季
  - 指定剧集组
  
![image](https://github.com/user-attachments/assets/f87da260-dfdd-4f96-8e20-f83780dcf5e9)
![image](https://github.com/user-attachments/assets/326aeb66-8343-4440-b256-916c7da5a38a)

* 设定/媒体服务器配置页
  - 同步媒体库
  
![image](https://github.com/user-attachments/assets/e7063e01-d03a-4990-a723-7d8fd82a62d8)

* 设定/存储目录
 - 目录配置
 
![image](https://github.com/user-attachments/assets/162c56ee-0c8e-43f6-a185-a38f625d0b83)

* 设定/规则
 - 过滤规则
 
![image](https://github.com/user-attachments/assets/fe3e51d2-2e1b-41e5-933e-971f4c2eca36)
* 设定/搜索下载
![image](https://github.com/user-attachments/assets/b5fa28fe-7d72-4124-9ecc-4d38fbef66f6)

* 设定/订阅
![image](https://github.com/user-attachments/assets/bec5f24c-e665-45a2-97d8-1e02542c405d)

* 设定/缓存
![image](https://github.com/user-attachments/assets/44de80f8-76cb-4e14-b47a-55942f7cff34)

* 设定/通知
 - 通知渠道
![image](https://github.com/user-attachments/assets/a54ad264-9463-4ab5-9412-711857936173)
