### PR TITLE
fix(pwa): prevent stale service worker caching

### DIFF
--- a/public/nginx.conf
+++ b/public/nginx.conf
@@ -35,6 +35,22 @@ http {
             try_files $uri $uri/ /index.html;
         }
 
+        location = /service-worker.js {
+            # Service Worker 必须保持稳定 URL 并每次重新验证，避免前端更新后继续注册旧版本。
+            expires off;
+            add_header Cache-Control "no-cache, must-revalidate";
+            root html;
+            try_files $uri =404;
+        }
+
+        location = /manifest.webmanifest {
+            # Web App Manifest 参与 PWA 安装与资源发现，不能跟普通静态资源一起长缓存。
+            expires off;
+            add_header Cache-Control "no-cache, must-revalidate";
+            root html;
+            try_files $uri =404;
+        }
+
         location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$ {
             # 静态资源
             expires 1y;
@@ -45,7 +61,7 @@ http {
         location /assets {
             # 静态资源
             expires 1y;
-            add_header Cache-Control "public";
+            add_header Cache-Control "public, max-age=31536000, immutable";
             root html;
         }
 

--- a/public/nginx.conf
+++ b/public/nginx.conf
@@ -46,6 +46,7 @@ http {
         location = /manifest.webmanifest {
             # Web App Manifest 参与 PWA 安装与资源发现，不能跟普通静态资源一起长缓存。
             expires off;
+            default_type application/manifest+json;
             add_header Cache-Control "no-cache, must-revalidate";
             root html;
             try_files $uri =404;
@@ -60,7 +61,6 @@ http {
 
         location /assets {
             # 静态资源
-            expires 1y;
             add_header Cache-Control "public, max-age=31536000, immutable";
             root html;
         }


### PR DESCRIPTION
## 变更说明

- 为前端独立部署 nginx 示例增加 `/service-worker.js` 精确缓存规则，避免前端升级后浏览器继续注册旧 Service Worker。
- 为 `/manifest.webmanifest` 增加同样的重新验证规则，避免 PWA 元数据被普通静态资源策略长缓存。
- 将 `/assets` 的长缓存策略显式补充 `max-age=31536000`，保持带 hash 静态资源长期缓存语义。

## 影响路径

- `public/nginx.conf`

## 验证

- `git diff --check`
- 通过 `nginx -t` 语法验证；本机验证副本仅适配了 `mime.types` include 路径。

## 联动 PR

- 主程序 Docker nginx 配置同步修复：https://github.com/jxxghp/MoviePilot/pull/5973

本 PR 为 Codex 协作提交
