### PR TITLE
fix: refine season subscription mode defaults

### DIFF
--- a/src/components/dialog/SubscribeSeasonDialog.vue
+++ b/src/components/dialog/SubscribeSeasonDialog.vue
@@ -34,6 +34,7 @@ const props = defineProps({
   selectedSeason: Number,
   subscribedSeasons: Array as PropType<number[]>,
   subscribedSeasonModes: Object as PropType<SeasonSubscribeModes>,
+  defaultSubscribeMode: String as PropType<SubscribeMode>,
 })
 
 // 从 provide 中获取全局设置
@@ -49,6 +50,9 @@ const seasonsSelected = ref<number[]>([])
 
 // 各季订阅方式
 const seasonModes = ref<Record<number, SubscribeMode>>({})
+
+// 用户已手动选择过模式的季号，入库状态异步刷新时不再覆盖。
+const manuallySelectedModeSeasons = ref(new Set<number>())
 
 // 各季缺失状态：0-已入库 1-部分缺失 2-全部缺失，没有数据也是已入库
 const seasonsNotExisted = ref<{ [key: number]: number }>({})
@@ -294,11 +298,25 @@ function setSeasonMode(season: number, mode: SubscribeMode) {
 
 function updateSeasonMode(season: number, mode: unknown) {
   if (!isSubscribeMode(mode)) return
+  manuallySelectedModeSeasons.value.add(season)
   setSeasonMode(season, mode)
 }
 
+function getDefaultSeasonMode(season: number) {
+  if (!seasonsNotExisted.value[season]) return 'best_version_full'
+
+  return props.defaultSubscribeMode ?? 'normal'
+}
+
 function ensureSeasonMode(season: number) {
-  if (!seasonModes.value[season]) setSeasonMode(season, props.subscribedSeasonModes?.[season] ?? 'normal')
+  if (!seasonModes.value[season]) setSeasonMode(season, props.subscribedSeasonModes?.[season] ?? getDefaultSeasonMode(season))
+}
+
+function syncDefaultSeasonModes() {
+  seasonsSelected.value.forEach(season => {
+    if (subscribedSeasonSet.value.has(season) || manuallySelectedModeSeasons.value.has(season)) return
+    setSeasonMode(season, getDefaultSeasonMode(season))
+  })
 }
 
 function isSeasonSubscribed(season: number) {
@@ -353,6 +371,8 @@ watchEffect(() => {
 })
 
 watch(seasonInfos, syncSelectedSeason)
+
+watch(seasonsNotExisted, syncDefaultSeasonModes, { deep: true })
 
 watch(() => props.selectedSeason, syncSelectedSeason)
 
@@ -624,7 +644,7 @@ onMounted(async () => {
 
 .subscribe-season-mode-toggle {
   block-size: 2rem;
-  max-inline-size: 16rem;
+  max-inline-size: 18rem;
 }
 
 .subscribe-season-mode-button {

--- a/src/composables/useMediaSubscribe.ts
+++ b/src/composables/useMediaSubscribe.ts
@@ -16,6 +16,12 @@ interface SubscribePayload {
   best_version_full?: number
 }
 
+interface SubscribeConfig {
+  show_edit_dialog?: boolean
+  best_version?: unknown
+  best_version_full?: unknown
+}
+
 interface AddSubscribeOptions {
   openEditDialog?: boolean
 }
@@ -65,6 +71,13 @@ export function getSubscribeMode(subscribe: { best_version?: unknown; best_versi
   if (!isEnabledFlag(subscribe.best_version)) return 'normal'
 
   return isEnabledFlag(subscribe.best_version_full) ? 'best_version_full' : 'best_version'
+}
+
+function getSubscribeConfigMode(config?: SubscribeConfig): SubscribeMode {
+  return getSubscribeMode({
+    best_version: config?.best_version,
+    best_version_full: config?.best_version_full,
+  })
 }
 
 function getModeName(t: ReturnType<typeof useI18n>['t'], mode: SubscribeMode) {
@@ -161,9 +174,10 @@ export function useMediaSubscribe(options: UseMediaSubscribeOptions) {
     )
   }
 
-  function openSubscribeSeasonDialog(selectedSeason?: number | null) {
+  async function openSubscribeSeasonDialog(selectedSeason?: number | null) {
     const media = currentMedia()
     if (!media) return
+    const defaultSubscribeConfig = await queryDefaultSubscribeConfig()
 
     openSharedDialog(
       SubscribeSeasonDialog,
@@ -172,6 +186,7 @@ export function useMediaSubscribe(options: UseMediaSubscribeOptions) {
         selectedSeason,
         subscribedSeasons: options.subscribedSeasons?.value ?? [],
         subscribedSeasonModes: options.subscribedSeasonModes?.value ?? {},
+        defaultSubscribeMode: getSubscribeConfigMode(defaultSubscribeConfig),
       },
       {
         subscribe: subscribeSeasons,
@@ -180,8 +195,8 @@ export function useMediaSubscribe(options: UseMediaSubscribeOptions) {
     )
   }
 
-  async function queryDefaultSubscribeConfig() {
-    if (!options.canSubscribe()) return false
+  async function queryDefaultSubscribeConfig(): Promise<SubscribeConfig | undefined> {
+    if (!options.canSubscribe()) return undefined
 
     try {
       const media = currentMedia()
@@ -191,12 +206,12 @@ export function useMediaSubscribe(options: UseMediaSubscribeOptions) {
           : 'system/setting/public/DefaultTvSubscribeConfig'
       const result: { [key: string]: any } = await api.get(subscribeConfigUrl)
 
-      if (result.data?.value) return result.data.value.show_edit_dialog
+      return result.data?.value
     } catch (error) {
       console.log(error)
     }
 
-    return false
+    return undefined
   }
 
   function showSubscribeAddToast(
@@ -242,8 +257,8 @@ export function useMediaSubscribe(options: UseMediaSubscribeOptions) {
       showSubscribeAddToast(result.success, media.title ?? '', season, result.message, payload.best_version ?? 0)
 
       if (result.success && (addOptions.openEditDialog ?? true)) {
-        const showEditDialog = await queryDefaultSubscribeConfig()
-        if (showEditDialog) openSubscribeEditDialog(result.data.id)
+        const subscribeConfig = await queryDefaultSubscribeConfig()
+        if (subscribeConfig?.show_edit_dialog) openSubscribeEditDialog(result.data.id)
       }
     } catch (error) {
       console.error(error)

--- a/src/locales/en-US.ts
+++ b/src/locales/en-US.ts
@@ -2824,10 +2824,10 @@ export default {
     },
     subscribeMode: {
       title: 'Choose Subscription Type',
-      normal: 'Subscribe',
+      normal: 'Normal',
       bestVersion: 'Version Upgrade',
-      bestVersionEpisode: 'Episode Upgrade',
-      bestVersionFull: 'Full Season Upgrade',
+      bestVersionEpisode: 'Episode',
+      bestVersionFull: 'Full',
     },
     subscribeEdit: {
       titleDefault: 'Default Subscription Rules',


### PR DESCRIPTION
### **User description**
## 变更说明

- 电视剧季订阅弹窗读取默认订阅配置：未入库或部分入库季默认使用后端默认订阅模式，完整入库季默认选中全集洗版。
- 季订阅模式切换按钮优化英文展示：英文标签改为 `Normal` / `Episode` / `Full`，并放宽按钮组最大宽度，避免英文文案或右侧边框被裁切。

## 影响路径

- `src/composables/useMediaSubscribe.ts`
- `src/components/dialog/SubscribeSeasonDialog.vue`
- `src/locales/en-US.ts`

## 验证

- `yarn typecheck` 通过
- `yarn build` 通过
- `git diff --check` 通过
- `yarn lint` 未通过：当前仓库 `type: module` 下 ESLint 9 将 `.eslintrc.js` 作为 ESM 载入，`module.exports` 报 `module is not defined`，属于仓库 ESLint 配置兼容问题
- 已在本地前端页面验证季订阅模式按钮组右侧边框不再被裁切

本 PR 为 Codex 协作提交


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- 优化季订阅默认模式

- 读取后端默认订阅配置

- 保留用户手动选择

- 简化英文模式文案


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SubscribeSeasonDialog.vue</strong><dd><code>优化季订阅弹窗默认模式</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/dialog/SubscribeSeasonDialog.vue

<ul><li>新增 <code>defaultSubscribeMode</code> 属性接收后端默认模式<br> <li> 根据入库缺失状态计算季默认订阅模式<br> <li> 记录用户手动选择，避免异步刷新覆盖<br> <li> 放宽模式按钮组宽度避免英文裁切</ul>


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot-Frontend/pull/503/files#diff-3e007bcc9f75a7f612c612db38ee336633f841e5ddfe2ec4c433373e558abc89">+22/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useMediaSubscribe.ts</strong><dd><code>读取并传递默认订阅配置</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/composables/useMediaSubscribe.ts

<ul><li>新增订阅默认配置类型与模式解析<br> <li> 打开季订阅弹窗前查询默认订阅配置<br> <li> 将后端默认模式传入季订阅弹窗<br> <li> 保留编辑弹窗开关逻辑并改用配置对象</ul>


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot-Frontend/pull/503/files#diff-24dca4a89ca7192b46599494bbf5c707dfdfb5f9f35c0ac0ccd69b06759d0fc7">+22/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>en-US.ts</strong><dd><code>简化英文订阅模式标签</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/locales/en-US.ts

- 将英文普通订阅标签改为 `Normal`
- 将逐集洗版标签缩短为 `Episode`
- 将全集洗版标签缩短为 `Full`


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot-Frontend/pull/503/files#diff-80c655475e715e348c0200ab7e6e93c8a53af6adaab32692b47555ee33daf59a">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

