### PR TITLE
fix: avoid false in-library badge when TV season episode count is zero

### DIFF
--- a/src/components/cards/MediaCard.vue
+++ b/src/components/cards/MediaCard.vue
@@ -232,6 +232,18 @@ async function handleCheckSubscribe() {
 // 查询当前媒体是否已入库
 async function handleCheckExists() {
   try {
+    // 对于总集数为 0 的电视剧季（TMDB 未返回有效集数），不展示“已入库”角标，避免误判
+    const totalEpisode =
+      (props.media as any)?.total_episode ??
+      (props.media as any)?.episode_count ??
+      (props.media as any)?.number_of_episodes ??
+      0
+
+    if (props.media?.type === '电视剧' && totalEpisode === 0) {
+      isExists.value = false
+      return
+    }
+
     const result: { [key: string]: any } = await api.get('mediaserver/exists', {
       params: {
         tmdbid: props.media?.tmdb_id,

--- a/src/components/cards/MediaCard.vue
+++ b/src/components/cards/MediaCard.vue
@@ -18,9 +18,14 @@ import { hasPermission } from '@/utils/permission'
 // 国际化
 const { t } = useI18n()
 
+interface MediaCardMedia extends MediaInfo {
+  total_episode?: number
+  episode_count?: number
+}
+
 // 输入参数
 const props = defineProps({
-  media: Object as PropType<MediaInfo>,
+  media: Object as PropType<MediaCardMedia>,
   width: String,
   height: String,
 })
@@ -233,11 +238,7 @@ async function handleCheckSubscribe() {
 async function handleCheckExists() {
   try {
     // 对于总集数为 0 的电视剧季（TMDB 未返回有效集数），不展示“已入库”角标，避免误判
-    const totalEpisode =
-      (props.media as any)?.total_episode ??
-      (props.media as any)?.episode_count ??
-      (props.media as any)?.number_of_episodes ??
-      0
+    const totalEpisode = props.media?.total_episode ?? props.media?.episode_count ?? props.media?.number_of_episodes ?? 0
 
     if (props.media?.type === '电视剧' && totalEpisode === 0) {
       isExists.value = false


### PR DESCRIPTION
## Summary
- skip mediaserver/exists check for TV seasons whose episode count is unknown/zero
- prevent false-positive 已入库 badge on season cards

## Why
Issue #438 reports seasons with 0 episodes are shown as in-library even without subscription/library files.

## Changes
- in `MediaCard.vue` `handleCheckExists()`:
  - derive episode count from available fields (`total_episode`, `episode_count`, `number_of_episodes`)
  - if media type is TV and episode count is 0, force `isExists = false` and return early

## Validation
- `npm run typecheck` passed

Closes #438
