### PR TITLE
refactor(AccountSettingSystem): 重构按钮图标结构样式

### DIFF
--- a/src/views/setting/AccountSettingSystem.vue
+++ b/src/views/setting/AccountSettingSystem.vue
@@ -1205,9 +1205,15 @@ onDeactivated(() => {
                                 variant="tonal"
                                 rounded="lg"
                               >
-                                <VBtn value="skip" color="error" icon="mdi-file-remove" />
-                                <VBtn value="missingOnly" color="success" icon="mdi-file-plus" />
-                                <VBtn value="overwrite" color="primary" icon="mdi-file-replace" />
+                                <VBtn value="skip" color="error">
+                                  <VIcon icon="mdi-file-remove" />
+                                </VBtn>
+                                <VBtn value="missingOnly" color="success">
+                                  <VIcon icon="mdi-file-plus" />
+                                </VBtn>
+                                <VBtn value="overwrite" color="primary">
+                                  <VIcon icon="mdi-file-replace" />
+                                </VBtn>
                               </VBtnToggle>
                               <span class="ml-2">{{ t(item.label) }}</span>
                             </div>


### PR DESCRIPTION
旧: 
<img width="915" height="587" alt="image" src="https://github.com/user-attachments/assets/3abe859e-7108-4d63-96e6-d4fa6b525af0" />

新: 
<img width="924" height="587" alt="image" src="https://github.com/user-attachments/assets/aca83758-777c-4379-bd59-6173ed57effb" />
