### PR TITLE
feat: Web Agent 透明主题磨砂效果

### DIFF
--- a/src/@iconify/tsconfig.tsbuildinfo
+++ b/src/@iconify/tsconfig.tsbuildinfo
@@ -1,1 +1,1 @@
-{"root":["./build-icons.ts"],"version":"5.8.3"}
+{"root":["./build-icons.ts"],"errors":true,"version":"6.0.3"}

--- a/src/styles/themes/transparent.scss
+++ b/src/styles/themes/transparent.scss
@@ -130,4 +130,34 @@ html[data-theme="transparent"] {
       background-color: rgba(var(--v-theme-surface), var(--transparent-opacity));
     }
   }
+
+  // 主题定制器面板
+  .theme-customizer-panel-host {
+    backdrop-filter: blur(var(--transparent-blur-heavy));
+    background-color: rgba(var(--v-theme-surface), var(--transparent-opacity-heavy)) !important;
+    border-inline-start: 1px solid rgba(var(--v-theme-on-surface), 0.08) !important;
+  }
+
+  .theme-customizer-panel {
+    backdrop-filter: blur(var(--transparent-blur));
+    background-color: transparent;
+  }
+
+  // 智能助手面板
+  .agent-assistant-panel {
+    backdrop-filter: blur(var(--transparent-blur-heavy));
+    background-color: rgba(var(--v-theme-surface), var(--transparent-opacity-heavy)) !important;
+    border-inline-start: 1px solid rgba(var(--v-theme-on-surface), 0.08);
+  }
+
+  .agent-assistant-shell {
+    --agent-assistant-panel-bg: rgba(var(--v-theme-surface), var(--transparent-opacity-heavy));
+    --agent-assistant-panel-blur: var(--transparent-blur);
+    --agent-assistant-assistant-bg: rgba(var(--v-theme-surface), var(--transparent-opacity-heavy));
+  }
+
+  .agent-assistant-fab {
+    backdrop-filter: blur(var(--transparent-blur));
+    background-color: rgba(var(--v-theme-surface), var(--transparent-opacity-heavy));
+  }
 } 

--- a/src/views/setting/AccountSettingSystem.vue
+++ b/src/views/setting/AccountSettingSystem.vue
@@ -698,6 +698,8 @@ async function saveBasicSettings() {
   savingBasic.value = true
   try {
     if (await saveSystemSetting(SystemSettings.value.Basic)) {
+      // 更新全局设置store，使Web Agent图标实时生效
+      globalSettingsStore.setData({ ...globalSettingsStore.getData, ...SystemSettings.value.Basic })
       $toast.success(t('setting.system.basicSaveSuccess'))
     }
   } finally {


### PR DESCRIPTION
## 变更内容

### 1. 透明主题磨砂效果
- 为主题定制器面板添加透明主题磨砂效果样式
- 为Web Agent面板添加透明主题磨砂效果样式

### 2. 智能助手开关实时生效
- 保存基础设置后立即更新全局store
- Web Agent图标能实时响应开关状态变化

### 修改文件
- `src/styles/themes/transparent.scss` - 添加磨砂效果样式
- `src/views/setting/AccountSettingSystem.vue` - 添加设置保存后的状态更新