### PR TITLE
修复 媒体整理按标题、大小无法正确排序的问题

### DIFF
--- a/src/views/reorganize/TransferHistoryView.vue
+++ b/src/views/reorganize/TransferHistoryView.vue
@@ -46,12 +46,37 @@ const redoTargetStorage = ref<string>()
 // 已选中的数据
 const selected = ref<TransferHistory[]>([])
 
+const getNum = (s?: string) => (s ? parseInt(s.replace(/[^0-9]/g, ''), 10) || 0 : 0);
+
+function sortByTitle(a: TransferHistory, b: TransferHistory) {
+  if (a.type !== b.type) {
+    return (a.type ?? '').localeCompare(b.type ?? '');
+  }
+  if (a.title !== b.title) {
+    return (a.title ?? '').toLocaleLowerCase().localeCompare((b.title ?? '').toLocaleLowerCase());
+  }
+  if (a.type === '电视剧') {
+    if (a.seasons !== b.seasons) {
+      return getNum(a.seasons) - getNum(b.seasons);
+    }
+    if (a.episodes !== b.episodes) {
+      return getNum(a.episodes) - getNum(b.episodes);
+    }
+  }
+  return 0
+}
+
+function sortBySourceSize(a: TransferHistory, b: TransferHistory) {
+  return (a.src_fileitem?.size ?? 0) - (b.src_fileitem?.size ?? 0)
+}
+
 // 表头
 const headers = [
   {
     title: t('transferHistory.titleColumn'),
     key: 'title',
     sortable: true,
+    sortRaw: sortByTitle,
   },
   {
     title: t('transferHistory.pathColumn'),
@@ -67,6 +92,7 @@ const headers = [
     title: t('transferHistory.sizeColumn'),
     key: 'size',
     sortable: true,
+    sortRaw: sortBySourceSize,
   },
   {
     title: t('transferHistory.dateColumn'),
@@ -91,6 +117,7 @@ const groupHeaders = [
     title: t('transferHistory.seasonEpisode'),
     key: 'title',
     sortable: true,
+    sortRaw: sortByTitle,
   },
   {
     title: t('transferHistory.pathColumn'),
@@ -106,6 +133,7 @@ const groupHeaders = [
     title: t('transferHistory.sizeColumn'),
     key: 'size',
     sortable: true,
+    sortRaw: sortBySourceSize,
   },
   {
     title: t('transferHistory.dateColumn'),


### PR DESCRIPTION
fix https://github.com/jxxghp/MoviePilot/issues/5364
fix #372

- 优化电视剧类型按标题的排序，现在可以按季、集顺序正确排序了
- 修复按大小排序无效问题，改用`src_fileitem.size`作为排序关键字