### PR TITLE
feat(settings): expose image proxy private ranges

### DIFF
--- a/src/locales/en-US.ts
+++ b/src/locales/en-US.ts
@@ -1697,6 +1697,11 @@ export default {
       securityImageDomainsHint: 'Allowed image domains whitelist for caching, used to control trusted image sources',
       noSecurityImageDomains: 'No security domains',
       securityImageDomainAdd: 'Add domain, e.g.: image.tmdb.org',
+      imageProxyAllowedPrivateRanges: 'Image Proxy Allowed Private Ranges',
+      imageProxyAllowedPrivateRangesHint:
+        'Only applies after a URL matches a security image domain. Use for TUN mappings or internal CDNs; broad ranges weaken SSRF protection',
+      noImageProxyAllowedPrivateRanges: 'No allowed ranges',
+      imageProxyAllowedPrivateRangeAdd: 'Add CIDR, e.g.: 198.18.0.0/15',
       proxyHost: 'Proxy Server',
       proxyHostHint: 'Set proxy server address, support: http(s), socks5, socks5h, etc.',
       moviePilotAutoUpdate: 'Auto Update MoviePilot',

--- a/src/locales/zh-CN.ts
+++ b/src/locales/zh-CN.ts
@@ -1670,6 +1670,11 @@ export default {
       securityImageDomainsHint: '允许缓存的图片域名白名单，用于控制可信任的图片来源',
       noSecurityImageDomains: '暂无安全域名',
       securityImageDomainAdd: '添加域名，如：image.tmdb.org',
+      imageProxyAllowedPrivateRanges: '图片代理允许非公网网段',
+      imageProxyAllowedPrivateRangesHint:
+        '仅对已命中安全图片域名的地址生效，用于 TUN 映射、内网 CDN 等特殊场景；配置过宽会降低 SSRF 防护强度',
+      noImageProxyAllowedPrivateRanges: '暂无允许网段',
+      imageProxyAllowedPrivateRangeAdd: '添加 CIDR，如：198.18.0.0/15',
       proxyHost: '代理服务器',
       proxyHostHint: '设置代理服务器地址，支持：http(s)、socks5、socks5h 等协议',
       moviePilotAutoUpdate: '自动更新MoviePilot',

--- a/src/locales/zh-TW.ts
+++ b/src/locales/zh-TW.ts
@@ -1671,6 +1671,11 @@ export default {
       securityImageDomainsHint: '允許緩存的圖片域名白名單，用於控制可信任的圖片來源',
       noSecurityImageDomains: '暫無安全域名',
       securityImageDomainAdd: '添加域名，如：image.tmdb.org',
+      imageProxyAllowedPrivateRanges: '圖片代理允許非公網網段',
+      imageProxyAllowedPrivateRangesHint:
+        '僅對已命中安全圖片域名的地址生效，用於 TUN 映射、內網 CDN 等特殊場景；配置過寬會降低 SSRF 防護強度',
+      noImageProxyAllowedPrivateRanges: '暫無允許網段',
+      imageProxyAllowedPrivateRangeAdd: '添加 CIDR，如：198.18.0.0/15',
       proxyHost: '代理服務器',
       proxyHostHint: '設置代理服務器地址，支持：http(s)、socks5、socks5h 等協議',
       moviePilotAutoUpdate: '自動更新MoviePilot',

--- a/src/views/setting/AccountSettingSystem.vue
+++ b/src/views/setting/AccountSettingSystem.vue
@@ -112,6 +112,7 @@ const SystemSettings = ref<any>({
     DOH_RESOLVERS: null,
     DOH_DOMAINS: null,
     SECURITY_IMAGE_DOMAINS: [],
+    IMAGE_PROXY_ALLOWED_PRIVATE_RANGES: [],
     // 日志
     DEBUG: false,
     LOG_LEVEL: 'INFO',
@@ -494,6 +495,8 @@ const dataCleanupFieldRules = [
 
 // 安全域名添加变量
 const newSecurityDomain = ref('')
+// 图片代理允许非公网网段添加变量
+const newImageProxyAllowedPrivateRange = ref('')
 
 // 加载 LLM 模型列表与 provider 目录
 async function refreshLlmModels(forceRefresh = true) {
@@ -541,6 +544,19 @@ function addSecurityDomain() {
   ) {
     SystemSettings.value.Advanced.SECURITY_IMAGE_DOMAINS.push(newSecurityDomain.value)
     newSecurityDomain.value = ''
+  }
+}
+
+// 添加图片代理允许访问的非公网网段
+function addImageProxyAllowedPrivateRange() {
+  if (
+    newImageProxyAllowedPrivateRange.value &&
+    !SystemSettings.value.Advanced.IMAGE_PROXY_ALLOWED_PRIVATE_RANGES.includes(
+      newImageProxyAllowedPrivateRange.value,
+    )
+  ) {
+    SystemSettings.value.Advanced.IMAGE_PROXY_ALLOWED_PRIVATE_RANGES.push(newImageProxyAllowedPrivateRange.value)
+    newImageProxyAllowedPrivateRange.value = ''
   }
 }
 
@@ -2098,6 +2114,51 @@ watch(currentLlmSnapshotKey, (snapshotKey, previousSnapshotKey) => {
                           >
                             <template #append>
                               <VBtn icon color="primary" @click="addSecurityDomain" :disabled="!newSecurityDomain">
+                                <VIcon icon="mdi-plus" />
+                              </VBtn>
+                            </template>
+                          </VTextField>
+                        </div>
+                        <VDivider class="my-4" />
+                        <div class="text-subtitle-2 mb-1">
+                          {{ t('setting.system.imageProxyAllowedPrivateRanges') }}
+                        </div>
+                        <div class="text-caption text-medium-emphasis mb-3">
+                          {{ t('setting.system.imageProxyAllowedPrivateRangesHint') }}
+                        </div>
+                        <div class="d-flex flex-wrap gap-2 mb-3">
+                          <VChip
+                            v-for="(range, index) in SystemSettings.Advanced.IMAGE_PROXY_ALLOWED_PRIVATE_RANGES"
+                            :key="index"
+                            closable
+                            @click:close="
+                              SystemSettings.Advanced.IMAGE_PROXY_ALLOWED_PRIVATE_RANGES.splice(index, 1)
+                            "
+                          >
+                            {{ range }}
+                          </VChip>
+                          <VChip
+                            v-if="SystemSettings.Advanced.IMAGE_PROXY_ALLOWED_PRIVATE_RANGES.length === 0"
+                            color="warning"
+                          >
+                            {{ t('setting.system.noImageProxyAllowedPrivateRanges') }}
+                          </VChip>
+                        </div>
+                        <div class="d-flex align-center gap-2">
+                          <VTextField
+                            v-model="newImageProxyAllowedPrivateRange"
+                            :placeholder="t('setting.system.imageProxyAllowedPrivateRangeAdd')"
+                            hide-details
+                            density="compact"
+                            prepend-inner-icon="mdi-ip-network"
+                          >
+                            <template #append>
+                              <VBtn
+                                icon
+                                color="primary"
+                                @click="addImageProxyAllowedPrivateRange"
+                                :disabled="!newImageProxyAllowedPrivateRange"
+                              >
                                 <VIcon icon="mdi-plus" />
                               </VBtn>
                             </template>


### PR DESCRIPTION
## 变更说明

- 在高级设置的“安全图片域名”面板下方新增“图片代理允许非公网网段”配置。
- 配置交互复用安全图片域名的 chip 添加/删除方式，支持填写 CIDR，如 `198.18.0.0/15`。
- 补充中简、中繁、英文文案，并提示该配置仅在安全图片域名命中后生效，配置过宽会降低 SSRF 防护强度。

## 影响路径

- `src/views/setting/AccountSettingSystem.vue`
- `src/locales/zh-CN.ts`
- `src/locales/zh-TW.ts`
- `src/locales/en-US.ts`

## 验证

- `yarn typecheck`
- `git diff --check`

本 PR 为 Codex 协作提交