### PR TITLE
fix(plugin): refine release version history UI

### DIFF
--- a/src/components/dialog/PluginMarketDetailDialog.vue
+++ b/src/components/dialog/PluginMarketDetailDialog.vue
@@ -227,12 +227,11 @@ onUnmounted(() => {
                   class="mb-3"
                   :text="props.plugin?.system_version_message || t('plugin.incompatibleSystemVersion')"
                 />
-                <div class="text-center text-md-left">
+                <div class="plugin-market-detail-actions">
                   <VBtn
                     variant="tonal"
                     @click="showUpdateHistory"
                     prepend-icon="mdi-update"
-                    class="me-2"
                   >
                     {{ t('plugin.versionHistory') }}
                   </VBtn>
@@ -244,7 +243,7 @@ onUnmounted(() => {
                   >
                     {{ t('plugin.installToLocal') }}
                   </VBtn>
-                  <div class="text-xs mt-2" v-if="props.count">
+                  <div class="plugin-market-detail-actions__downloads" v-if="props.count">
                     <VIcon icon="mdi-fire" />
                     {{ t('plugin.totalDownloads', { count: formatDownloadCount(props.count) }) }}
                   </div>
@@ -257,3 +256,30 @@ onUnmounted(() => {
     </VCard>
   </VDialog>
 </template>
+
+<style scoped>
+.plugin-market-detail-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  justify-content: center;
+}
+
+.plugin-market-detail-actions__downloads {
+  flex-basis: 100%;
+  color: rgba(var(--v-theme-on-surface), var(--v-medium-emphasis-opacity));
+  font-size: 0.75rem;
+  text-align: center;
+}
+
+@media (min-width: 960px) {
+  .plugin-market-detail-actions {
+    justify-content: flex-start;
+  }
+
+  .plugin-market-detail-actions__downloads {
+    text-align: start;
+  }
+}
+</style>

--- a/src/components/dialog/PluginVersionHistoryDialog.vue
+++ b/src/components/dialog/PluginVersionHistoryDialog.vue
@@ -67,6 +67,8 @@ const latestActionText = computed(() => props.actionMode === 'install' ? t('plug
 
 const releaseItems = computed(() => releaseDetail.value?.items || [])
 
+const shouldShowUpdatePanel = computed(() => props.showUpdateAction)
+
 const releaseByHistoryVersion = computed(() => {
   const releaseMap = new Map<string, PluginReleaseVersion>()
   releaseItems.value.forEach(item => {
@@ -88,6 +90,11 @@ function formatReleaseDate(value?: string) {
 
 function releaseItemByHistoryVersion(version: string) {
   return releaseByHistoryVersion.value.get(version)
+}
+
+function shouldShowReleaseButton(item?: PluginReleaseVersion) {
+  if (!item || item.is_current) return false
+  return !(item.is_latest && shouldShowUpdatePanel.value && props.actionMode === 'update')
 }
 
 async function loadPluginHistory() {
@@ -130,7 +137,7 @@ async function loadPluginHistory() {
 }
 
 async function loadPluginReleases(plugin: Plugin | null | undefined = resolvedPlugin.value, force = false) {
-  if (!plugin?.id || !plugin?.repo_url) {
+  if (!plugin?.id || !plugin?.repo_url || !plugin.release) {
     releaseDetail.value = null
     releaseError.value = ''
     return
@@ -190,47 +197,47 @@ watch(
         <VCardText v-if="releaseError" class="pb-0">
           <VAlert type="warning" variant="tonal" density="compact" :text="releaseError" />
         </VCardText>
-        <VersionHistory :history="resolvedHistory">
-          <template #action="{ version }">
-            <div class="plugin-release-action" v-if="releaseItemByHistoryVersion(version)">
-              <template v-if="releaseItemByHistoryVersion(version)">
-                <div class="plugin-release-action__meta">
-                  <VChip v-if="releaseItemByHistoryVersion(version)?.is_current" size="x-small" color="success" variant="tonal">
-                    {{ t('plugin.currentVersion') }}
-                  </VChip>
-                  <VChip v-if="releaseItemByHistoryVersion(version)?.is_latest" size="x-small" color="primary" variant="tonal">
-                    {{ t('plugin.latestVersion') }}
-                  </VChip>
-                  <span v-if="formatReleaseDate(releaseItemByHistoryVersion(version)?.published_at)" class="text-caption text-medium-emphasis">
-                    {{ formatReleaseDate(releaseItemByHistoryVersion(version)?.published_at) }}
-                  </span>
-                </div>
-                <VBtn
-                  size="small"
-                  min-width="5.5rem"
-                  :block="$vuetify.display.xs"
-                  :color="releaseItemByHistoryVersion(version)?.is_latest ? 'primary' : undefined"
-                  :variant="releaseItemByHistoryVersion(version)?.is_latest ? 'flat' : 'tonal'"
-                  :disabled="
-                    releaseItemByHistoryVersion(version)?.is_current ||
-                    (releaseItemByHistoryVersion(version)?.is_latest && resolvedPlugin?.system_version_compatible === false)
-                  "
-                  @click.stop="handleUpdate(releaseItemByHistoryVersion(version))"
-                >
-                  {{
-                    releaseItemByHistoryVersion(version)?.is_current
-                      ? t('plugin.installed')
-                      : releaseItemByHistoryVersion(version)?.is_latest
-                        ? latestActionText
-                        : t('plugin.installReleaseVersion')
-                  }}
-                </VBtn>
-              </template>
+        <VersionHistory
+          :history="resolvedHistory"
+          :has-action="version => shouldShowReleaseButton(releaseItemByHistoryVersion(version))"
+        >
+          <template #meta="{ version }">
+            <div v-if="releaseItemByHistoryVersion(version)" class="plugin-release-meta">
+              <span v-if="formatReleaseDate(releaseItemByHistoryVersion(version)?.published_at)" class="plugin-release-meta__date">
+                {{ formatReleaseDate(releaseItemByHistoryVersion(version)?.published_at) }}
+              </span>
+              <VChip v-if="releaseItemByHistoryVersion(version)?.is_latest" size="x-small" color="primary" variant="tonal">
+                {{ t('plugin.latestVersion') }}
+              </VChip>
+              <VChip v-if="releaseItemByHistoryVersion(version)?.is_current" size="x-small" color="success" variant="tonal">
+                {{ t('plugin.currentVersion') }}
+              </VChip>
             </div>
+          </template>
+          <template #action="{ version }">
+            <VBtn
+              v-if="shouldShowReleaseButton(releaseItemByHistoryVersion(version))"
+              class="plugin-release-button"
+              size="small"
+              min-width="5rem"
+              :color="releaseItemByHistoryVersion(version)?.is_latest ? 'primary' : undefined"
+              :variant="releaseItemByHistoryVersion(version)?.is_latest ? 'flat' : 'tonal'"
+              :disabled="
+                releaseItemByHistoryVersion(version)?.is_current ||
+                (releaseItemByHistoryVersion(version)?.is_latest && resolvedPlugin?.system_version_compatible === false)
+              "
+              @click.stop="handleUpdate(releaseItemByHistoryVersion(version))"
+            >
+              {{
+                releaseItemByHistoryVersion(version)?.is_latest
+                    ? latestActionText
+                    : t('plugin.installReleaseVersion')
+              }}
+            </VBtn>
           </template>
         </VersionHistory>
       </template>
-      <template v-if="props.showUpdateAction">
+      <template v-if="shouldShowUpdatePanel">
         <VDivider />
         <VCardItem>
           <VAlert
@@ -241,7 +248,11 @@ watch(
             class="mb-3"
             :text="resolvedPlugin?.system_version_message || t('plugin.incompatibleSystemVersion')"
           />
-          <VBtn @click="handleUpdate()" block :disabled="resolvedPlugin?.system_version_compatible === false">
+          <VBtn
+            @click="handleUpdate()"
+            block
+            :disabled="resolvedPlugin?.system_version_compatible === false"
+          >
             <template #prepend>
               <VIcon icon="mdi-arrow-up-circle-outline" />
             </template>
@@ -261,32 +272,22 @@ watch(
   justify-content: center;
 }
 
-.plugin-release-action,
-.plugin-release-action__meta {
+.plugin-release-button {
+  white-space: nowrap;
+}
+
+.plugin-release-meta {
   display: flex;
   align-items: center;
   gap: 0.5rem;
   flex-wrap: wrap;
+  min-width: 0;
 }
 
-.plugin-release-action {
-  justify-content: flex-end;
-  min-width: 10rem;
+.plugin-release-meta__date {
+  color: rgba(var(--v-theme-on-surface), var(--v-disabled-opacity));
+  font-size: 0.875rem;
+  white-space: nowrap;
 }
 
-.plugin-release-action__meta {
-  justify-content: flex-end;
-}
-
-@media (max-width: 600px) {
-  .plugin-release-action,
-  .plugin-release-action__meta {
-    justify-content: flex-start;
-    width: 100%;
-  }
-
-  .plugin-release-action {
-    min-width: 0;
-  }
-}
 </style>

--- a/src/components/misc/VersionHistory.vue
+++ b/src/components/misc/VersionHistory.vue
@@ -27,41 +27,98 @@ function renderMarkdown(value: string) {
 // 输入参数
 const props = defineProps({
   history: Object as PropType<{ [key: string]: string }>,
+  hasAction: Function as PropType<(version: string) => boolean>,
 })
+
+function shouldRenderAction(version: string) {
+  return props.hasAction?.(version) ?? true
+}
 </script>
 
 <template>
   <VCardText class="version-history">
-    <VList bg-color="transparent" class="version-history__list">
-      <VListItem v-for="(value, key) in props.history" :key="key" class="version-history__item">
-        <VListItemTitle class="font-bold text-lg">
-          {{ key }}
-        </VListItemTitle>
-        <div class="markdown-body text-gray-500" v-html="renderMarkdown(value)" />
-        <template v-if="$slots.action" #append>
-          <slot name="action" :version="String(key)" />
-        </template>
-      </VListItem>
-    </VList>
+    <div class="version-history__list">
+      <section v-for="(value, key) in props.history" :key="key" class="version-history__item">
+        <div
+          class="version-history__top"
+          :class="{ 'version-history__top--with-action': $slots.action && shouldRenderAction(String(key)) }"
+        >
+          <div class="version-history__header">
+            <div class="version-history__version">
+              {{ key }}
+            </div>
+            <div v-if="$slots.meta" class="version-history__meta">
+              <slot name="meta" :version="String(key)" />
+            </div>
+          </div>
+          <div v-if="$slots.action && shouldRenderAction(String(key))" class="version-history__action">
+            <slot name="action" :version="String(key)" />
+          </div>
+        </div>
+        <div class="markdown-body text-medium-emphasis" v-html="renderMarkdown(value)" />
+      </section>
+    </div>
   </VCardText>
 </template>
 
 <style scoped>
 .version-history {
-  padding-block: 1rem;
+  padding: 0;
 }
 
 .version-history__list {
-  padding-block: 0;
+  display: flex;
+  flex-direction: column;
 }
 
 .version-history__item {
-  align-items: start;
-  padding-block: 0.75rem;
+  padding: 1.25rem 2rem;
 }
 
 .version-history__item + .version-history__item {
   border-block-start: 1px solid rgba(var(--v-border-color), var(--v-border-opacity));
+}
+
+.version-history__top {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  grid-template-areas: "main";
+  gap: 0;
+  align-items: center;
+  margin-block-end: 0.5rem;
+}
+
+.version-history__top--with-action {
+  grid-template-columns: minmax(0, 1fr) max-content;
+  grid-template-areas: "main action";
+  gap: 1rem;
+}
+
+.version-history__header {
+  grid-area: main;
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  justify-content: flex-start;
+  min-width: 0;
+}
+
+.version-history__version {
+  color: rgba(var(--v-theme-on-surface), var(--v-high-emphasis-opacity));
+  font-size: 1.25rem;
+  font-weight: 700;
+  line-height: 1.25;
+}
+
+.version-history__meta {
+  display: flex;
+  min-width: 0;
+}
+
+.version-history__action {
+  grid-area: action;
+  align-self: center;
+  justify-self: end;
 }
 
 .markdown-body :deep(h1),
@@ -135,22 +192,25 @@ const props = defineProps({
 
 @media (max-width: 600px) {
   .version-history {
-    padding-inline: 0.75rem;
+    padding: 0;
   }
 
   .version-history__item {
-    padding-inline: 0;
+    padding: 1rem;
   }
 
-  :deep(.version-history__item .v-list-item__append) {
-    align-self: stretch;
-    margin-inline-start: 0;
-    padding-inline-start: 0;
-    padding-block-start: 0.75rem;
+  .version-history__top--with-action {
+    gap: 0.75rem;
   }
 
-  :deep(.version-history__item .v-list-item__content) {
-    overflow: visible;
+  .version-history__header {
+    flex-wrap: wrap;
+    justify-content: flex-start;
   }
+
+  .version-history__version {
+    font-size: 1.125rem;
+  }
+
 }
 </style>


### PR DESCRIPTION
## 变更说明

- 调整插件市场详情操作区布局，改善按钮与下载量信息在桌面和窄屏下的排列。
- 重构版本历史列表结构，分离版本、Release 标签、发布日期和操作按钮区域。
- 已安装插件的 Release 请求继续与 history 使用相同的强制刷新语义；市场插件沿用已有市场元数据和缓存读取。
- 当前版本不再显示重复安装按钮；最新版更新入口与底部更新操作避免重复。

## 影响路径

- `src/components/dialog/PluginMarketDetailDialog.vue`
- `src/components/dialog/PluginVersionHistoryDialog.vue`
- `src/components/misc/VersionHistory.vue`

## 验证

- `yarn typecheck`
- `yarn build`
- `git diff --check`
- `yarn lint` 受仓库现有 ESLint 9 与 `.eslintrc.js` ESM/CJS 配置冲突阻塞

## 关联

- 后端 PR：https://github.com/jxxghp/MoviePilot/pull/5966
- 背景前端 PR：https://github.com/jxxghp/MoviePilot-Frontend/pull/494

本 PR 为 Codex 协作提交
