### PR TITLE
Fix tab selection on discovery page

### DIFF
--- a/src/composables/useDynamicHeaderTab.ts
+++ b/src/composables/useDynamicHeaderTab.ts
@@ -91,6 +91,8 @@ export function useDynamicHeaderTab() {
       tabConfig.routePath = route.path
       // 确保items是最新的
       tabConfig.items = Array.isArray(config.items) ? config.items : config.items.value
+      // 确保modelValue是最新的
+      tabConfig.modelValue = config.modelValue.value
 
       if (registerDynamicHeaderTab) {
         registerDynamicHeaderTab(tabConfig)

--- a/src/pages/discover.vue
+++ b/src/pages/discover.vue
@@ -123,23 +123,6 @@ async function saveTabOrder() {
 // 使用动态标签页
 const { registerHeaderTab } = useDynamicHeaderTab()
 
-// 注册动态标签页
-registerHeaderTab({
-  items: discoverTabItems, // 传递computed值，而不是.value
-  modelValue: activeTab,
-  appendButtons: [
-    {
-      icon: 'mdi-order-alphabetical-ascending',
-      variant: 'text',
-      color: 'grey',
-      class: 'settings-icon-button',
-      action: () => {
-        orderConfigDialog.value = true
-      },
-    },
-  ],
-})
-
 onBeforeMount(async () => {
   initDiscoverTabs()
   await loadOrderConfig()
@@ -149,6 +132,23 @@ onBeforeMount(async () => {
   if (discoverTabs.value.length > 0) {
     activeTab.value = discoverTabs.value[0].mediaid_prefix
   }
+  
+  // 注册动态标签页（在数据准备好之后）
+  registerHeaderTab({
+    items: discoverTabItems, // 传递computed值，而不是.value
+    modelValue: activeTab,
+    appendButtons: [
+      {
+        icon: 'mdi-order-alphabetical-ascending',
+        variant: 'text',
+        color: 'grey',
+        class: 'settings-icon-button',
+        action: () => {
+          orderConfigDialog.value = true
+        },
+      },
+    ],
+  })
 })
 
 

--- a/src/pages/discover.vue
+++ b/src/pages/discover.vue
@@ -151,13 +151,20 @@ onBeforeMount(async () => {
   }
 })
 
+// 确保在标签页数据变化后，如果没有选中任何标签页，自动选中第一个
+watch(discoverTabItems, (newItems) => {
+  if (newItems.length > 0 && !activeTab.value) {
+    activeTab.value = newItems[0].tab
+  }
+}, { immediate: true })
+
 
 
 onActivated(async () => {
   await loadExtraDiscoverSources()
   sortSubscribeOrder()
-  // 如果当前选中的标签页不存在，则选中第一个标签页
-  if (activeTab.value && !discoverTabs.value.find(tab => tab.mediaid_prefix === activeTab.value)) {
+  // 如果当前没有选中任何标签页，或者当前选中的标签页不存在，则选中第一个标签页
+  if (!activeTab.value || !discoverTabs.value.find(tab => tab.mediaid_prefix === activeTab.value)) {
     if (discoverTabs.value.length > 0) {
       activeTab.value = discoverTabs.value[0].mediaid_prefix
     }

--- a/src/pages/discover.vue
+++ b/src/pages/discover.vue
@@ -145,21 +145,24 @@ onBeforeMount(async () => {
   await loadOrderConfig()
   await loadExtraDiscoverSources()
   sortSubscribeOrder()
-})
-
-onMounted(() => {
   // 选中第一个标签页
   if (discoverTabs.value.length > 0) {
     activeTab.value = discoverTabs.value[0].mediaid_prefix
   }
 })
 
+onMounted(() => {
+  // 空的，因为初始化已经在onBeforeMount中完成
+})
+
 onActivated(async () => {
   await loadExtraDiscoverSources()
   sortSubscribeOrder()
-  // 如果当前没有选中任何标签页，则选中第一个标签页
-  if (!activeTab.value && discoverTabs.value.length > 0) {
-    activeTab.value = discoverTabs.value[0].mediaid_prefix
+  // 如果当前选中的标签页不存在，则选中第一个标签页
+  if (activeTab.value && !discoverTabs.value.find(tab => tab.mediaid_prefix === activeTab.value)) {
+    if (discoverTabs.value.length > 0) {
+      activeTab.value = discoverTabs.value[0].mediaid_prefix
+    }
   }
 })
 </script>

--- a/src/pages/discover.vue
+++ b/src/pages/discover.vue
@@ -123,6 +123,23 @@ async function saveTabOrder() {
 // 使用动态标签页
 const { registerHeaderTab } = useDynamicHeaderTab()
 
+// 注册动态标签页（在setup阶段，但使用computed保证响应性）
+registerHeaderTab({
+  items: discoverTabItems, // 传递computed值，会自动响应变化
+  modelValue: activeTab,
+  appendButtons: [
+    {
+      icon: 'mdi-order-alphabetical-ascending',
+      variant: 'text',
+      color: 'grey',
+      class: 'settings-icon-button',
+      action: () => {
+        orderConfigDialog.value = true
+      },
+    },
+  ],
+})
+
 onBeforeMount(async () => {
   initDiscoverTabs()
   await loadOrderConfig()
@@ -132,23 +149,6 @@ onBeforeMount(async () => {
   if (discoverTabs.value.length > 0) {
     activeTab.value = discoverTabs.value[0].mediaid_prefix
   }
-  
-  // 注册动态标签页（在数据准备好之后）
-  registerHeaderTab({
-    items: discoverTabItems, // 传递computed值，而不是.value
-    modelValue: activeTab,
-    appendButtons: [
-      {
-        icon: 'mdi-order-alphabetical-ascending',
-        variant: 'text',
-        color: 'grey',
-        class: 'settings-icon-button',
-        action: () => {
-          orderConfigDialog.value = true
-        },
-      },
-    ],
-  })
 })
 
 

--- a/src/pages/discover.vue
+++ b/src/pages/discover.vue
@@ -157,6 +157,12 @@ onMounted(() => {
 onActivated(async () => {
   await loadExtraDiscoverSources()
   sortSubscribeOrder()
+  // 如果当前没有选中任何标签页，或者当前选中的标签页不存在，则选中第一个标签页
+  if (!activeTab.value || !discoverTabs.value.find(tab => tab.mediaid_prefix === activeTab.value)) {
+    if (discoverTabs.value.length > 0) {
+      activeTab.value = discoverTabs.value[0].mediaid_prefix
+    }
+  }
 })
 </script>
 

--- a/src/pages/discover.vue
+++ b/src/pages/discover.vue
@@ -151,9 +151,7 @@ onBeforeMount(async () => {
   }
 })
 
-onMounted(() => {
-  // 空的，因为初始化已经在onBeforeMount中完成
-})
+
 
 onActivated(async () => {
   await loadExtraDiscoverSources()

--- a/src/pages/discover.vue
+++ b/src/pages/discover.vue
@@ -151,12 +151,7 @@ onBeforeMount(async () => {
   }
 })
 
-// 确保在标签页数据变化后，如果没有选中任何标签页，自动选中第一个
-watch(discoverTabItems, (newItems) => {
-  if (newItems.length > 0 && !activeTab.value) {
-    activeTab.value = newItems[0].tab
-  }
-}, { immediate: true })
+
 
 
 

--- a/src/pages/discover.vue
+++ b/src/pages/discover.vue
@@ -157,11 +157,9 @@ onMounted(() => {
 onActivated(async () => {
   await loadExtraDiscoverSources()
   sortSubscribeOrder()
-  // 如果当前没有选中任何标签页，或者当前选中的标签页不存在，则选中第一个标签页
-  if (!activeTab.value || !discoverTabs.value.find(tab => tab.mediaid_prefix === activeTab.value)) {
-    if (discoverTabs.value.length > 0) {
-      activeTab.value = discoverTabs.value[0].mediaid_prefix
-    }
+  // 如果当前没有选中任何标签页，则选中第一个标签页
+  if (!activeTab.value && discoverTabs.value.length > 0) {
+    activeTab.value = discoverTabs.value[0].mediaid_prefix
   }
 })
 </script>


### PR DESCRIPTION
Fix Discover page tabs not auto-selecting the first tab after reordering or on page activation.

The `HeaderTab` component was not always receiving the latest `activeTab` value due to a missing `modelValue` update in `useDynamicHeaderTab`'s `doRegister` function. This PR ensures `modelValue` is always current and refines the `onBeforeMount` and `onActivated` logic in `discover.vue` to correctly handle initial tab selection and reordering scenarios.