### PR TITLE
Update subscription sorting and scoring

### DIFF
--- a/src/views/subscribe/SubscribePopularView.vue
+++ b/src/views/subscribe/SubscribePopularView.vue
@@ -219,56 +219,66 @@ async function fetchData({ done }: { done: any }) {
     
     <div class="flex justify-start align-center mb-3">
       <div class="mr-5">
-        <VLabel>{{ t('tmdb.rating') }}</VLabel>
+        <VLabel>{{ t('tmdb.rating') }} & {{ t('subscribe.minSubscribers') }}</VLabel>
       </div>
-      <VSlider
-        v-model="filterParams.min_rating"
-        thumb-label
-        max="10"
-        min="0"
-        :step="0.1"
-        class="align-center"
-        hide-details
-        style="width: 200px;"
-      >
-        <template v-slot:append>
-          <span class="ml-2 text-body-2">- 10</span>
-        </template>
-      </VSlider>
-    </div>
-    
-    <div class="flex justify-start align-center mb-3">
-      <div class="mr-5">
-        <VLabel>{{ t('subscribe.minSubscribers') }}</VLabel>
+      <div class="flex align-center">
+        <VSlider
+          v-model="filterParams.min_rating"
+          thumb-label
+          max="10"
+          min="0"
+          :step="1"
+          class="align-center"
+          hide-details
+          style="width: 200px;"
+        >
+          <template v-slot:append>
+            <span class="ml-2 text-body-2">- 10</span>
+          </template>
+        </VSlider>
+        <VTextField
+          v-model="filterParams.min_sub"
+          variant="outlined"
+          density="compact"
+          type="number"
+          hide-details
+          single-line
+          min="1"
+          style="width: 120px; margin-left: 20px;"
+        />
       </div>
-      <VTextField
-        v-model="filterParams.min_sub"
-        variant="outlined"
-        density="compact"
-        type="number"
-        hide-details
-        single-line
-        min="1"
-        style="width: 120px;"
-      />
     </div>
     
     <div class="flex justify-start align-center">
       <div class="mr-5">
         <VLabel>{{ t('tmdb.sort') }}</VLabel>
       </div>
-      <VSelect
-        v-model="filterParams.sort_type"
-        :items="[
-          { title: t('tmdb.sortType.time'), value: 'time' },
-          { title: t('tmdb.sortType.count'), value: 'count' },
-          { title: t('tmdb.sortType.rating'), value: 'rating' }
-        ]"
-        variant="outlined"
-        density="compact"
-        hide-details
-        style="width: 150px;"
-      />
+      <VChipGroup v-model="filterParams.sort_type">
+        <VChip
+          :color="filterParams.sort_type == 'time' ? 'primary' : ''"
+          filter
+          tile
+          value="time"
+        >
+          {{ t('tmdb.sortType.time') }}
+        </VChip>
+        <VChip
+          :color="filterParams.sort_type == 'count' ? 'primary' : ''"
+          filter
+          tile
+          value="count"
+        >
+          {{ t('tmdb.sortType.count') }}
+        </VChip>
+        <VChip
+          :color="filterParams.sort_type == 'rating' ? 'primary' : ''"
+          filter
+          tile
+          value="rating"
+        >
+          {{ t('tmdb.sortType.rating') }}
+        </VChip>
+      </VChipGroup>
     </div>
   </div>
 

--- a/src/views/subscribe/SubscribePopularView.vue
+++ b/src/views/subscribe/SubscribePopularView.vue
@@ -201,6 +201,38 @@ async function fetchData({ done }: { done: any }) {
   <div class="px-3 mb-4">
     <div class="flex justify-start align-center mb-3">
       <div class="mr-5">
+        <VLabel>{{ t('tmdb.sort') }}</VLabel>
+      </div>
+      <VChipGroup v-model="filterParams.sort_type">
+        <VChip
+          :color="filterParams.sort_type == 'time' ? 'primary' : ''"
+          filter
+          tile
+          value="time"
+        >
+          {{ t('tmdb.sortType.time') }}
+        </VChip>
+        <VChip
+          :color="filterParams.sort_type == 'count' ? 'primary' : ''"
+          filter
+          tile
+          value="count"
+        >
+          {{ t('tmdb.sortType.count') }}
+        </VChip>
+        <VChip
+          :color="filterParams.sort_type == 'rating' ? 'primary' : ''"
+          filter
+          tile
+          value="rating"
+        >
+          {{ t('tmdb.sortType.rating') }}
+        </VChip>
+      </VChipGroup>
+    </div>
+    
+    <div class="flex justify-start align-center mb-3">
+      <div class="mr-5">
         <VLabel>{{ t('tmdb.genre') }}</VLabel>
       </div>
       <VChipGroup v-model="filterParams.genre_id">
@@ -247,38 +279,6 @@ async function fetchData({ done }: { done: any }) {
           style="width: 120px; margin-left: 20px;"
         />
       </div>
-    </div>
-    
-    <div class="flex justify-start align-center">
-      <div class="mr-5">
-        <VLabel>{{ t('tmdb.sort') }}</VLabel>
-      </div>
-      <VChipGroup v-model="filterParams.sort_type">
-        <VChip
-          :color="filterParams.sort_type == 'time' ? 'primary' : ''"
-          filter
-          tile
-          value="time"
-        >
-          {{ t('tmdb.sortType.time') }}
-        </VChip>
-        <VChip
-          :color="filterParams.sort_type == 'count' ? 'primary' : ''"
-          filter
-          tile
-          value="count"
-        >
-          {{ t('tmdb.sortType.count') }}
-        </VChip>
-        <VChip
-          :color="filterParams.sort_type == 'rating' ? 'primary' : ''"
-          filter
-          tile
-          value="rating"
-        >
-          {{ t('tmdb.sortType.rating') }}
-        </VChip>
-      </VChipGroup>
     </div>
   </div>
 

--- a/src/views/subscribe/SubscribeShareView.vue
+++ b/src/views/subscribe/SubscribeShareView.vue
@@ -245,7 +245,7 @@ function removeData(id: number) {
         thumb-label
         max="10"
         min="0"
-        :step="0.1"
+        :step="1"
         class="align-center"
         hide-details
         style="width: 200px;"
@@ -260,18 +260,32 @@ function removeData(id: number) {
       <div class="mr-5">
         <VLabel>{{ t('tmdb.sort') }}</VLabel>
       </div>
-      <VSelect
-        v-model="filterParams.sort_type"
-        :items="[
-          { title: t('tmdb.sortType.time'), value: 'time' },
-          { title: t('tmdb.sortType.count'), value: 'count' },
-          { title: t('tmdb.sortType.rating'), value: 'rating' }
-        ]"
-        variant="outlined"
-        density="compact"
-        hide-details
-        style="width: 150px;"
-      />
+      <VChipGroup v-model="filterParams.sort_type">
+        <VChip
+          :color="filterParams.sort_type == 'time' ? 'primary' : ''"
+          filter
+          tile
+          value="time"
+        >
+          {{ t('tmdb.sortType.time') }}
+        </VChip>
+        <VChip
+          :color="filterParams.sort_type == 'count' ? 'primary' : ''"
+          filter
+          tile
+          value="count"
+        >
+          {{ t('tmdb.sortType.count') }}
+        </VChip>
+        <VChip
+          :color="filterParams.sort_type == 'rating' ? 'primary' : ''"
+          filter
+          tile
+          value="rating"
+        >
+          {{ t('tmdb.sortType.rating') }}
+        </VChip>
+      </VChipGroup>
     </div>
   </div>
 

--- a/src/views/subscribe/SubscribeShareView.vue
+++ b/src/views/subscribe/SubscribeShareView.vue
@@ -220,6 +220,38 @@ function removeData(id: number) {
   <div class="px-3 mb-4">
     <div class="flex justify-start align-center mb-3">
       <div class="mr-5">
+        <VLabel>{{ t('tmdb.sort') }}</VLabel>
+      </div>
+      <VChipGroup v-model="filterParams.sort_type">
+        <VChip
+          :color="filterParams.sort_type == 'time' ? 'primary' : ''"
+          filter
+          tile
+          value="time"
+        >
+          {{ t('tmdb.sortType.time') }}
+        </VChip>
+        <VChip
+          :color="filterParams.sort_type == 'count' ? 'primary' : ''"
+          filter
+          tile
+          value="count"
+        >
+          {{ t('tmdb.sortType.count') }}
+        </VChip>
+        <VChip
+          :color="filterParams.sort_type == 'rating' ? 'primary' : ''"
+          filter
+          tile
+          value="rating"
+        >
+          {{ t('tmdb.sortType.rating') }}
+        </VChip>
+      </VChipGroup>
+    </div>
+    
+    <div class="flex justify-start align-center mb-3">
+      <div class="mr-5">
         <VLabel>{{ t('tmdb.genre') }}</VLabel>
       </div>
       <VChipGroup v-model="filterParams.genre_id">
@@ -254,38 +286,6 @@ function removeData(id: number) {
           <span class="ml-2 text-body-2">- 10</span>
         </template>
       </VSlider>
-    </div>
-    
-    <div class="flex justify-start align-center">
-      <div class="mr-5">
-        <VLabel>{{ t('tmdb.sort') }}</VLabel>
-      </div>
-      <VChipGroup v-model="filterParams.sort_type">
-        <VChip
-          :color="filterParams.sort_type == 'time' ? 'primary' : ''"
-          filter
-          tile
-          value="time"
-        >
-          {{ t('tmdb.sortType.time') }}
-        </VChip>
-        <VChip
-          :color="filterParams.sort_type == 'count' ? 'primary' : ''"
-          filter
-          tile
-          value="count"
-        >
-          {{ t('tmdb.sortType.count') }}
-        </VChip>
-        <VChip
-          :color="filterParams.sort_type == 'rating' ? 'primary' : ''"
-          filter
-          tile
-          value="rating"
-        >
-          {{ t('tmdb.sortType.rating') }}
-        </VChip>
-      </VChipGroup>
     </div>
   </div>
 


### PR DESCRIPTION
Refactor popular and shared subscription pages to use ChipGroup for sorting, set rating slider step to 1, and combine rating with minimum subscribers for a more consistent and intuitive UI.

---
<a href="https://cursor.com/background-agent?bcId=bc-3868e0ff-2c72-46ed-a6a1-f43d4e5eb318">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3868e0ff-2c72-46ed-a6a1-f43d4e5eb318">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

