### PR TITLE
fix: 修复推荐和探索页面电视剧已入库标识不显示的问题

### DIFF
--- a/src/components/cards/MediaCard.vue
+++ b/src/components/cards/MediaCard.vue
@@ -237,14 +237,6 @@ async function handleCheckSubscribe() {
 // 查询当前媒体是否已入库
 async function handleCheckExists() {
   try {
-    // 对于总集数为 0 的电视剧季（TMDB 未返回有效集数），不展示“已入库”角标，避免误判
-    const totalEpisode = props.media?.total_episode ?? props.media?.episode_count ?? props.media?.number_of_episodes ?? 0
-
-    if (props.media?.type === '电视剧' && totalEpisode === 0) {
-      isExists.value = false
-      return
-    }
-
     const result: { [key: string]: any } = await api.get('mediaserver/exists', {
       params: {
         tmdbid: props.media?.tmdb_id,


### PR DESCRIPTION
## 问题描述

推荐页和探索页中，电视剧的"已入库"角标消失，但电影不受影响。

## 根本原因

`MediaCard.vue` 中有一段逻辑，目的是对"集数为 0 的电视剧季"跳过入库检查，避免误判：

```javascript
const totalEpisode = props.media?.total_episode
  ?? props.media?.episode_count
  ?? props.media?.number_of_episodes
  ?? 0  // ← 问题所在

if (props.media?.type === '电视剧' && totalEpisode === 0) {
  isExists.value = false
  return  // 跳过 API 检查
}
```

实际上，TMDB 的列表类 API（`/discover/tv`、`/search/tv`、趋势等）在设计上**从不返回 `number_of_episodes` 字段**，只有 `/tv/{id}` 详情接口才有该字段。

推荐/探索页走的是列表 API，因此三个集数字段均为 `null`，末尾的 `?? 0` 将其补成 `0`，导致所有电视剧都命中跳过条件。

此外，后端 `set_tmdb_info()` 中有 `if not value: continue` 过滤，即使 TMDB 详情接口返回 `0`，也不会被赋值到 `MediaInfo`。因此该字段实际上不存在"有效值为 0"的场景，整段判断均为无效逻辑。

## 修复方式

删除上述无效的集数判断逻辑，所有媒体类型统一直接调用`mediaserver/exists` 接口检查入库状态。

## 影响范围

- `Frontend/src/components/cards/MediaCard.vue`
- 仅影响推荐页、探索页的电视剧已入库角标显示，无其他副作用

Fix [#5588](https://github.com/jxxghp/MoviePilot/issues/5588#issuecomment-4229743385)