### PR TITLE
Block body scroll when quick access opens

### DIFF
--- a/src/layouts/components/QuickAccess.vue
+++ b/src/layouts/components/QuickAccess.vue
@@ -212,6 +212,11 @@ watch(
     if (visible) {
       fetchPluginsWithPage()
       loadRecentPlugins()
+      // 添加v-overlay-scroll-blocked类到html元素
+      document.documentElement.classList.add('v-overlay-scroll-blocked')
+    } else {
+      // 移除v-overlay-scroll-blocked类
+      document.documentElement.classList.remove('v-overlay-scroll-blocked')
     }
   },
   { immediate: true },
@@ -222,6 +227,11 @@ onMounted(() => {
     fetchPluginsWithPage()
     loadRecentPlugins()
   }
+})
+
+// 组件卸载时确保移除v-overlay-scroll-blocked类
+onUnmounted(() => {
+  document.documentElement.classList.remove('v-overlay-scroll-blocked')
 })
 
 // 处理触摸开始


### PR DESCRIPTION
Manage `v-overlay-scroll-blocked` class on the `html` element to disable body scrolling when the QuickAccess panel is open.

---
<a href="https://cursor.com/background-agent?bcId=bc-e912a60c-ee45-4095-9632-02ba561f9ad2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e912a60c-ee45-4095-9632-02ba561f9ad2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

