### PR TITLE
refactor: 重构 PWA 版本检查与 Service Worker 更新机制

### DIFF
--- a/src/composables/useVersionChecker.ts
+++ b/src/composables/useVersionChecker.ts
@@ -1,17 +1,20 @@
-import { ref, computed, h } from 'vue'
+import { ref, h } from 'vue'
 import { useToast } from 'vue-toastification'
+import { Workbox } from 'workbox-window'
 import i18n from '@/plugins/i18n'
 import VersionUpdateToast from '@/components/toast/VersionUpdateToast.vue'
 
 // 全局状态
 const currentVersion = ref(__APP_VERSION__)
-let isListenerAdded = false
-let notificationShowTime = 0
-const serverVersion = ref<string | null>(null)
-const versionChecked = ref(false)
-const needsUpdate = computed(() => {
-  return serverVersion.value !== null && serverVersion.value !== currentVersion.value
-})
+let isUpdateToastShown = false
+let wb: Workbox | null = null
+
+/**
+ * 普通刷新页面
+ */
+export const reloadPage = (): void => {
+  window.location.reload()
+}
 
 /**
  * 刷新页面并添加时间戳
@@ -46,25 +49,40 @@ export const clearCachesAndServiceWorker = async (): Promise<void> => {
 }
 
 /**
+ * 清除缓存并刷新
+ */
+const clearCacheAndReload = async (): Promise<void> => {
+  await clearCachesAndServiceWorker()
+  reloadWithTimestamp()
+}
+
+/**
  * 版本检查 Composable
  *
  * 功能：
- * - 检查前端版本与服务端版本是否一致
- * - 检测到版本更新时清除缓存和 Service Worker
+ * - 使用 Workbox 监听 Service Worker 更新
+ * - 检查浏览器版本与服务端版本是否一致
  * - 显示持久化更新通知
  */
 export function useVersionChecker() {
   const toast = useToast()
 
   /**
-   * 显示版本更新通知（带刷新按钮）
+   * 显示版本更新通知
+   * @param message 通知消息文本
+   * @param refreshText 按钮文本,不传则不显示按钮
+   * @param onRefresh 按钮点击事件
    */
-  const showUpdateNotification = (): void => {
-    // 使用自定义 Vue 组件作为 toast 内容，传递翻译后的文本作为 props
+  const showUpdateNotification = (message: string, refreshText?: string, onRefresh?: () => void): void => {
+    if (isUpdateToastShown) return
+    isUpdateToastShown = true
     const component = h(VersionUpdateToast, {
-      message: i18n.global.t('common.newVersionAvailable'),
-      refreshText: i18n.global.t('common.refresh'),
-      onRefresh: reloadWithTimestamp,
+      message,
+      ...(refreshText &&
+        onRefresh && {
+          refreshText,
+          onRefresh,
+        }),
     })
 
     toast.info(component, {
@@ -72,8 +90,25 @@ export function useVersionChecker() {
       closeButton: false,
       closeOnClick: false,
       draggable: false,
-      toastClassName: 'version-update-toast-container',
     })
+  }
+
+  // 初始化 Workbox
+  if (!wb && 'serviceWorker' in navigator) {
+    wb = new Workbox('/service-worker.js')
+
+    // Service Worker 激活事件 (install -> activate)
+    wb.addEventListener('activated', event => {
+      // 只有在更新时才显示通知
+      if (event.isUpdate) {
+        console.log('[VersionChecker] Service Worker 更新已就绪，等待用户刷新')
+
+        showUpdateNotification(i18n.global.t('common.swUpdateReady'), i18n.global.t('common.refresh'), reloadPage)
+      }
+    })
+
+    // 注册 Service Worker
+    wb.register()
   }
 
   /**
@@ -81,96 +116,65 @@ export function useVersionChecker() {
    * @param latestVersion 服务端返回的最新版本号
    */
   const checkVersion = async (latestVersion: string): Promise<void> => {
-    // 如果已经检查过，则跳过
-    if (versionChecked.value) {
+    // 如果已经显示过通知,说明已经检查过了
+    if (isUpdateToastShown) return
+
+    // 版本一致，无需操作
+    if (latestVersion === currentVersion.value) {
+      console.log('[VersionChecker] 版本号一致，无需操作')
       return
     }
 
-    // 更新服务端版本
-    serverVersion.value = latestVersion
+    console.log(`[VersionChecker] 检测到版本不一致: ${currentVersion.value} -> ${latestVersion}`)
 
-    // 执行版本不一致时的处理逻辑
-    const handleVersionMismatch = async () => {
-      if (needsUpdate.value) {
-        versionChecked.value = true
-        console.log(`[VersionChecker] 检测到版本更新: ${currentVersion.value} -> ${latestVersion}`)
-
-        // 清除缓存和 Service Worker
-        await clearCachesAndServiceWorker()
-
-        // 显示持久化通知
-        showUpdateNotification()
-      }
-    }
-
-    // 优先尝试通过 Service Worker 检查更新
+    // 尝试触发 Service Worker 更新检查
     if ('serviceWorker' in navigator && navigator.serviceWorker.controller) {
-      console.log('[VersionChecker] 正在请求 Service Worker 检查更新...')
+      try {
+        const registration = await navigator.serviceWorker.getRegistration()
+        if (registration) {
+          console.log('[VersionChecker] 触发 Service Worker 更新检查...')
 
-      const registration = await navigator.serviceWorker.getRegistration()
+          // 标记是否发现更新
+          let updateFound = false
+          const onUpdateFound = () => {
+            updateFound = true
+          }
 
-      // 如果已经有等待中的更新，直接处理
-      if (registration?.waiting) {
-        console.log('[VersionChecker] Service Worker 发现新版本，跳过版本号对比')
-        handleVersionMismatch()
-        return
-      }
+          // 监听 updatefound 事件
+          registration.addEventListener('updatefound', onUpdateFound, { once: true })
 
-      const messageChannel = new MessageChannel()
+          // 等待检查完成
+          await registration.update()
 
-      messageChannel.port1.onmessage = event => {
-        if (event.data && event.data.type === 'SW_NO_UPDATE_DETECTED') {
-          console.log('[VersionChecker] Service Worker 报告无更新, 进行版本号检查...')
-          handleVersionMismatch()
+          // 移除监听器
+          registration.removeEventListener('updatefound', onUpdateFound)
+
+          // 检查是否有更新正在进行
+          // 如果发现更新，或者正在安装/等待中，则直接返回（交由 SW activated 事件处理）
+          if (updateFound || registration.installing || registration.waiting) {
+            console.log('[VersionChecker] Service Worker 更新中...')
+            return
+          }
+
+          console.log('[VersionChecker] SW 无更新，但版本号不一致，可能是缓存问题')
         }
+      } catch (error) {
+        console.log('[VersionChecker] Service Worker 更新检查失败:', error)
+        // 失败继续向下执行，显示通知
       }
-
-      navigator.serviceWorker.controller.postMessage({ type: 'CHECK_SW_UPDATE' }, [messageChannel.port2])
     } else {
-      // 如果没有 Service Worker 控制，直接进行版本比较
-      await handleVersionMismatch()
+      console.log('[VersionChecker] 无 Service Worker, 直接显示通知')
     }
-  }
 
-  // 监听 Service Worker 版本更新消息
-  if (!isListenerAdded && 'serviceWorker' in navigator) {
-    navigator.serviceWorker.addEventListener('message', event => {
-      // 1. 发现新版本 -> 弹出通知
-      if (event.data && event.data.type === 'SW_VERSION_DETECTED') {
-        console.log('[VersionChecker] 发现新版本:', event.data.version)
-        notificationShowTime = Date.now()
-
-        const component = h(VersionUpdateToast, {
-          message: i18n.global.t('common.newVersionFound'),
-        })
-
-        toast.info(component, {
-          timeout: false,
-          hideProgressBar: true,
-          closeButton: false,
-          toastClassName: 'version-update-toast-container',
-        })
-      }
-      // 2. 安装完成 -> 刷新页面
-      else if (event.data && event.data.type === 'SW_RELOAD_PAGE') {
-        const elapsed = Date.now() - notificationShowTime
-        const delay = Math.max(0, 1500 - elapsed)
-        console.log(`[VersionChecker] 更新已安装, 延迟 ${delay}ms 后刷新...`)
-        setTimeout(() => {
-          reloadWithTimestamp()
-        }, delay)
-      }
-    })
-    isListenerAdded = true
+    // 最终兜底：显示版本不一致通知（清除缓存）
+    showUpdateNotification(
+      i18n.global.t('common.versionMismatch'),
+      i18n.global.t('common.clearCache'),
+      clearCacheAndReload,
+    )
   }
 
   return {
-    // 状态
-    currentVersion: computed(() => currentVersion.value),
-    serverVersion: computed(() => serverVersion.value),
-    needsUpdate,
-    versionChecked: computed(() => versionChecked.value),
-    // 方法
     checkVersion,
   }
 }

--- a/src/composables/useVersionChecker.ts
+++ b/src/composables/useVersionChecker.ts
@@ -78,11 +78,8 @@ export function useVersionChecker() {
     isUpdateToastShown = true
     const component = h(VersionUpdateToast, {
       message,
-      ...(refreshText &&
-        onRefresh && {
-          refreshText,
-          onRefresh,
-        }),
+      refreshText,
+      onRefresh,
     })
 
     toast.info(component, {
@@ -145,9 +142,6 @@ export function useVersionChecker() {
 
           // 等待检查完成
           await registration.update()
-
-          // 移除监听器
-          registration.removeEventListener('updatefound', onUpdateFound)
 
           // 检查是否有更新正在进行
           // 如果发现更新，或者正在安装/等待中，则直接返回（交由 SW activated 事件处理）

--- a/src/locales/en-US.ts
+++ b/src/locales/en-US.ts
@@ -68,8 +68,9 @@ export default {
     status: 'Status',
     preset: 'Preset',
     refresh: 'Refresh',
-    newVersionAvailable: 'New version detected, please refresh the page to get the latest features',
-    newVersionFound: 'New version found, updating...',
+    swUpdateReady: 'New version is ready, please refresh the page to get the latest features',
+    versionMismatch: 'Browser cache version does not match server version, please try clearing cache',
+    clearCache: 'Clear Cache',
   },
   mediaType: {
     movie: 'Movie',

--- a/src/locales/zh-CN.ts
+++ b/src/locales/zh-CN.ts
@@ -68,8 +68,9 @@ export default {
     status: '状态',
     preset: '预设',
     refresh: '刷新',
-    newVersionAvailable: '检测到新版本，请刷新页面以获取最新功能',
-    newVersionFound: '发现新版本，正在更新...',
+    swUpdateReady: '新版本已就绪，请刷新页面以获取最新功能',
+    versionMismatch: '浏览器缓存版本与服务端版本不一致，请尝试清除缓存',
+    clearCache: '清除缓存',
   },
   mediaType: {
     movie: '电影',

--- a/src/locales/zh-TW.ts
+++ b/src/locales/zh-TW.ts
@@ -68,8 +68,9 @@ export default {
     status: '狀態',
     preset: '預設',
     refresh: '刷新',
-    newVersionAvailable: '檢測到新版本，請刷新頁面以獲取最新功能',
-    newVersionFound: '發現新版本，正在更新...',
+    swUpdateReady: '新版本已就緒，請刷新頁面以獲取最新功能',
+    versionMismatch: '瀏覽器快取版本與伺服器版本不一致，請嘗試清除快取',
+    clearCache: '清除快取',
   },
   mediaType: {
     movie: '電影',

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -23,27 +23,10 @@ cleanupOutdatedCaches()
 // 预缓存并路由
 precacheAndRoute(self.__WB_MANIFEST)
 
-// 变量记录是否为更新安装
-let isUpdate = false
-
-// 监听安装事件以检测更新
+// 监听安装事件
 self.addEventListener('install', () => {
-  // 强制等待中的 Service Worker 立即激活
+  // 强制跳过等待，自动激活
   self.skipWaiting()
-
-  // 检查是否是更新（即是否已经有激活的 Service Worker）
-  if (self.registration.active) {
-    isUpdate = true
-    // 通知客户端发现新版本
-    self.clients.matchAll({ includeUncontrolled: true, type: 'window' }).then(clients => {
-      clients.forEach(client => {
-        client.postMessage({
-          type: 'SW_VERSION_DETECTED',
-          version: CACHE_VERSION,
-        })
-      })
-    })
-  }
 })
 
 // 监听激活事件
@@ -55,16 +38,6 @@ self.addEventListener('activate', event => {
 
       // 清理旧版本的运行时缓存
       await cleanupRuntimeCaches(true)
-
-      // 如果是更新，则通知客户端刷新页面
-      if (isUpdate) {
-        const clients = await self.clients.matchAll({ type: 'window' })
-        clients.forEach(client => {
-          client.postMessage({
-            type: 'SW_RELOAD_PAGE',
-          })
-        })
-      }
     })(),
   )
 })
@@ -491,20 +464,6 @@ self.addEventListener('message', function (event) {
       })
       .catch(error => {
         event.ports[0]?.postMessage({ success: false, error: error instanceof Error ? error.message : String(error) })
-      })
-  } else if (event.data && event.data.type === 'CHECK_SW_UPDATE') {
-    // 检查 Service Worker 更新
-    self.registration
-      .update()
-      .then(() => {
-        // 如果没有正在安装或等待的 worker，说明没有检测到更新
-        if (!self.registration.installing && !self.registration.waiting) {
-          event.ports[0]?.postMessage({ type: 'SW_NO_UPDATE_DETECTED' })
-        }
-      })
-      .catch(error => {
-        console.error('Failed to check for SW update:', error)
-        event.ports[0]?.postMessage({ type: 'SW_NO_UPDATE_DETECTED' })
       })
   } else if (event.data && event.data.type === 'SKIP_WAITING') {
     self.skipWaiting()

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -23,10 +23,27 @@ cleanupOutdatedCaches()
 // 预缓存并路由
 precacheAndRoute(self.__WB_MANIFEST)
 
+// 变量记录是否为更新安装(兼容旧版前端监听逻辑)
+let isUpdate = false
+
 // 监听安装事件
 self.addEventListener('install', () => {
-  // 强制跳过等待，自动激活
+  // 强制等待中的 Service Worker 立即激活
   self.skipWaiting()
+
+  // 检查是否是更新(兼容旧版前端监听逻辑)
+  if (self.registration.active) {
+    isUpdate = true
+    // 通知客户端发现新版本
+    self.clients.matchAll({ includeUncontrolled: true, type: 'window' }).then(clients => {
+      clients.forEach(client => {
+        client.postMessage({
+          type: 'SW_VERSION_DETECTED',
+          version: CACHE_VERSION,
+        })
+      })
+    })
+  }
 })
 
 // 监听激活事件
@@ -38,6 +55,16 @@ self.addEventListener('activate', event => {
 
       // 清理旧版本的运行时缓存
       await cleanupRuntimeCaches(true)
+
+      // 如果是更新，则通知客户端刷新页面(兼容旧版前端监听逻辑)
+      if (isUpdate) {
+        const clients = await self.clients.matchAll({ type: 'window' })
+        clients.forEach(client => {
+          client.postMessage({
+            type: 'SW_RELOAD_PAGE',
+          })
+        })
+      }
     })(),
   )
 })

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -11,36 +11,3 @@
 @import 'vue-toastification/dist/index.css';
 @import 'vue3-perfect-scrollbar/style.css';
 @import '@vue-js-cron/vuetify/dist/vuetify.css'; 
-
-/* 版本更新通知专用样式 */
-.version-update-toast-container {
-  min-width: unset !important;
-  width: fit-content !important;
-
-  // 移动端适配：强制靠右并修正位置
-  @media only screen and (width <= 600px) {
-    max-width: calc(100vw - 1rem) !important;
-    margin-inline: 0 0.5rem !important;
-    border-radius: 8px !important;
-    position: relative !important;
-    top: calc(100vh - 12rem) !important; 
-  }
-}
-
-// 使用 :has 选择器精准控制包含更新通知的容器
-.Vue-Toastification__container:has(.version-update-toast-container) {
-  @media only screen and (width <= 600px) {
-    top: auto !important;
-    bottom: 0 !important;
-    display: flex !important;
-    flex-direction: column !important;
-    align-items: flex-end !important;
-    padding-block-end: 4.5rem !important;
-    pointer-events: none;
-
-    .version-update-toast-container {
-      pointer-events: auto;
-      margin-inline-end: 0.5rem !important;
-    }
-  }
-}


### PR DESCRIPTION
#### 📝 概述
本次 PR 对版本更新检查机制进行了深度重构，引入了 `workbox-window` 来更优雅地管理 Service Worker 生命周期。移除了之前基于原生 `MessageChannel` 的复杂通信逻辑，改为基于 SW 生命周期事件的响应式更新流程，显著提升了代码的可维护性和更新感知的准确性。

#### 🚀 主要变更

*   **引入 Workbox 生命周期管理 (`useVersionChecker.ts`)**
    *   移除了手写的 `isListenerAdded` 和原生消息监听，改为使用 `Workbox` 实例监听 `activated` 事件。
    *   **精准触发更新**：通过 `registration.update()` 与 `updatefound` 事件配合，能够更准确地捕捉到 SW 的下载与安装过程。
    *   **增强型通知策略**：支持区分“新版本就绪（正常刷新）”和“版本不一致（需清理缓存）”两种场景。
    *   **移除自动刷新**：将控制权交给用户，避免极端场景下无限刷新。
    *   **更严谨的通知显示逻辑**：确保在任何情况下同一时间只会存在一个更新提示。

*   **Service Worker 逻辑简化 (`service-worker.ts`)**
    *   **移除冗余通信**：删除了 `CHECK_SW_UPDATE` 消息处理逻辑，不再需要通过 `MessageChannel` 回复 `SW_NO_UPDATE_DETECTED`。
    *   **兼容性保留**：保留了旧版的 `isUpdate` 逻辑和消息广播，并添加了明确的注释，以兼容旧版客户端。

*   **多语言与文案优化**
    *   新增 `swUpdateReady`、`versionMismatch` 和 `clearCache` 键值。
    *   区分了“新版本已就绪”与“缓存版本不一致”的提示文案，引导用户进行更合适的操作。

*   **UI 与样式精简**
    *   移除了 `main.scss` 中大量针对版本更新 Toast 的手动位置修正样式，通过更通用的方式处理交互。
    *   `useVersionChecker` 的状态管理更简洁，去掉了不再需要的 `computed` 导出。

#### 🔍 逻辑细节对比
| 维度 | 旧逻辑 | 新逻辑 |
| :--- | :--- | :--- |
| **触发方式** | `postMessage` + `MessageChannel` | `registration.update()` + 状态监听 |
| **监听点** | 原生 `navigator.serviceWorker` 消息 | Workbox `activated` 事件 |
| **异常处理** | 无明确区分 | 若 SW 检查后无更新但版本仍不匹配，触发“清除缓存”兜底 |
| **样式控制** | 复杂的 SCSS 媒体查询布局 | 基于 `VersionUpdateToast` 组件的标准化 Toast 样式 |