### PR TITLE
fix(theme): stabilize transparent background transitions

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -25,6 +25,7 @@ import { applyDocumentThemeChrome, resolveThemeName } from '@/utils/themePalette
 import { configureApexChartsTheme } from '@/utils/apexCharts'
 
 const LOGIN_WALLPAPER_ROUTE = '/login'
+const BACKGROUND_CROSSFADE_DURATION_MS = 1500
 
 // 生效主题
 const vuetifyTheme = useTheme()
@@ -64,6 +65,7 @@ const loginStateKey = computed(() => (isLogin.value ? 'logged-in' : 'logged-out'
 // 背景图片
 const backgroundImages = ref<string[]>([])
 const activeImageIndex = ref(0)
+const previousImageIndex = ref<number | null>(null)
 const isTransparentTheme = computed(() => globalTheme.name.value === 'transparent')
 const isLoginWallpaperRoute = computed(() => !isLogin.value && route.path === LOGIN_WALLPAPER_ROUTE)
 const shouldUseTransparentBackgroundTreatment = computed(
@@ -84,6 +86,7 @@ const shouldRenderGlobalBlurLayer = computed(
 )
 let backgroundRetryTimer: number | null = null
 let backgroundRequestController: AbortController | null = null
+let backgroundCrossfadeTimer: number | null = null
 let authenticatedStateTimer: number | null = null
 
 function applyTransparentBackgroundSettings() {
@@ -179,6 +182,31 @@ function handlePageShowThemeSync() {
   syncThemePreferenceFromStorage()
 }
 
+function clearBackgroundCrossfadeTimer() {
+  if (backgroundCrossfadeTimer) {
+    window.clearTimeout(backgroundCrossfadeTimer)
+    backgroundCrossfadeTimer = null
+  }
+}
+
+function resetBackgroundCrossfade() {
+  clearBackgroundCrossfadeTimer()
+  previousImageIndex.value = null
+}
+
+// 切换期保留上一张背景的渲染状态，避免图片合成层重建时露出透明底。
+function activateBackgroundImage(nextIndex: number) {
+  if (nextIndex === activeImageIndex.value) return
+
+  clearBackgroundCrossfadeTimer()
+  previousImageIndex.value = activeImageIndex.value
+  activeImageIndex.value = nextIndex
+  backgroundCrossfadeTimer = window.setTimeout(() => {
+    previousImageIndex.value = null
+    backgroundCrossfadeTimer = null
+  }, BACKGROUND_CROSSFADE_DURATION_MS)
+}
+
 // 获取背景图片
 async function fetchBackgroundImages() {
   try {
@@ -187,6 +215,7 @@ async function fetchBackgroundImages() {
     backgroundImages.value = await api.get(`/login/wallpapers`, {
       signal: backgroundRequestController.signal,
     })
+    resetBackgroundCrossfade()
     activeImageIndex.value = 0
   } catch (e) {
     throw e
@@ -202,7 +231,7 @@ function rotateBackgroundImage() {
     preloadImage(backgroundImages.value[nextIndex]).then(success => {
       // 只有图片成功加载才切换
       if (success) {
-        activeImageIndex.value = nextIndex
+        activateBackgroundImage(nextIndex)
       }
     })
   }
@@ -236,6 +265,7 @@ function stopBackgroundLoading() {
     backgroundRetryTimer = null
   }
 
+  resetBackgroundCrossfade()
   removeBackgroundTimer('background-rotation')
 }
 
@@ -449,7 +479,7 @@ onUnmounted(() => {
         v-for="(imageUrl, index) in backgroundImages"
         :key="`bg-${index}-${loginStateKey}`"
         class="background-image"
-        :class="{ 'active': index === activeImageIndex }"
+        :class="{ 'active': index === activeImageIndex, 'previous': index === previousImageIndex }"
         :style="{ 'backgroundImage': `url(${imageUrl})` }"
       />
       <!-- 全局磨砂层 -->
@@ -507,7 +537,12 @@ onUnmounted(() => {
   }
 
   &.active {
+    z-index: 2;
     opacity: 1;
+  }
+
+  &.previous {
+    z-index: 1;
   }
 }
 
@@ -515,12 +550,14 @@ onUnmounted(() => {
   opacity: var(--transparent-background-poster-opacity, 1);
 }
 
-.background-container.is-transparent-glass-lightweight .background-image.active {
+.background-container.is-transparent-glass-lightweight .background-image.active,
+.background-container.is-transparent-glass-lightweight .background-image.previous {
   filter: blur(var(--transparent-background-blur, 16px));
   transform: scale(1.03);
 }
 
-.background-container.is-transparent-glass-lightweight .background-image.active::after {
+.background-container.is-transparent-glass-lightweight .background-image.active::after,
+.background-container.is-transparent-glass-lightweight .background-image.previous::after {
   background:
     linear-gradient(rgba(0, 0, 0, 30%) 0%, rgba(0, 0, 0, 60%) 100%),
     rgba(128, 128, 128, 30%);
@@ -529,7 +566,7 @@ onUnmounted(() => {
 /* 全局磨砂层 */
 .global-blur-layer {
   position: absolute;
-  z-index: 1;
+  z-index: 3;
   backdrop-filter: blur(var(--transparent-background-blur, 16px));
   background-color: rgba(128, 128, 128, 30%);
   block-size: 100%;


### PR DESCRIPTION
### **User description**
## 变更说明

- 背景轮播切换时保留上一张背景图作为 `previous` 层，待新图淡入完成后再释放，避免透明主题背景切换瞬间露出透明底。
- 轻量级毛玻璃模式下，切换期间的上一张背景图继续沿用当前背景 blur、scale 和遮罩处理，避免 crossfade 两层之间视觉处理不一致。
- 将实时毛玻璃层 `.global-blur-layer` 的内部层级从 `z-index: 1` 调整为 `z-index: 3`，确保它在新增的 active 背景层之上。

## 为什么这样设计

背景切换前只有一张 active 背景图，实时毛玻璃层位于其上方即可。加入 crossfade 后，背景容器内部会同时存在上一张图和当前图，因此需要明确内部层级：

- previous background: `z-index: 1`
- active background: `z-index: 2`
- realtime `.global-blur-layer`: `z-index: 3`

这样可以保证 active 背景图淡入时不会盖住实时毛玻璃层，实时模式仍然保持“背景图在下、毛玻璃层在上”的叠放关系。

这个 `z-index` 调整只发生在 `.background-container` 内部。`.background-container` 自身仍是固定背景层，位于应用内容层之下；页面内容、Footer、QuickAccess、菜单、弹窗等不在该背景容器内，不会因为这次内部层级调整被覆盖或改变全局层级。轻量级模式下 `.global-blur-layer` 不参与渲染，因此该 z-index 调整对轻量级模式没有额外影响。

## 影响路径

- `src/App.vue`

## 验证

- `yarn typecheck` 通过
- `yarn build` 通过
- `git diff --check` 通过
- `yarn lint` 未进入代码检查：当前仓库使用 ESLint 9，加载 `.eslintrc.js` 时受 `package.json` 的 `type: module` 影响，报 `module is not defined in ES module scope`

本 PR 为 Codex 协作提交


___

### **PR Type**
Bug fix


___

### **Description**
- 保留上一背景完成交叉淡入

- 加载停止重置过渡状态

- 统一轻量毛玻璃过渡样式

- 调整背景与磨砂层级


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>App.vue</strong><dd><code>稳定透明背景交叉淡入层级</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/App.vue

<ul><li>新增 <code>previousImageIndex</code> 和交叉淡入计时器，切换时保留上一张背景图。<br> <li> 通过 <code>activateBackgroundImage</code> 控制轮播切换，并在获取或停止加载时重置过渡状态。<br> <li> 为上一背景层添加 <code>previous</code> 类和层级，避免透明主题切换露底。<br> <li> 让轻量毛玻璃样式覆盖 <code>previous</code> 层，并提高 <code>.global-blur-layer</code> 层级。</ul>


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot-Frontend/pull/509/files#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0">+42/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

