### PR TITLE
feat(dashboard): 移除 Vue 渲染模式下的固定拖拽图标

### DIFF
--- a/docs/module-federation-guide.md
+++ b/docs/module-federation-guide.md
@@ -245,13 +245,21 @@ const props = defineProps({
 
 <template>
   <div class="dashboard-widget">
-    <!-- 仪表板内容 -->
-    <v-card>
-      <v-card-title>{{ config.title || '仪表板组件' }}</v-card-title>
-      <v-card-text>
-        <!-- 组件内容 -->
-      </v-card-text>
-    </v-card>
+    <v-hover>
+      <!-- 仪表板内容 -->
+      <template #default="{ isHovering, props: hoverProps }">
+        <v-card v-bind="hoverProps">
+          <v-card-title>{{ config.title || '仪表板组件' }}</v-card-title>
+          <v-card-text>
+            <!-- 组件内容 -->
+          </v-card-text>
+          <!-- 只在悬停时显示拖拽图标 -->
+          <div v-show="isHovering" class="absolute right-5 top-5">
+            <v-icon class="cursor-move">mdi-drag</v-icon>
+          </div>
+        </v-card>
+      </template>
+    </v-hover>
   </div>
 </template>
 ```

--- a/src/components/misc/DashboardElement.vue
+++ b/src/components/misc/DashboardElement.vue
@@ -91,10 +91,6 @@ onUnmounted(() => {
     <!-- Vue 渲染模式 -->
     <div v-if="pluginRenderMode === 'vue'">
       <component :is="dynamicPluginComponent" :config="props.config" :allow-refresh="props.allowRefresh" :api="api" />
-      <!-- Vue 模式下也可以显示拖拽句柄 -->
-      <div class="absolute right-5 top-5">
-        <VIcon class="cursor-move">mdi-drag</VIcon>
-      </div>
     </div>
     <!-- Vuetify 渲染模式 -->
     <VHover v-else-if="pluginRenderMode === 'vuetify'">


### PR DESCRIPTION
更新`docs/module-federation-guide.md` 文档，使用 `v-hover` 实现仅在鼠标悬停时显示拖拽图标。