### PR TITLE
fix(auth): decouple webpush subscription from login

### DIFF
--- a/src/pages/login.vue
+++ b/src/pages/login.vue
@@ -469,26 +469,27 @@ async function switchLanguage(locale: SupportedLocale) {
 
 // 订阅推送通知
 async function subscribeForPushNotifications() {
-  if ('serviceWorker' in navigator && 'PushManager' in window) {
+  if (!('serviceWorker' in navigator) || !('PushManager' in window)) return
+
+  try {
     const registration = await navigator.serviceWorker.ready
-    // 获取订阅信息
-    const subscription = await registration.pushManager.getSubscription().then(function (subscription) {
-      if (subscription === null) {
-        const convertedVapidKey = urlBase64ToUint8Array(import.meta.env.VITE_PUBLIC_VAPID_KEY)
-        return registration.pushManager.subscribe({
-          userVisibleOnly: true,
-          applicationServerKey: convertedVapidKey,
-        })
-      } else {
-        return subscription
-      }
-    })
-    // 发送订阅请求
-    try {
-      await api.post('/message/webpush/subscribe', subscription)
-    } catch (e) {
-      console.error(e)
+    let subscription = await registration.pushManager.getSubscription()
+
+    if (!subscription) {
+      if (typeof Notification !== 'undefined' && Notification.permission !== 'granted') return
+
+      const convertedVapidKey = urlBase64ToUint8Array(import.meta.env.VITE_PUBLIC_VAPID_KEY)
+      subscription = await registration.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey: convertedVapidKey,
+      })
     }
+
+    if (subscription) {
+      await api.post('/message/webpush/subscribe', subscription)
+    }
+  } catch (error) {
+    console.warn('WebPush subscription failed:', error)
   }
 }
 
@@ -508,7 +509,7 @@ async function afterLogin(superuser: boolean, userPayload: userState, filteredMe
   }
 
   // 订阅推送通知
-  if (superuser) await subscribeForPushNotifications()
+  if (superuser) void subscribeForPushNotifications()
 }
 
 // 处理登录成功


### PR DESCRIPTION
### **User description**
## 变更说明

修正登录成功后，登录页可能短暂显示“登录失败”再进入 Dashboard 的问题。

根因是登录成功后的 WebPush 订阅属于后置副作用，但原流程会在 `afterLogin()` 中 `await subscribeForPushNotifications()`。当浏览器通知权限被拒绝、Service Worker/PushManager 状态异常、VAPID 配置或订阅接口失败时，异常会继续冒泡到登录请求的 `catch`，导致前端误把已经成功写入 token 并跳转的登录流程标记为失败。

本 PR 将 WebPush 订阅改为登录成功后的 best-effort 后台流程：

- 登录成功流程不再等待 WebPush 订阅完成，避免通知订阅失败污染登录结果；
- WebPush 内部自行捕获异常并输出 warning；
- 保留已有订阅的上报逻辑；
- 仅在通知权限已授权时创建新订阅，避免权限未授权或被拒绝时触发异常链路。

## 影响路径

- `src/pages/login.vue`

## 验证

- `yarn typecheck` 通过
- `yarn build` 通过
- `git diff --check` 通过
- 静态断言通过：WebPush 不再被登录成功流程 await，且创建新订阅前会检查通知权限
- `yarn lint` 未完成：当前 ESLint 配置在 `"type": "module"` 项目下以 `.eslintrc.js` 加载 CommonJS `module.exports` 时失败，未进入代码 lint 阶段

本 PR 为 Codex 协作提交


___

### **PR Type**
Bug fix


___

### **Description**
- 登录不再等待 WebPush 订阅

- 捕获订阅异常并记录警告

- 未授权通知时跳过新订阅

- 保留已有订阅上报


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>login.vue</strong><dd><code>WebPush 订阅与登录流程解耦</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/pages/login.vue

<ul><li>缺少 Service Worker 或 PushManager 时直接返回<br> <li> WebPush 订阅全流程捕获异常并警告<br> <li> 仅通知权限已授权时创建新订阅<br> <li> 登录成功后异步触发订阅流程</ul>


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot-Frontend/pull/510/files#diff-236737c1dd4c90b4b7013221263ad002b0cdddb4716de2ab2829285d1272a538">+19/-18</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

