### PR TITLE
fix: TMDB 剧集详情页支持显示第 0 季（特别篇）并将其排序到末尾 (jxxghp/MoviePilot#5444)

### DIFF
--- a/src/views/discover/MediaDetailView.vue
+++ b/src/views/discover/MediaDetailView.vue
@@ -234,9 +234,14 @@ async function checkMovieSubscribed() {
   isSubscribed.value = await checkSubscribe()
 }
 
-// 过滤掉第0季
+// 季列表，第0季排在最后
 const getMediaSeasons = computed(() => {
-  return mediaDetail.value?.season_info?.filter(season => season.season_number !== 0)
+  if (!mediaDetail.value?.season_info) return []
+  return [...mediaDetail.value.season_info].sort((a, b) => {
+    if (a.season_number === 0) return 1
+    if (b.season_number === 0) return -1
+    return (a.season_number || 0) - (b.season_number || 0)
+  })
 })
 
 // 检查所有季的订阅状态
@@ -742,8 +747,9 @@ onBeforeMount(() => {
                   <template #default>
                     <div class="flex flex-row items-center justify-between">
                       <span class="font-weight-bold">{{
-                        t('media.seasonNumber', { number: season.season_number })
-                      }}</span>
+                        season.season_number === 0 && season.name ?
+                        season.name : t('media.seasonNumber', { number: season.season_number })
+                        }}</span>
                       <VChip size="small" class="ms-1">
                         {{ t('media.episodeCount', { count: season.episode_count }) }}
                       </VChip>


### PR DESCRIPTION
之前的代码注释中提到主动把第0季过滤掉，我没搞懂是为什么，暂且把第0季排到末尾。

还有把第0季的季名改成后端返回的名称（如“特别篇”）