### PR TITLE
feat: add log download actions

### DIFF
--- a/src/components/dialog/PluginLogDialog.vue
+++ b/src/components/dialog/PluginLogDialog.vue
@@ -42,6 +42,12 @@ function openLoggerWindow() {
   }system/logging?length=-1&logfile=plugins/${props.plugin?.id?.toLowerCase()}.log`
   window.open(url, '_blank')
 }
+
+/** 下载当前插件日志压缩包。 */
+function downloadLogger() {
+  const url = `${import.meta.env.VITE_API_BASE_URL}system/logging/download/${props.plugin?.id?.toLowerCase()}`
+  window.open(url, '_blank')
+}
 </script>
 
 <template>
@@ -52,12 +58,20 @@ function openLoggerWindow() {
         <VCardTitle class="d-inline-flex">
           <VIcon icon="mdi-file-document" class="me-2" />
           {{ t('plugin.logTitle') }}
-          <a class="mx-2 d-inline-flex align-center cursor-pointer" @click="openLoggerWindow">
-            <VChip color="grey-darken-1" size="small" class="ml-2">
-              <VIcon icon="mdi-open-in-new" size="small" start />
-              {{ t('common.openInNewWindow') }}
-            </VChip>
-          </a>
+          <span class="ms-4 d-inline-flex align-center ga-1">
+            <a class="d-inline-flex align-center cursor-pointer" @click="downloadLogger">
+              <VChip color="grey-darken-1" size="small">
+                <VIcon icon="mdi-download" size="small" start />
+                {{ t('common.download') }}
+              </VChip>
+            </a>
+            <a class="d-inline-flex align-center cursor-pointer" @click="openLoggerWindow">
+              <VChip color="grey-darken-1" size="small">
+                <VIcon icon="mdi-open-in-new" size="small" start />
+                {{ t('common.openInNewWindow') }}
+              </VChip>
+            </a>
+          </span>
         </VCardTitle>
       </VCardItem>
       <VDivider />

--- a/src/components/dialog/ShortcutLogDialog.vue
+++ b/src/components/dialog/ShortcutLogDialog.vue
@@ -34,6 +34,11 @@ const visible = computed({
 function allLoggingUrl() {
   return `${import.meta.env.VITE_API_BASE_URL}system/logging?length=-1`
 }
+
+/** 拼接主程序日志下载 URL。 */
+function allLoggingDownloadUrl() {
+  return `${import.meta.env.VITE_API_BASE_URL}system/logging/download/moviepilot`
+}
 </script>
 
 <template>
@@ -44,12 +49,20 @@ function allLoggingUrl() {
         <VCardTitle class="d-inline-flex">
           <VIcon icon="mdi-file-document" class="me-2" />
           {{ t('shortcut.log.subtitle') }}
-          <a class="mx-2 d-inline-flex align-center" :href="allLoggingUrl()" target="_blank">
-            <VChip color="grey-darken-1" size="small" class="ml-2">
-              <VIcon icon="mdi-open-in-new" size="small" start />
-              {{ t('common.openInNewWindow') }}
-            </VChip>
-          </a>
+          <span class="ms-4 d-inline-flex align-center ga-1">
+            <a class="d-inline-flex align-center" :href="allLoggingDownloadUrl()" target="_blank">
+              <VChip color="grey-darken-1" size="small">
+                <VIcon icon="mdi-download" size="small" start />
+                {{ t('common.download') }}
+              </VChip>
+            </a>
+            <a class="d-inline-flex align-center" :href="allLoggingUrl()" target="_blank">
+              <VChip color="grey-darken-1" size="small">
+                <VIcon icon="mdi-open-in-new" size="small" start />
+                {{ t('common.openInNewWindow') }}
+              </VChip>
+            </a>
+          </span>
         </VCardTitle>
       </VCardItem>
       <VDivider />

--- a/src/locales/en-US.ts
+++ b/src/locales/en-US.ts
@@ -14,6 +14,7 @@ export default {
     success: 'Success',
     error: 'Error',
     openInNewWindow: 'Open in new window',
+    download: 'Download',
     inputMessage: 'Enter message or command',
     send: 'Send',
     noData: 'No data',

--- a/src/locales/zh-CN.ts
+++ b/src/locales/zh-CN.ts
@@ -14,6 +14,7 @@ export default {
     success: '成功',
     error: '错误',
     openInNewWindow: '在新窗口中打开',
+    download: '下载',
     inputMessage: '输入消息或命令',
     send: '发送',
     noData: '暂无数据',

--- a/src/locales/zh-TW.ts
+++ b/src/locales/zh-TW.ts
@@ -14,6 +14,7 @@ export default {
     success: '成功',
     error: '錯誤',
     openInNewWindow: '在新窗口中打開',
+    download: '下載',
     inputMessage: '輸入消息或命令',
     send: '發送',
     noData: '暫無數據',


### PR DESCRIPTION
## 变更说明

- 在主程序日志和插件日志弹窗中增加日志下载入口。
- 下载入口分别传 `moviepilot` 和插件 ID，由后端按标识打包日志。
- 补充下载按钮多语言文案，并保持按钮组与原有新窗口入口样式一致。

## 验证

- `git diff --check -- src/components/dialog/PluginLogDialog.vue src/components/dialog/ShortcutLogDialog.vue src/locales/en-US.ts src/locales/zh-CN.ts src/locales/zh-TW.ts`
- `yarn typecheck` 未通过：上游新增 `gridstack` 后当前依赖解析失败，错误集中在 `src/pages/dashboard.vue`，与本次日志弹窗改动无关。

本 PR 为 Codex 协作提交
