### PR TITLE
Fix cacheview toolbar stats centering on small screens

### DIFF
--- a/src/views/system/CacheView.vue
+++ b/src/views/system/CacheView.vue
@@ -239,9 +239,9 @@ onMounted(() => {
         <!-- 移动端垂直布局，桌面端水平布局 -->
         <div class="d-flex flex-column flex-md-row align-center justify-space-between w-100 gap-4">
           <!-- 左侧统计信息 -->
-          <div class="d-flex align-center gap-2 gap-md-6 w-100 w-md-auto">
+          <div class="d-flex align-center justify-center justify-md-start gap-2 gap-md-6 w-100 w-md-auto">
             <!-- 统计信息卡片 -->
-            <div class="d-flex gap-2 gap-md-4 flex-wrap">
+            <div class="d-flex gap-2 gap-md-4 flex-wrap justify-center justify-md-start">
               <VCard variant="tonal" color="primary" class="pa-2 pa-md-3 flex-grow-1 flex-md-grow-0" style="min-width: 120px;">
                 <div class="d-flex align-center gap-2">
                   <VIcon color="primary" size="small">mdi-database</VIcon>


### PR DESCRIPTION
Center CacheView toolbar left statistics on small screens by adjusting CSS classes.

---
<a href="https://cursor.com/background-agent?bcId=bc-a47c9c97-0139-41d5-bf59-35047e0eda0e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a47c9c97-0139-41d5-bf59-35047e0eda0e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

