### PR TITLE
feat(globalSetting): 添加版本检查与通知功能

### DIFF
--- a/src/locales/en-US.ts
+++ b/src/locales/en-US.ts
@@ -66,6 +66,7 @@ export default {
     serviceUnavailable: 'Service Unavailable',
     status: 'Status',
     preset: 'Preset',
+    newVersionAvailable: 'New version detected, please refresh the page to get the latest features',
   },
   mediaType: {
     movie: 'Movie',

--- a/src/locales/zh-CN.ts
+++ b/src/locales/zh-CN.ts
@@ -66,6 +66,7 @@ export default {
     serviceUnavailable: '服务不可用',
     status: '状态',
     preset: '预设',
+    newVersionAvailable: '检测到新版本，请刷新页面以获取最新功能',
   },
   mediaType: {
     movie: '电影',

--- a/src/locales/zh-TW.ts
+++ b/src/locales/zh-TW.ts
@@ -66,6 +66,7 @@ export default {
     serviceUnavailable: '服務不可用',
     status: '狀態',
     preset: '預設',
+    newVersionAvailable: '檢測到新版本，請刷新頁面以獲取最新功能',
   },
   mediaType: {
     movie: '電影',

--- a/src/utils/globalSetting.ts
+++ b/src/utils/globalSetting.ts
@@ -1,7 +1,57 @@
 import api from '@/api'
+import { useToast } from 'vue-toastification'
+import i18n from '@/plugins/i18n'
 
 // 创建一个专用的AbortController，用于globalSetting请求
 const globalSettingController = new AbortController()
+
+// 声明全局变量类型
+declare const __APP_VERSION__: string
+
+// 当前前端版本号（由 Vite 在编译时注入）
+const CURRENT_FRONTEND_VERSION = __APP_VERSION__
+console.log(`[VersionChecker] 当前前端版本: ${CURRENT_FRONTEND_VERSION}`)
+
+// 标记是否已经显示过版本更新通知
+let versionNotificationShown = false
+
+/**
+ * 检查版本并在需要时显示更新通知
+ */
+async function checkVersionAndNotify(serverVersion: string): Promise<void> {
+  // 版本不同，且尚未显示通知
+  if (serverVersion !== CURRENT_FRONTEND_VERSION && !versionNotificationShown) {
+    versionNotificationShown = true
+    console.log(`[VersionChecker] 检测到版本更新: ${CURRENT_FRONTEND_VERSION} -> ${serverVersion}`)
+
+    try {
+      // 1. 清除所有缓存
+      if ('caches' in window) {
+        const cacheNames = await caches.keys()
+        await Promise.all(cacheNames.map(name => caches.delete(name)))
+        console.log('[VersionChecker] 已清除所有缓存')
+      }
+
+      // 2. 注销Service Worker
+      if ('serviceWorker' in navigator) {
+        const registrations = await navigator.serviceWorker.getRegistrations()
+        await Promise.all(registrations.map(registration => registration.unregister()))
+        console.log('[VersionChecker] 已注销所有 Service Worker')
+      }
+    } catch (error) {
+      console.error('[VersionChecker] 清除缓存失败:', error)
+    }
+
+    // 3. 显示持久化通知，提示用户刷新
+    const toast = useToast()
+    toast.info(i18n.global.t('common.newVersionAvailable'), {
+      timeout: false, // 不自动消失
+      closeButton: false,
+      closeOnClick: false,
+      draggable: false,
+    })
+  }
+}
 
 export async function fetchGlobalSettings() {
   try {
@@ -12,7 +62,15 @@ export async function fetchGlobalSettings() {
       // 手动设置signal，防止reqestOptimizer添加可中断的controller
       signal: globalSettingController.signal,
     })
-    return result.data || {}
+
+    const data = result.data || {}
+
+    // 检查版本更新
+    if (data.FRONTEND_VERSION) {
+      await checkVersionAndNotify(data.FRONTEND_VERSION)
+    }
+
+    return data
   } catch (error) {
     console.error('Failed to fetch global settings', error)
     throw error

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,6 +10,10 @@ import VueI18n from '@intlify/unplugin-vue-i18n/vite'
 import { resolve } from 'node:path'
 import federation from '@originjs/vite-plugin-federation'
 import topLevelAwait from 'vite-plugin-top-level-await'
+import { readFileSync } from 'node:fs'
+
+// 读取 package.json 获取版本号
+const packageJson = JSON.parse(readFileSync('./package.json', 'utf-8'))
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -277,7 +281,10 @@ export default defineConfig({
       promiseImportName: i => `__mp_tla_${i}`,
     }),
   ],
-  define: { 'process.env': {} },
+  define: {
+    'process.env': {},
+    '__APP_VERSION__': JSON.stringify(`v${packageJson.version}`)
+  },
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url)),


### PR DESCRIPTION
## 概述

实现前端版本自动检测功能，当检测到服务端部署的前端版本与客户端当前版本不一致时，自动清理缓存并提示用户刷新页面。
关联：https://github.com/jxxghp/MoviePilot/pull/5290

## 主要改动

- **版本检测**：在 `fetchGlobalSettings()` 中检测服务端返回的 `FRONTEND_VERSION` 与本地版本是否一致
- **自动清理**：检测到新版本时自动清除浏览器缓存和注销 Service Worker
- **用户通知**：显示持久化通知提示用户刷新页面
- **版本注入**：从 `package.json` 读取版本号并在编译时注入

## 用户体验

检测到新版本后：
1. 自动清除缓存和注销 Service Worker
2. 显示通知："检测到新版本，请刷新页面以获取最新功能"
3. 用户刷新页面即可获取最新版本