### PR TITLE
LibraryCard中drawImages优化

### DIFF
--- a/src/components/cards/LibraryCard.vue
+++ b/src/components/cards/LibraryCard.vue
@@ -121,18 +121,18 @@ async function drawImages(imageList: string[]) {
       img.width,
       img.height,
       x,
-      canvas.height - (POSTER_HEIGHT + MARGIN_HEIGHT + REFLECTION_HEIGHT),  // 倒影位置在海报下方，考虑画布翻转
+      0,
       POSTER_WIDTH,
       REFLECTION_HEIGHT,
     )
 
-    const gradient = ctx.createLinearGradient(0, canvas.height - (POSTER_HEIGHT + MARGIN_HEIGHT + REFLECTION_HEIGHT), 0, canvas.height - (POSTER_HEIGHT + MARGIN_HEIGHT))
+    const gradient = ctx.createLinearGradient(0, 0, 0, canvas.height - (POSTER_HEIGHT + MARGIN_HEIGHT))
 
     gradient.addColorStop(0, 'rgba(0, 0, 0, 1)')
     gradient.addColorStop(1, 'rgba(0, 0, 0, 0.7)')
     ctx.globalCompositeOperation = 'destination-out';
     ctx.fillStyle = gradient
-    ctx.fillRect(x, canvas.height - (POSTER_HEIGHT + MARGIN_HEIGHT + REFLECTION_HEIGHT), POSTER_WIDTH, REFLECTION_HEIGHT)
+    ctx.fillRect(x, 0, POSTER_WIDTH, REFLECTION_HEIGHT)
 
     ctx.restore()
   }

--- a/src/components/cards/LibraryCard.vue
+++ b/src/components/cards/LibraryCard.vue
@@ -72,12 +72,12 @@ async function drawImages(imageList: string[]) {
   if (!canvas) return getDefaultImage()
 
   // 画布参数
-  const POSTER_WIDTH = (canvas.width - 32) / 4
-  const POSTER_HEIGHT = canvas.height * 0.75 - 8
-  const MARGIN_WIDTH = 4
-  const MARGIN_HEIGHT = 4
-  const REFLECTION_HEIGHT = POSTER_HEIGHT / 2
-  const REFLECTION_SHOW_HEIGHT = canvas.height / 4
+  const POSTER_WIDTH = (canvas.width - 40) / 4  // 左右边框8px + 3个间隔24px = 40px
+  const POSTER_HEIGHT = 256  // 上方海报高256
+  const MARGIN_WIDTH = 8  // 左右间隔为8
+  const MARGIN_HEIGHT = 4  // 海报和倒影之间的间隔为4
+  const REFLECTION_HEIGHT = canvas.height - POSTER_HEIGHT - MARGIN_HEIGHT  // 下方倒影使用剩余全部高度
+  const REFLECTION_SHOW_HEIGHT = REFLECTION_HEIGHT
 
   // 获取画布上下文
   const ctx = canvas.getContext('2d')
@@ -104,12 +104,12 @@ async function drawImages(imageList: string[]) {
     } catch (error) {
       console.error(error)
       ctx.fillStyle = '#e5e7eb'
-      ctx.fillRect(MARGIN_WIDTH * index + POSTER_WIDTH * (index - 1), MARGIN_HEIGHT, POSTER_WIDTH, POSTER_HEIGHT)
+      ctx.fillRect(MARGIN_WIDTH * index + POSTER_WIDTH * (index - 1), 0, POSTER_WIDTH, POSTER_HEIGHT)
       return
     }
 
     const x = MARGIN_WIDTH * index + POSTER_WIDTH * (index - 1)
-    const y = MARGIN_HEIGHT
+    const y = 0  // 海报紧贴顶部
 
     ctx.drawImage(img, x, y, POSTER_WIDTH, POSTER_HEIGHT)
 
@@ -123,17 +123,17 @@ async function drawImages(imageList: string[]) {
       img.width,
       img.height,
       x,
-      REFLECTION_SHOW_HEIGHT - REFLECTION_HEIGHT,
+      canvas.height - (POSTER_HEIGHT + MARGIN_HEIGHT + REFLECTION_HEIGHT),  // 倒影位置在海报下方，考虑画布翻转
       POSTER_WIDTH,
       REFLECTION_HEIGHT,
     )
 
-    const gradient = ctx.createLinearGradient(0, REFLECTION_SHOW_HEIGHT - REFLECTION_HEIGHT, 0, REFLECTION_HEIGHT)
+    const gradient = ctx.createLinearGradient(0, canvas.height - (POSTER_HEIGHT + MARGIN_HEIGHT + REFLECTION_HEIGHT), 0, canvas.height - (POSTER_HEIGHT + MARGIN_HEIGHT))
 
     gradient.addColorStop(0, 'rgba(0, 0, 0, 1)')
     gradient.addColorStop(1, 'rgba(0, 0, 0, 0.3)')
     ctx.fillStyle = gradient
-    ctx.fillRect(x, 0, POSTER_WIDTH, REFLECTION_SHOW_HEIGHT)
+    ctx.fillRect(x, canvas.height - (POSTER_HEIGHT + MARGIN_HEIGHT + REFLECTION_HEIGHT), POSTER_WIDTH, REFLECTION_HEIGHT)
 
     ctx.restore()
   }

--- a/src/components/cards/LibraryCard.vue
+++ b/src/components/cards/LibraryCard.vue
@@ -130,7 +130,8 @@ async function drawImages(imageList: string[]) {
     const gradient = ctx.createLinearGradient(0, canvas.height - (POSTER_HEIGHT + MARGIN_HEIGHT + REFLECTION_HEIGHT), 0, canvas.height - (POSTER_HEIGHT + MARGIN_HEIGHT))
 
     gradient.addColorStop(0, 'rgba(0, 0, 0, 1)')
-    gradient.addColorStop(1, 'rgba(0, 0, 0, 0.3)')
+    gradient.addColorStop(1, 'rgba(0, 0, 0, 0.7)')
+    ctx.globalCompositeOperation = 'destination-out';
     ctx.fillStyle = gradient
     ctx.fillRect(x, canvas.height - (POSTER_HEIGHT + MARGIN_HEIGHT + REFLECTION_HEIGHT), POSTER_WIDTH, REFLECTION_HEIGHT)
 

--- a/src/components/cards/LibraryCard.vue
+++ b/src/components/cards/LibraryCard.vue
@@ -77,7 +77,6 @@ async function drawImages(imageList: string[]) {
   const MARGIN_WIDTH = 8  // 左右间隔为8
   const MARGIN_HEIGHT = 4  // 海报和倒影之间的间隔为4
   const REFLECTION_HEIGHT = canvas.height - POSTER_HEIGHT - MARGIN_HEIGHT  // 下方倒影使用剩余全部高度
-  const REFLECTION_SHOW_HEIGHT = REFLECTION_HEIGHT
 
   // 获取画布上下文
   const ctx = canvas.getContext('2d')

--- a/src/components/cards/LibraryCard.vue
+++ b/src/components/cards/LibraryCard.vue
@@ -83,9 +83,8 @@ async function drawImages(imageList: string[]) {
   const ctx = canvas.getContext('2d')
   if (!ctx) return getDefaultImage()
 
-  // 设置背景色为黑色
-  ctx.fillStyle = '#000000'
-  ctx.fillRect(0, 0, canvas.width, canvas.height)
+  // 设置背景色为透明
+  ctx.clearRect(0, 0, canvas.width, canvas.height)
 
   // 绘制图片
   async function drawImageWithReflection(imgSrc: string, index: number) {

--- a/src/components/cards/LibraryCard.vue
+++ b/src/components/cards/LibraryCard.vue
@@ -166,7 +166,7 @@ onMounted(async () => {
         @click="goPlay"
       >
         <template #image>
-          <canvas ref="canvasRef" class="w-full h-full hidden" />
+          <canvas ref="canvasRef" width="640" height="360" class="w-full h-full hidden" />
           <VImg :src="imgUrl" aspect-ratio="2/3" cover @load="imageLoadHandler" @error="imageErrorHandler">
             <template #placeholder>
               <div class="w-full h-full">


### PR DESCRIPTION
-  canvas设定宽高,封面更清晰
    - 之前的尺寸为canvas的默认宽高(300*150)
- 布局有点歪,优化一下
- 黑色背景改为透明背景,与主题更搭

## old
<img width="300" height="150" alt="old" src="https://github.com/user-attachments/assets/f82ad51f-6078-4576-885d-3ecbd4f34cbc" />

## new
<img width="640" height="360" alt="new" src="https://github.com/user-attachments/assets/eabb52a4-2929-46d2-9098-5a8ef1cf7cb7" />
