### PR TITLE
feat(resource): 资源搜索结果页增加重新搜索按钮

### DIFF
--- a/src/locales/en-US.ts
+++ b/src/locales/en-US.ts
@@ -998,6 +998,7 @@ export default {
     aiRecommend: 'AI Recommendation',
     reRecommend: 'Regenerate Recommendation',
     aiRecommendError: 'AI Recommendation Failed',
+    refreshSearch: 'Re-search',
   },
   browse: {
     actor: 'Actor',

--- a/src/locales/zh-CN.ts
+++ b/src/locales/zh-CN.ts
@@ -993,6 +993,7 @@ export default {
     aiRecommend: '智能推荐',
     reRecommend: '重新生成推荐',
     aiRecommendError: '智能推荐失败',
+    refreshSearch: '重新搜索',
   },
   browse: {
     actor: '演员',

--- a/src/locales/zh-TW.ts
+++ b/src/locales/zh-TW.ts
@@ -994,6 +994,7 @@ export default {
     aiRecommend: '智能推薦',
     reRecommend: '重新生成推薦',
     aiRecommendError: '智能推薦失敗',
+    refreshSearch: '重新搜尋',
   },
   browse: {
     actor: '演員',

--- a/src/pages/resource.vue
+++ b/src/pages/resource.vue
@@ -95,6 +95,9 @@ const cardScroll = useInfiniteScroll(filteredCardDataList)
 // 是否刷新过
 const isRefreshed = ref(false)
 
+// 是否正在重新搜索
+const isRefreshing = ref(false)
+
 // 加载进度文本
 const progressText = ref(t('common.pleaseWait'))
 
@@ -461,6 +464,23 @@ async function fetchData() {
     stopLoadingProgress()
     isRefreshed.value = true
     return Promise.reject(error)
+  }
+}
+
+// 重新搜索（使用相同参数重新触发搜索）
+async function refreshSearch() {
+  if (isRefreshing.value || progressActive.value) return
+  isRefreshing.value = true
+  try {
+    // 如正在显示AI推荐结果，先切回原始结果，确保状态干净
+    if (showingAiResults.value) {
+      await switchToOriginalResults()
+    }
+    await fetchData()
+  } catch (error) {
+    console.error('重新搜索失败:', error)
+  } finally {
+    isRefreshing.value = false
   }
 }
 
@@ -833,6 +853,22 @@ onUnmounted(() => {
 
       <VSpacer />
 
+      <!-- 重新搜索按钮 -->
+      <VBtn
+        variant="text"
+        size="small"
+        icon
+        class="me-2 refresh-search-btn"
+        :loading="isRefreshing"
+        :disabled="isRefreshing || progressActive"
+        @click="refreshSearch"
+      >
+        <VIcon icon="mdi-refresh" size="20" />
+        <VTooltip activator="parent" location="top">
+          {{ t('resource.refreshSearch') }}
+        </VTooltip>
+      </VBtn>
+
       <!-- AI操作按钮组 -->
       <div v-if="aiRecommendEnabled && originalDataList.length > 0" class="ai-toggle-container me-2">
         <div class="ai-toggle-buttons">
@@ -1180,6 +1216,14 @@ onUnmounted(() => {
   background-color: rgba(var(--v-theme-primary), 0.05);
 }
 
+/* 重新搜索按钮 */
+.refresh-search-btn {
+  block-size: 44px !important;
+  inline-size: 44px !important;
+  border-radius: 8px !important;
+  background-color: rgba(var(--v-theme-surface-variant), 0.1);
+}
+
 /* AI按钮组样式 */
 .ai-toggle-container {
   position: relative;
@@ -1369,6 +1413,11 @@ onUnmounted(() => {
   .view-toggle-btn {
     block-size: 32px;
     inline-size: 36px;
+  }
+
+  .refresh-search-btn {
+    block-size: 36px !important;
+    inline-size: 36px !important;
   }
 
   .ai-toggle-buttons {

--- a/src/pages/resource.vue
+++ b/src/pages/resource.vue
@@ -472,10 +472,8 @@ async function refreshSearch() {
   if (isRefreshing.value || progressActive.value) return
   isRefreshing.value = true
   try {
-    // 如正在显示AI推荐结果，先切回原始结果，确保状态干净
-    if (showingAiResults.value) {
-      await switchToOriginalResults()
-    }
+    // 重新搜索时退出 AI 视图，其余状态由 fetchData 内部重置
+    showingAiResults.value = false
     await fetchData()
   } catch (error) {
     console.error('重新搜索失败:', error)
@@ -828,8 +826,8 @@ onUnmounted(() => {
       </div>
     </VFadeTransition>
 
-    <!-- 精简标题栏 -->
-    <VCard v-if="isRefreshed && !progressActive" class="search-header d-flex align-center mb-3">
+    <!-- 精简标题栏：搜索过后保持挂载，加载中由按钮 :disabled / :loading 表达状态 -->
+    <VCard v-if="isRefreshed" class="search-header d-flex align-center mb-3">
       <div class="search-info-container">
         <div class="search-title text-moviepilot">
           <span class="d-none d-sm-inline">{{ t('resource.searchResults') }}</span>


### PR DESCRIPTION
## 背景与动机

资源搜索结果会随着站点状态、刮削数据、Tracker 缓存、订阅器抓取节奏等动态变化——同一组关键词，过几分钟再搜可能就有新种被补回来。但目前用户在结果页想用相同条件重新搜索一次，只能：

1. 返回搜索框
2. 重新输入 / 选择关键词、年份、TMDB ID 等参数
3. 再次提交

操作链路过长，做剧集追更、订阅排查这类高频场景时尤其繁琐。

本 PR 在结果页右上角直接加一个「重新搜索」按钮，点一下就能用**完全相同的搜索参数**原地刷新结果列表。

## 改动内容

- src/pages/resource.vue
  - 工具栏（视图切换按钮左侧）新增 \`mdi-refresh\` 图标按钮
  - 新增 \`refreshSearch()\`：复用现有 \`fetchData()\` 流程
  - 若当前展示的是 AI 推荐结果，先 \`switchToOriginalResults()\` 切回原始结果再请求，避免 AI 状态与刷新结果混杂
  - 加载中 / 正在重新搜索时按钮 \`:loading\` + \`:disabled\`，避免重复提交
  - PC / 移动端均适配（44px / 36px 两套尺寸）
- src/locales/zh-CN.ts / zh-TW.ts / en-US.ts
  - 新增 \`resource.refreshSearch\` 文案

## 效果截图

<img width="1324" height="722" alt="image" src="https://github.com/user-attachments/assets/a6455626-9cee-41bc-9591-7d363abaad0d" />

## 测试要点

- [x] 搜索 → 进入结果页 → 点击右上「重新搜索」按钮，列表用相同参数重新加载
- [x] 点击时按钮显示 loading，期间无法重复点击
- [x] AI 推荐结果展示状态下点击重新搜索，先切回原始结果再请求，状态不串台
- [x] 切换到 zh-TW / en-US，按钮 tooltip 文案正确显示
- [x] 移动端布局下按钮尺寸正确（36px）