### PR TITLE
ci: review PRs with PR-Agent

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -1,9 +1,9 @@
 name: PR Agent
 
 on:
-  pull_request:
-    # PR-Agent 读取 PR diff，并写入 Review 评论或更新 PR 描述。
-    # synchronize 用于在 PR 推送新 commit 后刷新审查结果。
+  pull_request_target:
+    # PR-Agent 通过 base repo 上下文读取 PR diff 并发布 Review，不 checkout 或执行 PR 分支代码。
+    # pull_request_target 允许 fork PR 使用仓库 secrets，因此 workflow 只运行固定 digest 的 PR-Agent 容器。
     types:
       - opened
       - reopened
@@ -28,14 +28,11 @@ permissions:
 jobs:
   pr-agent:
     name: PR-Agent review and describe
-    # 同仓 PR 可自动处理；fork PR 由允许身份在 PR 下用评论命令触发，避免任意评论消耗模型配额。
+    # PR 事件自动处理；评论命令仅允许指定身份在 PR 下触发，避免任意评论消耗模型配额。
     if: >-
       github.event.sender.type != 'Bot' &&
       (
-        (
-          github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name == github.repository
-        ) ||
+        github.event_name == 'pull_request_target' ||
         (
           github.event_name == 'issue_comment' &&
           github.event.issue.pull_request != null &&
@@ -80,7 +77,7 @@ jobs:
           config.ignore_pr_title: '["^\\[Auto\\]", "^Auto"]'
           config.ignore_pr_labels: '["skip pr-agent"]'
 
-          # pull_request 事件默认自动执行 /review 和 /describe；/improve 保持手动触发。
+          # pull_request_target 事件默认自动执行 /review 和 /describe；/improve 保持手动触发。
           github_action_config.auto_review: "true"
           github_action_config.auto_describe: "true"
           github_action_config.auto_improve: "false"


### PR DESCRIPTION
## 变更说明

将 PR-Agent workflow 从 `pull_request` 调整为 `pull_request_target`，使同仓 PR 和 fork PR 都能自动运行受控审查。

- PR 打开、重新打开、ready、请求 review 或推送新 commit 时自动执行 `/review` 和 `/describe`
- 可信作者仍可在 PR 评论中手动触发 `/review`、`/describe`、`/improve` 或 `/ask`
- 保留固定 digest 的 PR-Agent 容器、最小权限、中文输出、GPT-5.5 默认模型和 GPT-5.4 fallback 配置

## 安全边界

- workflow 不 checkout PR 分支代码
- workflow 不执行来自 PR 分支的脚本或命令
- `pull_request_target` 仅用于 base repo 上下文读取 PR diff 并发布 Review
- API Key 继续通过 repository secrets 注入

## 验证

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pr-agent.yml"); puts "yaml ok"'`
- `git diff --check`

本 PR 为 Codex 协作提交
