### PR TITLE
fix(plugin): sanitize version history markdown

### DIFF
--- a/src/components/dialog/PluginVersionHistoryDialog.vue
+++ b/src/components/dialog/PluginVersionHistoryDialog.vue
@@ -137,7 +137,7 @@ async function loadPluginHistory() {
 }
 
 async function loadPluginReleases(plugin: Plugin | null | undefined = resolvedPlugin.value, force = false) {
-  if (!plugin?.id || !plugin?.repo_url || !plugin.release) {
+  if (!plugin?.id || !plugin?.repo_url || !plugin?.release) {
     releaseDetail.value = null
     releaseError.value = ''
     return

--- a/src/components/misc/VersionHistory.vue
+++ b/src/components/misc/VersionHistory.vue
@@ -3,9 +3,9 @@ import type { PropType } from 'vue'
 import MarkdownIt from 'markdown-it'
 import mdLinkAttributes from 'markdown-it-link-attributes'
 
-// 初始化 markdown-it
+// 版本历史可能来自插件市场或 Release 内容，禁止透传原始 HTML，避免外部内容注入脚本或事件属性。
 const md = new MarkdownIt({
-  html: true,
+  html: false,
   linkify: true,
   typographer: true,
 })


### PR DESCRIPTION
## 变更说明

- 关闭版本历史 Markdown 渲染中的原始 HTML 透传，避免插件市场或 Release 内容通过 v-html 注入脚本或事件属性。
- 将插件 Release 历史加载前置判断中的 plugin.release 改为一致的可选链访问。

## 影响路径

- `src/components/misc/VersionHistory.vue`
- `src/components/dialog/PluginVersionHistoryDialog.vue`

## 关联

Refs #495

## 验证

- `yarn typecheck`
- `yarn build`
- `git diff --check`
- 已用最小复现确认：修复前 markdown-it 会原样输出带事件属性的 HTML，修复后原始 HTML 被转义。

未完成：

- `yarn lint`：当前 ESLint 9 加载项目的 CommonJS `.eslintrc.js` 时被 `type: module` 阻塞，未进入具体规则检查。

本 PR 为 Codex 协作提交
