### PR TITLE
feat: add wildcard glob support to file manager filter

### DIFF
--- a/src/components/filebrowser/FileList.vue
+++ b/src/components/filebrowser/FileList.vue
@@ -119,6 +119,15 @@ const dropdownItems = ref<{ [key: string]: any }[]>([])
 // 进度是否激活
 const progressActive = ref(false)
 
+// 将 glob 模式转换为正则表达式
+function globToRegex(pattern: string, flags: string = ''): RegExp {
+  const regexStr = pattern
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+    .replace(/\*/g, '.*')
+    .replace(/\?/g, '.')
+  return new RegExp(`^${regexStr}$`, flags)
+}
+
 // 通用过滤
 const getFilteredItems = (type: 'dir' | 'file') => {
   const filterValue = filter.value
@@ -126,11 +135,19 @@ const getFilteredItems = (type: 'dir' | 'file') => {
     return items.value.filter(item => item.type === type)
   }
 
+  // 通配符模式
+  if (filterValue.includes('*') || filterValue.includes('?')) {
+    const flags = ignoreCase.value ? 'i' : ''
+    const regex = globToRegex(filterValue, flags)
+    return items.value.filter(item => item.type === type && regex.test(item.name ?? ''))
+  }
+
+  // 子字符串模式
   if (ignoreCase.value) {
     const lowerCaseFilter = filterValue.toLowerCase()
-    return items.value.filter(item => item.type === type && item.name.toLowerCase().includes(lowerCaseFilter))
+    return items.value.filter(item => item.type === type && (item.name ?? '').toLowerCase().includes(lowerCaseFilter))
   } else {
-    return items.value.filter(item => item.type === type && item.name.includes(filterValue))
+    return items.value.filter(item => item.type === type && (item.name ?? '').includes(filterValue))
   }
 }
 
@@ -639,8 +656,8 @@ onUnmounted(() => {
           flat
           density="compact"
           variant="plain"
-          :placeholder="t('common.search')"
-          prepend-inner-icon="mdi-filter-outline"
+          :placeholder="t('file.filterPlaceholder')"
+          :prepend-inner-icon="(filter.includes('*') || filter.includes('?')) ? 'mdi-asterisk' : 'mdi-filter-outline'"
           class="mx-2"
           rounded
         />

--- a/src/locales/en-US.ts
+++ b/src/locales/en-US.ts
@@ -2727,6 +2727,7 @@ export default {
     close: 'Close',
     loadingDirectoryStructure: 'Loading directory structure...',
     reorganize: 'Reorganize',
+    filterPlaceholder: 'Filter (supports * ? wildcards)',
   },
   person: {
     alias: 'Also Known As:',

--- a/src/locales/zh-CN.ts
+++ b/src/locales/zh-CN.ts
@@ -2682,6 +2682,7 @@ export default {
     close: '关闭',
     loadingDirectoryStructure: '加载目录结构...',
     reorganize: '整理',
+    filterPlaceholder: '搜索（支持 * ? 通配符）',
   },
   person: {
     alias: '别名：',

--- a/src/locales/zh-TW.ts
+++ b/src/locales/zh-TW.ts
@@ -2684,6 +2684,7 @@ export default {
     close: '關閉',
     loadingDirectoryStructure: '加載目錄結構...',
     reorganize: '整理',
+    filterPlaceholder: '搜尋（支援 * ? 萬用字元）',
   },
   person: {
     alias: '別名：',


### PR DESCRIPTION
Support * and ? wildcards in the file list filter input. When the filter contains glob chars, switch from substring matching to regex-based glob matching (case-insensitive). Update placeholder text and icon to indicate wildcard mode.