### PR TITLE
fix: 修复推荐页面外部推荐源URL参数拼接问题

### DIFF
--- a/src/pages/recommend.vue
+++ b/src/pages/recommend.vue
@@ -127,9 +127,11 @@ async function loadExtraRecommendSources() {
     if (extraRecommendSources.value.length > 0) {
       extraRecommendSources.value.map(source => {
         if (!viewList.some(item => item.apipath === source.api_path)) {
+          const querySeparator = source.api_path.includes('?') ? '&' : '?';
+          const linkUrl = `/browse/${source.api_path}${querySeparator}title=${encodeURIComponent(source.name)}`;
           viewList.push({
             apipath: source.api_path,
-            linkurl: `/browse/${source.api_path}&title=${source.name}`,
+            linkurl: linkUrl,
             title: source.name,
             type: source.type,
           })


### PR DESCRIPTION
- 修改`linkurl`拼接逻辑，兼容`api_path`包含和不包含查询参数的情况  
- URL编码`title`