### PR TITLE
feat: 新增优先使用插件识别的功能

### DIFF
--- a/src/locales/en-US.ts
+++ b/src/locales/en-US.ts
@@ -1386,6 +1386,8 @@ export default {
       fanartEnableHint: 'Use image data from fanart.tv',
       fanartLang: 'Fanart Language',
       fanartLangHint: 'Set language preference for Fanart images, ordered by priority when multiple selected',
+      recognizePluginFirst: "Prioritize Plugin Recognition",
+      recognizePluginFirstHint: "Prioritize calling plugins for media recognition. If a plugin matches, native recognition will be skipped",
       githubProxy: 'Github Acceleration Proxy',
       githubProxyPlaceholder: 'Leave empty for no proxy',
       githubProxyHint: 'Use proxy to accelerate Github access speed',

--- a/src/locales/zh-CN.ts
+++ b/src/locales/zh-CN.ts
@@ -1377,6 +1377,8 @@ export default {
       fanartEnableHint: '使用 fanart.tv 的图片数据',
       fanartLang: 'Fanart语言',
       fanartLangHint: '设置Fanart图片的语言偏好，多选时按优先级顺序排列',
+      recognizePluginFirst: "优先使用插件识别",
+      recognizePluginFirstHint: "优先调用插件识别媒体信息，若插件命中则不再调用原生识别",
       githubProxy: 'Github加速代理',
       githubProxyPlaceholder: '留空表示不使用代理',
       githubProxyHint: '使用代理加速Github访问速度',

--- a/src/locales/zh-TW.ts
+++ b/src/locales/zh-TW.ts
@@ -1378,6 +1378,8 @@ export default {
       fanartEnableHint: '使用 fanart.tv 的圖片數據',
       fanartLang: 'Fanart語言',
       fanartLangHint: '設定Fanart圖片的語言偏好，多選時按優先級順序排列',
+      recognizePluginFirst: "優先使用插件識別",
+      recognizePluginFirstHint: "優先調用插件識別媒體信息，若插件命中則不再調用原生識別",
       githubProxy: 'Github加速代理',
       githubProxyPlaceholder: '留空表示不使用代理',
       githubProxyHint: '使用代理加速Github訪問速度',

--- a/src/views/setting/AccountSettingSystem.vue
+++ b/src/views/setting/AccountSettingSystem.vue
@@ -55,6 +55,7 @@ const SystemSettings = ref<any>({
     AUTO_UPDATE_RESOURCE: true,
     MOVIEPILOT_AUTO_UPDATE: false,
     // 媒体
+    RECOGNIZE_PLUGIN_FIRST: false,
     TMDB_API_DOMAIN: null,
     TMDB_IMAGE_DOMAIN: null,
     TMDB_LOCALE: null,
@@ -1099,6 +1100,16 @@ onDeactivated(() => {
                     chips
                     closable-chips
                     prepend-inner-icon="mdi-translate"
+                  />
+                </VCol>
+              </VRow>
+              <VRow>
+                <VCol cols="12" md="6">
+                  <VSwitch
+                    v-model="SystemSettings.Advanced.RECOGNIZE_PLUGIN_FIRST"
+                    :label="t('setting.system.recognizePluginFirst')"
+                    :hint="t('setting.system.recognizePluginFirstHint')"
+                    persistent-hint
                   />
                 </VCol>
               </VRow>


### PR DESCRIPTION
## 功能

配合后端同名 PR（[#5531](https://github.com/jxxghp/MoviePilot/pull/5531)），在 Web 界面提供全局设置 `RECOGNIZE_PLUGIN_FIRST` 可视化的开关控制

## 改动逻辑

在‎ `‎src/views/setting/AccountSettingSystem.vue` 新增了开关插件优先功能的按钮。

在‎ `‎‎src/locales` 中，为该按钮名称及功能介绍编写了三种语言的翻译。

## 预期效果

用户可以根据需求选择插件优先，充分发挥 LLM 的语义理解优势避免误判，为辅助识别插件的编写与使用提供更好的底层支持。