### PR TITLE
fix:修改清华pip源地址

### DIFF
--- a/src/views/setting/AccountSettingSystem.vue
+++ b/src/views/setting/AccountSettingSystem.vue
@@ -304,7 +304,7 @@ const githubMirrorsItems: string[] = [
 
 // 预设部分PIP镜像站
 const pipMirrorsItems = [
-  'https://pypi.tuna.tsinghua.edu.cn/simple', // 清华大学
+  'https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple', // 清华大学
   'https://pypi.mirrors.ustc.edu.cn/simple', // 中国科技大学
   'https://mirrors.pku.edu.cn/pypi/web/simple', // 北京大学
   'https://mirrors.aliyun.com/pypi/simple', // 阿里云


### PR DESCRIPTION
清华 pip源 修改地址了。
官网：https://mirrors.tuna.tsinghua.edu.cn/help/pypi/