### PR TITLE
修复自定义过滤规则在规则组弹窗中显示原始 ID

### DIFF
--- a/src/components/cards/FilterRuleCard.vue
+++ b/src/components/cards/FilterRuleCard.vue
@@ -28,19 +28,18 @@ function filtersChanged(value: string[]) {
 }
 
 // 过滤规则下拉框
-const selectFilterOptions = ref<{ [key: string]: string }[]>([])
-
-onMounted(() => {
-  selectFilterOptions.value = cloneDeep(innerFilterRules)
-  if (props.custom_rules) {
-    console.log(props.custom_rules)
-    props.custom_rules.map(rule => {
-      selectFilterOptions.value.push({
-        title: rule.name,
-        value: rule.id,
-      })
+// 同时包含内置规则与用户自定义规则；使用 computed 而非 onMounted 一次性赋值，
+// 是为了在父组件异步加载完 custom_rules 或后续新增/删除规则时，
+// 选项与已选 chip 的显示名（title）能跟随刷新，避免回退到原始 ID（如 "zhong"）。
+const selectFilterOptions = computed<{ [key: string]: string }[]>(() => {
+  const options = cloneDeep(innerFilterRules)
+  props.custom_rules?.forEach(rule => {
+    options.push({
+      title: rule.name,
+      value: rule.id,
     })
-  }
+  })
+  return options
 })
 </script>
 


### PR DESCRIPTION
## 问题

规则组编辑弹窗中，自定义过滤规则的 chip 显示原始 ID（如 `zhong`、`filterSeries`），而不是用户在「自定义规则」里配置的名称（如 `中字改`）。后端解析与实际过滤行为正常，仅前端显示层异常。

## 根因

`FilterRuleCard.vue` 中，`selectFilterOptions` 通过 `onMounted` 一次性由 `innerFilterRules` 与 `props.custom_rules` 组合构建。`custom_rules` 由父组件 `AccountSettingRule.vue` 异步加载（`queryCustomRules`），且后续可能因新增/编辑/删除自定义规则发生变化；`onMounted` 不会重跑，子组件的下拉项与已选 chip 的 `title` 因此与父级数据脱钩，VAutocomplete 找不到匹配项时直接 fallback 到原始 value（即裸 ID）。

## 修复

将 `selectFilterOptions` 改为 `computed`，依赖 `props.custom_rules`，使下拉选项与 chip 名称随父组件数据自动刷新；顺带移除遗留的 `console.log` 调试输出，并补充中文 review 注释说明这一约束。

## 验证

- 打开任一规则组编辑弹窗，已选自定义规则 chip 显示为规则名称而非 ID。
- 在「自定义规则」中新增/重命名规则后，无需刷新页面，规则组弹窗中的下拉选项与 chip 标题随之更新。
- 既有内置规则（`1080P` 等）chip 展示行为不变。
- 工程既有的 typecheck/lint 报错（`ReorganizeDialog.vue`、`.eslintrc.js` ESM 兼容）与本次改动无关。

本 PR 为 Claude Code 协作提交