### PR TITLE
Add sorting to subscription filters

### DIFF
--- a/src/locales/en-US.ts
+++ b/src/locales/en-US.ts
@@ -2744,6 +2744,9 @@ export default {
       firstAirDateAsc: 'First Air Date Ascending',
       voteAverageDesc: 'Vote Average Descending',
       voteAverageAsc: 'Vote Average Ascending',
+      time: 'Sort by Time',
+      count: 'Sort by Popularity',
+      rating: 'Sort by Rating',
     },
     genreType: {
       action: 'Action',

--- a/src/locales/zh-CN.ts
+++ b/src/locales/zh-CN.ts
@@ -2712,6 +2712,9 @@ export default {
       firstAirDateAsc: '首播日期升序',
       voteAverageDesc: '评分降序',
       voteAverageAsc: '评分升序',
+      time: '按时间排序',
+      count: '按热度排序',
+      rating: '按评分排序',
     },
     genreType: {
       action: '动作',

--- a/src/locales/zh-TW.ts
+++ b/src/locales/zh-TW.ts
@@ -2698,6 +2698,9 @@ export default {
       firstAirDateAsc: '首播日期升序',
       voteAverageDesc: '評分降序',
       voteAverageAsc: '評分升序',
+      time: '按時間排序',
+      count: '按熱度排序',
+      rating: '按評分排序',
     },
     genreType: {
       action: '動作',

--- a/src/views/subscribe/SubscribePopularView.vue
+++ b/src/views/subscribe/SubscribePopularView.vue
@@ -40,6 +40,7 @@ const filterParams = reactive({
   min_rating: 0,
   max_rating: 10,
   min_sub: 1,
+  sort_type: 'count', // 默认按热度排序
 })
 
 // 当前Key（用于重新加载数据）
@@ -122,6 +123,9 @@ function getParams() {
   }
   if (filterParams.min_sub > 1) {
     params.min_sub = filterParams.min_sub
+  }
+  if (filterParams.sort_type) {
+    params.sort_type = filterParams.sort_type
   }
   
   return params
@@ -233,7 +237,7 @@ async function fetchData({ done }: { done: any }) {
       </VSlider>
     </div>
     
-    <div class="flex justify-start align-center">
+    <div class="flex justify-start align-center mb-3">
       <div class="mr-5">
         <VLabel>{{ t('subscribe.minSubscribers') }}</VLabel>
       </div>
@@ -246,6 +250,24 @@ async function fetchData({ done }: { done: any }) {
         single-line
         min="1"
         style="width: 120px;"
+      />
+    </div>
+    
+    <div class="flex justify-start align-center">
+      <div class="mr-5">
+        <VLabel>{{ t('tmdb.sort') }}</VLabel>
+      </div>
+      <VSelect
+        v-model="filterParams.sort_type"
+        :items="[
+          { title: t('tmdb.sortType.time'), value: 'time' },
+          { title: t('tmdb.sortType.count'), value: 'count' },
+          { title: t('tmdb.sortType.rating'), value: 'rating' }
+        ]"
+        variant="outlined"
+        density="compact"
+        hide-details
+        style="width: 150px;"
       />
     </div>
   </div>

--- a/src/views/subscribe/SubscribeShareView.vue
+++ b/src/views/subscribe/SubscribeShareView.vue
@@ -33,6 +33,7 @@ const filterParams = reactive({
   genre_id: '',
   min_rating: 0,
   max_rating: 10,
+  sort_type: 'time', // 默认按时间排序
 })
 
 // 当前Key（用于重新加载数据）
@@ -137,6 +138,9 @@ function getParams() {
   if (filterParams.max_rating < 10) {
     params.max_rating = filterParams.max_rating
   }
+  if (filterParams.sort_type) {
+    params.sort_type = filterParams.sort_type
+  }
   
   return params
 }
@@ -232,7 +236,7 @@ function removeData(id: number) {
       </VChipGroup>
     </div>
     
-    <div class="flex justify-start align-center">
+    <div class="flex justify-start align-center mb-3">
       <div class="mr-5">
         <VLabel>{{ t('tmdb.rating') }}</VLabel>
       </div>
@@ -250,6 +254,24 @@ function removeData(id: number) {
           <span class="ml-2 text-body-2">- 10</span>
         </template>
       </VSlider>
+    </div>
+    
+    <div class="flex justify-start align-center">
+      <div class="mr-5">
+        <VLabel>{{ t('tmdb.sort') }}</VLabel>
+      </div>
+      <VSelect
+        v-model="filterParams.sort_type"
+        :items="[
+          { title: t('tmdb.sortType.time'), value: 'time' },
+          { title: t('tmdb.sortType.count'), value: 'count' },
+          { title: t('tmdb.sortType.rating'), value: 'rating' }
+        ]"
+        variant="outlined"
+        density="compact"
+        hide-details
+        style="width: 150px;"
+      />
     </div>
   </div>
 


### PR DESCRIPTION
Add sort condition filters to "Popular Subscriptions" and "Shared Subscriptions" pages to utilize the new backend `sort_type` parameter.

---
<a href="https://cursor.com/background-agent?bcId=bc-fff38fa1-47db-4395-afb8-421cbfff3102">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fff38fa1-47db-4395-afb8-421cbfff3102">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

