### PR TITLE
fix: restore search filter chip colors

### DIFF
--- a/src/components/dialog/TorrentAllFiltersDialog.vue
+++ b/src/components/dialog/TorrentAllFiltersDialog.vue
@@ -141,4 +141,29 @@ function updateFilter(key: string, values: string[]) {
   gap: 1rem;
   grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
 }
+
+.filter-options {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.filter-chip {
+  border: 1px solid rgba(var(--v-theme-primary), 0.2);
+  margin: 4px;
+  background-color: rgba(var(--v-theme-primary), 0.1) !important;
+  color: rgba(var(--v-theme-on-surface), 0.9) !important;
+  font-weight: 500;
+  transition: all 0.2s ease;
+}
+
+.filter-chip:hover {
+  background-color: rgba(var(--v-theme-primary), 0.15) !important;
+}
+
+.filter-chip.v-chip--selected {
+  background-color: rgba(var(--v-theme-primary), 0.85) !important;
+  box-shadow: 0 2px 4px rgba(var(--v-theme-primary), 0.3);
+  color: rgb(var(--v-theme-on-primary)) !important;
+  font-weight: 600;
+}
 </style>

--- a/src/components/dialog/TorrentMoreSourcesDialog.vue
+++ b/src/components/dialog/TorrentMoreSourcesDialog.vue
@@ -142,4 +142,24 @@ function handleDetail(item: Context) {
   max-block-size: 60vh;
   overflow-y: auto;
 }
+
+.chip-season {
+  background-color: #3f51b5;
+  color: white;
+}
+
+.chip-free {
+  background-color: #4caf50;
+  color: white;
+}
+
+.chip-discount {
+  background-color: #ff5722;
+  color: white;
+}
+
+.chip-bonus {
+  background-color: #9c27b0;
+  color: white;
+}
 </style>

--- a/src/components/dialog/TorrentSingleFilterDialog.vue
+++ b/src/components/dialog/TorrentSingleFilterDialog.vue
@@ -85,7 +85,7 @@ function updateFilter(values: string[]) {
           @update:model-value="updateFilter"
         >
           <VChip
-          v-for="option in options"
+            v-for="option in options"
             :key="option"
             :value="option"
             filter
@@ -106,3 +106,30 @@ function updateFilter(values: string[]) {
     </VCard>
   </VDialog>
 </template>
+
+<style scoped>
+.filter-options {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.filter-chip {
+  border: 1px solid rgba(var(--v-theme-primary), 0.2);
+  margin: 4px;
+  background-color: rgba(var(--v-theme-primary), 0.1) !important;
+  color: rgba(var(--v-theme-on-surface), 0.9) !important;
+  font-weight: 500;
+  transition: all 0.2s ease;
+}
+
+.filter-chip:hover {
+  background-color: rgba(var(--v-theme-primary), 0.15) !important;
+}
+
+.filter-chip.v-chip--selected {
+  background-color: rgba(var(--v-theme-primary), 0.85) !important;
+  box-shadow: 0 2px 4px rgba(var(--v-theme-primary), 0.3);
+  color: rgb(var(--v-theme-on-primary)) !important;
+  font-weight: 600;
+}
+</style>

--- a/src/components/filter/TorrentFilterBar.vue
+++ b/src/components/filter/TorrentFilterBar.vue
@@ -372,7 +372,7 @@ onMounted(() => {
             :key="key"
             variant="tonal"
             size="small"
-            :color="filterForm[key].length > 0 ? 'primary' : undefined"
+            color="primary"
             :prepend-icon="getFilterIcon(key)"
             class="filter-btn"
             rounded="pill"
@@ -555,7 +555,7 @@ onMounted(() => {
             v-for="(title, key) in filterTitles"
             v-show="filterOptions[key].length > 0"
             :key="key"
-            variant="text"
+            variant="tonal"
             color="primary"
             class="filter-btn-mobile"
             @click="toggleFilterMenu(key)"
@@ -575,7 +575,7 @@ onMounted(() => {
           </VBtn>
 
           <!-- 全部筛选按钮 -->
-          <VBtn variant="text" color="primary" class="filter-btn-mobile" @click="toggleAllFilterMenu">
+          <VBtn variant="tonal" color="primary" class="filter-btn-mobile" @click="toggleAllFilterMenu">
             <VIcon icon="mdi-filter-variant" class="filter-icon me-1"></VIcon>
             <span class="filter-label">
               {{ t('torrent.allFilters') }}
@@ -665,7 +665,6 @@ onMounted(() => {
 
 .filter-btn {
   min-inline-size: 0;
-  background: rgba(var(--v-theme-surface-variant), 0.1);
   transition: opacity 0.2s;
 }
 
@@ -733,7 +732,6 @@ onMounted(() => {
   justify-content: center;
   border: 1px solid rgba(var(--v-theme-on-surface), 0.08);
   border-radius: 8px;
-  background-color: rgba(var(--v-theme-surface-variant), 0.08);
   block-size: auto;
   min-block-size: 48px;
   padding-block: 4px;


### PR DESCRIPTION
### 修复移动端视图筛选器标签颜色

| 修复前 | 修复后 |
|---|---|
| <img width="562" height="573" alt="修复前" src="https://github.com/user-attachments/assets/a07294e5-27aa-4bbd-a753-dff6df6216a0" /> | <img width="562" height="573" alt="修复后" src="https://github.com/user-attachments/assets/f4b475a0-f8ec-42db-b553-549f785bb520" /> |
| <img width="400" height="233" alt="修复前" src="https://github.com/user-attachments/assets/10ee7936-0710-4216-a4a4-1a3dbc710040" /> | <img width="400" height="233" alt="修复后" src="https://github.com/user-attachments/assets/039226ca-4e8a-4a64-a7d4-3e5dc18f2e6b" /> |
|<img width="801" height="48" alt="修复前" src="https://github.com/user-attachments/assets/db66b019-a9af-41cc-aa89-1ac67bac9be0" />|<img width="801" height="48" alt="修复后" src="https://github.com/user-attachments/assets/b35e6bf5-87d9-4428-a668-34d363cbc250" />
