### PR TITLE
Fix iOS detection inconsistency in PWA

### DIFF
--- a/src/composables/usePWAInstall.ts
+++ b/src/composables/usePWAInstall.ts
@@ -86,7 +86,7 @@ export function usePWAInstall() {
   const isPWASupported = computed(() => {
     const hasServiceWorker = 'serviceWorker' in navigator
     const supportsInstallPromptEvent = 'onbeforeinstallprompt' in window
-    const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent)
+    const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent) && !(window as any).MSStream
 
     return hasServiceWorker && (supportsInstallPromptEvent || isIOS)
   })


### PR DESCRIPTION
Align iOS detection in `isPWASupported` to match `getInstallInstructions` and prevent incorrect PWA support detection on Windows devices spoofing iOS user agents.