### PR TITLE
Add default all filter for subscription styles

### DIFF
--- a/src/views/subscribe/SubscribePopularView.vue
+++ b/src/views/subscribe/SubscribePopularView.vue
@@ -36,7 +36,7 @@ const currData = ref<MediaInfo[]>([])
 
 // 筛选参数
 const filterParams = reactive({
-  genre_id: '',
+  genre_id: '', // 空字符串表示选中"全部"
   min_rating: 0,
   max_rating: 10,
   min_sub: 1,
@@ -225,6 +225,14 @@ async function fetchData({ done }: { done: any }) {
         <VLabel>{{ t('tmdb.genre') }}</VLabel>
       </div>
       <VChipGroup v-model="filterParams.genre_id">
+        <VChip
+          :color="filterParams.genre_id == '' ? 'primary' : ''"
+          filter
+          tile
+          value=""
+        >
+          {{ t('common.all') }}
+        </VChip>
         <VChip
           :color="filterParams.genre_id == key ? 'primary' : ''"
           filter

--- a/src/views/subscribe/SubscribeShareView.vue
+++ b/src/views/subscribe/SubscribeShareView.vue
@@ -30,7 +30,7 @@ const keyword = ref(props.keyword)
 
 // 筛选参数
 const filterParams = reactive({
-  genre_id: '',
+  genre_id: '', // 空字符串表示选中"全部"
   min_rating: 0,
   max_rating: 10,
   sort_type: 'time', // 默认按时间排序
@@ -244,6 +244,14 @@ function removeData(id: number) {
         <VLabel>{{ t('tmdb.genre') }}</VLabel>
       </div>
       <VChipGroup v-model="filterParams.genre_id">
+        <VChip
+          :color="filterParams.genre_id == '' ? 'primary' : ''"
+          filter
+          tile
+          value=""
+        >
+          {{ t('common.all') }}
+        </VChip>
         <VChip
           :color="filterParams.genre_id == key ? 'primary' : ''"
           filter


### PR DESCRIPTION
Add an 'All' option to genre filters in Subscribe Share and Popular Subscriptions, making it default and ensuring no `genre_id` is passed when selected.

---
<a href="https://cursor.com/background-agent?bcId=bc-58dd49ed-2c46-4730-9053-9be53cced171">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-58dd49ed-2c46-4730-9053-9be53cced171">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

