### PR TITLE
fix(pluginSidebarNav): 修复首次登录后插件侧栏菜单不显示的问题

### DIFF
--- a/src/stores/pluginSidebarNav.ts
+++ b/src/stores/pluginSidebarNav.ts
@@ -26,18 +26,29 @@ export const usePluginSidebarNavStore = defineStore('pluginSidebarNav', {
       if (this.inflight) {
         return this.inflight
       }
-      this.inflight = (async () => {
+      this.inflight = this._doFetchSidebarNav()
+      return this.inflight
+    },
+
+    async _doFetchSidebarNav(): Promise<void> {
+      const maxRetries = 1
+      for (let attempt = 0; attempt <= maxRetries; attempt++) {
         try {
           const res = await api.get('plugin/sidebar_nav')
           this.items = Array.isArray(res) ? res : []
-        } catch {
-          this.items = []
-        } finally {
           this.loaded = true
           this.inflight = null
+          return
+        } catch (e) {
+          if (attempt < maxRetries) {
+            // 短暂延迟后重试，应对登录后导航过渡期的请求中断
+            await new Promise(resolve => setTimeout(resolve, 500))
+          }
         }
-      })()
-      return this.inflight
+      }
+      // 重试全部失败，不缓存失败状态以允许后续调用方再次尝试
+      this.items = []
+      this.inflight = null
     },
 
     reset() {

--- a/src/stores/pluginSidebarNav.ts
+++ b/src/stores/pluginSidebarNav.ts
@@ -35,6 +35,7 @@ export const usePluginSidebarNavStore = defineStore('pluginSidebarNav', {
       for (let attempt = 0; attempt <= maxRetries; attempt++) {
         try {
           const res = await api.get('plugin/sidebar_nav')
+          if (!this.inflight) return
           this.items = Array.isArray(res) ? res : []
           this.loaded = true
           this.inflight = null
@@ -43,10 +44,12 @@ export const usePluginSidebarNavStore = defineStore('pluginSidebarNav', {
           if (attempt < maxRetries) {
             // 短暂延迟后重试，应对登录后导航过渡期的请求中断
             await new Promise(resolve => setTimeout(resolve, 500))
+            if (!this.inflight) return
           }
         }
       }
       // 重试全部失败，不缓存失败状态以允许后续调用方再次尝试
+      if (!this.inflight) return
       this.items = []
       this.inflight = null
     },


### PR DESCRIPTION
### 问题描述

在测试 OIDC 认证插件时发现：通过 OIDC 首次登录后，侧边栏的插件菜单（如 OidcAuth 页面入口等）不会显示，必须**手动刷新页面**才能正常出现。

### 根因分析

`pluginSidebarNav` store 的 `ensureSidebarNav()` 存在两个缺陷：

1. **失败也缓存** — 原逻辑在 `finally` 块中无条件设置 `loaded = true`。登录后导航过渡期 `plugin/sidebar_nav` 请求可能被中断（如 AbortError），空结果被缓存后后续调用方看到 `loaded=true` 直接跳过，不再重试。

2. **无重试机制** — 请求失败即永久丢失菜单数据。

首次 OIDC 登录 → 导航过渡期请求中断 → 缓存空结果 → 菜单永远不显示 → 必须手动刷新

### 修复方案

- 拆出 `_doFetchSidebarNav()` 独立获取逻辑
- 添加自动重试：失败后延迟 500ms 重试一次，应对登录后导航过渡期的请求中断
- **仅在请求成功时**设置 `loaded = true`，失败不缓存，允许后续调用方再次尝试

### 改动文件

`src/stores/pluginSidebarNav.ts` (+17/-6)

### 影响范围

仅影响 `pluginSidebarNav` store 的获取逻辑，API 接口、返回数据结构、调用方接口均不变。正常网络畅通时行为与原版完全一致。