### PR TITLE
fix(subscribe-card): 暂停/待定状态文案补 i18n 多语言

### DIFF
--- a/src/components/cards/SubscribeCard.vue
+++ b/src/components/cards/SubscribeCard.vue
@@ -82,10 +82,10 @@ const isBestVersion = computed(() => isEnabledFlag(props.media?.best_version) &&
 
 const rightBottomStateDisplay = computed(() => {
   if (subscribeState.value === 'S') {
-    return { icon: 'mdi-pause-circle', label: '已暂停' }
+    return { icon: 'mdi-pause-circle', label: t('subscribe.cardStatePaused') }
   }
   if (subscribeState.value === 'P') {
-    return { icon: 'mdi-clock', label: '待定中' }
+    return { icon: 'mdi-clock', label: t('subscribe.cardStatePending') }
   }
   return null
 })

--- a/src/locales/en-US.ts
+++ b/src/locales/en-US.ts
@@ -993,6 +993,8 @@ export default {
     notStarted: 'Not Started',
     pending: 'Pending',
     paused: 'Paused',
+    cardStatePaused: 'Paused',
+    cardStatePending: 'Pending',
     selectedCount: 'Selected {count}/{total} items',
     noSelectedItems: 'Please select subscriptions to operate',
     batchEnable: 'Batch Enable',

--- a/src/locales/zh-CN.ts
+++ b/src/locales/zh-CN.ts
@@ -988,6 +988,8 @@ export default {
     notStarted: '未开始',
     pending: '待定',
     paused: '暂停',
+    cardStatePaused: '已暂停',
+    cardStatePending: '待定中',
     selectedCount: '已选择 {count}/{total} 项',
     noSelectedItems: '请先选择要操作的订阅',
     batchEnable: '批量启用',

--- a/src/locales/zh-TW.ts
+++ b/src/locales/zh-TW.ts
@@ -988,6 +988,8 @@ export default {
     notStarted: '未開始',
     pending: '待定',
     paused: '暫停',
+    cardStatePaused: '已暫停',
+    cardStatePending: '待定中',
     selectedCount: '已選擇 {count}/{total} 項',
     noSelectedItems: '請先選擇要操作的訂閱',
     batchEnable: '批量啟用',


### PR DESCRIPTION
## 背景

前一 PR #477 把订阅卡片暂停 / 待定状态的右下角文案改成了"已暂停" / "待定中"，但直接硬编码了中文字符串，未走 i18n 流程。en-US / zh-TW 用户看到的也是简中文案。

## 改动

新增 i18n 键，对照已有 `subscribe.paused` / `subscribe.pending`：

| key | zh-CN | zh-TW | en-US |
|---|---|---|---|
| `subscribe.cardStatePaused` | 已暂停 | 已暫停 | Paused |
| `subscribe.cardStatePending` | 待定中 | 待定中 | Pending |

中文版本沿用 3 字与 "X 天前" 视觉等宽；英文回归惯用的两词。

`SubscribeCard.vue` 中 `rightBottomStateDisplay` 改用 `t('subscribe.cardStatePaused')` / `t('subscribe.cardStatePending')` 替代硬编码字面量。

## 影响面

仅 4 文件改动，无破坏性。

## 验证

`yarn typecheck` 全部通过。

---

本 PR 为 Claude Code 协作提交