### PR TITLE
fix: 显示特别季 S0 标签

### DIFF
--- a/scripts/check-season-label.ts
+++ b/scripts/check-season-label.ts
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict'
+
+import { formatSeasonLabel } from '../src/@core/utils/season.ts'
+
+assert.equal(formatSeasonLabel(0, '特别篇'), '特别篇')
+assert.equal(formatSeasonLabel('0', 'Specials'), 'Specials')
+assert.equal(formatSeasonLabel(1, '特别篇'), 'S01')
+assert.equal(formatSeasonLabel('12', '特别篇'), 'S12')
+assert.equal(formatSeasonLabel(null, '特别篇'), '')
+assert.equal(formatSeasonLabel(undefined, '特别篇'), '')
+
+console.log('season label checks passed')

--- a/src/@core/utils/season.ts
+++ b/src/@core/utils/season.ts
@@ -1,0 +1,15 @@
+/**
+ * 格式化用户可见的季标签。
+ *
+ * TMDB 使用季号 0 表示特别季；调用方传入当前语言的特别季名称，
+ * 其余季号保持 MoviePilot 现有的 Sxx 展示口径。
+ */
+export function formatSeasonLabel(
+  season: number | string | null | undefined,
+  specialsLabel: string,
+): string {
+  if (season === null || season === undefined || season === '') return ''
+  if (Number(season) === 0) return specialsLabel
+
+  return `S${String(season).padStart(2, '0')}`
+}

--- a/src/components/cards/SubscribeCard.vue
+++ b/src/components/cards/SubscribeCard.vue
@@ -1,7 +1,8 @@
 <script lang="ts" setup>
 import { useToast } from 'vue-toastification'
 import { useConfirm } from '@/composables/useConfirm'
-import { formatDateDifference, formatSeason } from '@/@core/utils/formatters'
+import { formatDateDifference } from '@/@core/utils/formatters'
+import { formatSeasonLabel } from '@/@core/utils/season'
 import api from '@/api'
 import type { Subscribe } from '@/api/types'
 import router from '@/router'
@@ -478,7 +479,7 @@ function handleCardClick() {
                   <div class="text-sm font-medium text-white sm:pt-1">{{ props.media?.year }}</div>
                   <div class="mr-2 min-w-0 text-lg font-bold text-white text-ellipsis overflow-hidden line-clamp-2 ...">
                     {{ props.media?.name }}
-                    {{ formatSeason(props.media?.season ? props.media?.season.toString() : '') }}
+                    {{ formatSeasonLabel(props.media?.season, t('media.specials')) }}
                   </div>
                 </div>
               </VCardText>

--- a/src/locales/en-US.ts
+++ b/src/locales/en-US.ts
@@ -950,6 +950,7 @@ export default {
     minutes: 'minutes',
     overview: 'Overview',
     seasons: 'Seasons',
+    specials: 'Specials',
     seasonNumber: 'Season {number}',
     episodeCount: '{count} Episodes',
     actions: {

--- a/src/locales/zh-CN.ts
+++ b/src/locales/zh-CN.ts
@@ -946,6 +946,7 @@ export default {
     minutes: '分钟',
     overview: '简介',
     seasons: '季',
+    specials: '特别篇',
     seasonNumber: '第 {number} 季',
     episodeCount: '{count}集',
     actions: {

--- a/src/locales/zh-TW.ts
+++ b/src/locales/zh-TW.ts
@@ -946,6 +946,7 @@ export default {
     minutes: '分鐘',
     overview: '簡介',
     seasons: '季',
+    specials: '特別篇',
     seasonNumber: '第 {number} 季',
     episodeCount: '{count}集',
     actions: {

--- a/src/views/discover/MediaDetailView.vue
+++ b/src/views/discover/MediaDetailView.vue
@@ -7,6 +7,7 @@ import type { MediaInfo, NotExistMediaInfo, Site, Subscribe, TmdbEpisode } from 
 import NoDataFound from '@/components/NoDataFound.vue'
 import { doneNProgress, startNProgress } from '@/api/nprogress'
 import { formatSeason } from '@/@core/utils/formatters'
+import { formatSeasonLabel } from '@/@core/utils/season'
 import router from '@/router'
 import { isNullOrEmptyObject } from '@/@core/utils'
 import { useUserStore } from '@/stores'
@@ -807,8 +808,9 @@ onBeforeMount(() => {
                   <template #default>
                     <div class="flex flex-row items-center justify-between">
                       <span class="font-weight-bold">{{
-                        season.season_number === 0 && season.name ?
-                        season.name : t('media.seasonNumber', { number: season.season_number })
+                        season.season_number === 0
+                          ? season.name || formatSeasonLabel(0, t('media.specials'))
+                          : t('media.seasonNumber', { number: season.season_number })
                         }}</span>
                       <VChip size="small" class="ms-1">
                         {{ t('media.episodeCount', { count: season.episode_count }) }}


### PR DESCRIPTION
## 变更说明

- 新增统一的季标签格式化方法，普通季继续显示 `S01`、`S02`，特别季 `S0` 显示当前语言的“特别篇 / Specials”。
- 订阅卡片不再通过 truthy 判断过滤季号 `0`。
- 媒体详情中的特别季优先使用 TMDB 返回的季名称，名称缺失时回退本地化“特别篇”。

## 问题原因

TMDB 使用季号 `0` 表示特别季，但订阅卡片原先通过 `season ? ... : ''` 生成季标签。JavaScript 会把数字 `0` 判断为 false，导致后端已经返回 S0 时前端仍不显示季标记。

## 影响范围

- 订阅列表卡片的季标签
- 媒体详情页的特别季标题
- 简体中文、繁体中文和英文文案

## 验证

- `node --experimental-strip-types scripts/check-season-label.ts`
- `yarn typecheck`
- `yarn build`

本 PR 为 Codex 协作提交
