### PR TITLE
perf(app): throttle inactive realtime blur rendering

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -26,6 +26,7 @@ import { configureApexChartsTheme } from '@/utils/apexCharts'
 
 const LOGIN_WALLPAPER_ROUTE = '/login'
 const BACKGROUND_CROSSFADE_DURATION_MS = 1500
+const WINDOW_BLUR_RENDER_THROTTLE_DELAY_MS = 180_000
 
 // 生效主题
 const vuetifyTheme = useTheme()
@@ -82,10 +83,12 @@ const shouldRenderGlobalBlurLayer = computed(
     transparentBackgroundBlur.value > 0 &&
     transparencyGlassQuality.value === 'realtime',
 )
+const isRenderThrottled = ref(document.visibilityState === 'hidden')
 let backgroundRetryTimer: number | null = null
 let backgroundRequestController: AbortController | null = null
 let backgroundCrossfadeTimer: number | null = null
 let authenticatedStateTimer: number | null = null
+let windowBlurRenderThrottleTimer: number | null = null
 
 // 读取并同步透明主题背景设置到根组件响应式状态。
 function applyTransparentBackgroundSettings() {
@@ -104,6 +107,52 @@ function handleTransparencySettingsChanged(event: Event) {
 }
 
 applyTransparentBackgroundSettings()
+
+function clearWindowBlurRenderThrottleTimer() {
+  if (windowBlurRenderThrottleTimer) {
+    window.clearTimeout(windowBlurRenderThrottleTimer)
+    windowBlurRenderThrottleTimer = null
+  }
+}
+
+function restoreForegroundRendering() {
+  const wasRenderThrottled = isRenderThrottled.value
+
+  clearWindowBlurRenderThrottleTimer()
+  isRenderThrottled.value = false
+
+  if (wasRenderThrottled && backgroundImages.value.length > 1) {
+    startBackgroundRotation()
+    rotateBackgroundImage()
+  }
+}
+
+function throttleBackgroundRendering() {
+  clearWindowBlurRenderThrottleTimer()
+  resetBackgroundCrossfade()
+  isRenderThrottled.value = true
+}
+
+function handleWindowBlurRenderThrottle() {
+  clearWindowBlurRenderThrottleTimer()
+  if (document.visibilityState === 'hidden') {
+    throttleBackgroundRendering()
+    return
+  }
+
+  windowBlurRenderThrottleTimer = window.setTimeout(() => {
+    if (document.visibilityState === 'visible' && !document.hasFocus()) {
+      isRenderThrottled.value = true
+    }
+    windowBlurRenderThrottleTimer = null
+  }, WINDOW_BLUR_RENDER_THROTTLE_DELAY_MS)
+}
+
+function handleWindowFocusRenderThrottle() {
+  if (document.visibilityState === 'visible') {
+    restoreForegroundRendering()
+  }
+}
 
 // 心跳检测
 let heartbeatInterval: number | null = null
@@ -177,12 +226,18 @@ function handleSystemThemeChange() {
 // 页面重新可见时同步主题，修复后台期间设置被外部修改后的外观漂移。
 function handleVisibilityThemeSync() {
   if (document.visibilityState === 'visible') {
+    restoreForegroundRendering()
     syncThemePreferenceFromStorage()
+  } else {
+    throttleBackgroundRendering()
   }
 }
 
 // 页面从缓存或重新聚焦恢复时刷新主题偏好。
 function handlePageShowThemeSync() {
+  if (document.visibilityState === 'visible') {
+    restoreForegroundRendering()
+  }
   syncThemePreferenceFromStorage()
 }
 
@@ -230,6 +285,8 @@ async function fetchBackgroundImages() {
 
 // 背景图片轮换函数
 function rotateBackgroundImage() {
+  if (isRenderThrottled.value) return
+
   if (backgroundImages.value.length > 1) {
     // 计算下一个图片索引
     const nextIndex = (activeImageIndex.value + 1) % backgroundImages.value.length
@@ -414,6 +471,8 @@ onMounted(async () => {
   document.addEventListener('visibilitychange', handleVisibilityThemeSync)
   window.addEventListener('pageshow', handlePageShowThemeSync)
   window.addEventListener('focus', handlePageShowThemeSync)
+  window.addEventListener('focus', handleWindowFocusRenderThrottle)
+  window.addEventListener('blur', handleWindowBlurRenderThrottle)
   window.addEventListener(TRANSPARENCY_SETTINGS_CHANGED_EVENT, handleTransparencySettingsChanged)
 
   // 登录页壁纸仅在未登录登录页需要，避免其他首屏额外发起图片列表请求。
@@ -461,6 +520,7 @@ onUnmounted(() => {
     window.clearTimeout(authenticatedStateTimer)
     authenticatedStateTimer = null
   }
+  clearWindowBlurRenderThrottleTimer()
   // 停止心跳
   stopHeartbeat()
   prefersColorSchemeMediaQuery?.removeEventListener('change', handleSystemThemeChange)
@@ -468,12 +528,14 @@ onUnmounted(() => {
   document.removeEventListener('visibilitychange', handleVisibilityThemeSync)
   window.removeEventListener('pageshow', handlePageShowThemeSync)
   window.removeEventListener('focus', handlePageShowThemeSync)
+  window.removeEventListener('focus', handleWindowFocusRenderThrottle)
+  window.removeEventListener('blur', handleWindowBlurRenderThrottle)
   window.removeEventListener(TRANSPARENCY_SETTINGS_CHANGED_EVENT, handleTransparencySettingsChanged)
 })
 </script>
 
 <template>
-  <div class="app-wrapper">
+  <div class="app-wrapper" :class="{ 'app-wrapper--render-throttled': isRenderThrottled }">
     <!-- 透明主题背景 -->
     <div
       v-if="backgroundImages.length > 0 && (isTransparentTheme || !isLogin)"
@@ -582,6 +644,22 @@ onUnmounted(() => {
   inline-size: 100%;
   inset-block-start: 0;
   inset-inline-start: 0;
+}
+
+.app-wrapper--render-throttled {
+  .global-blur-layer {
+    backdrop-filter: none;
+  }
+
+  .login-bg-decor *,
+  .login-logo,
+  .login-logo-wrapper,
+  .login-logo-wrapper::before,
+  .login-title,
+  .login-subtitle,
+  .agent-assistant-fab * {
+    animation-play-state: paused !important;
+  }
 }
 
 /* 登录页壁纸在 VApp 外层渲染，登录页 VApp 需要透明才能露出壁纸。 */


### PR DESCRIPTION
### **User description**
## 变更说明

透明主题的实时毛玻璃会在窗口可见但 Chrome 不是前台应用时继续保持较高渲染成本。本 PR 为这类非前台场景增加轻量节流：

- 页面进入 `hidden` 时立即降低高成本渲染。
- 窗口失焦但页面仍可见时，延迟 3 分钟后进入节流。
- 窗口重新聚焦、页面重新可见或从 bfcache 恢复时立即恢复前台渲染。
- 节流期间关闭全局实时背景毛玻璃层的 `backdrop-filter`，保留背景灰色覆盖层，降低体感突变。
- 节流期间跳过背景图轮换，并暂停登录页装饰与助手入口的装饰动画。
- 恢复前台时重启背景轮换节奏，并补触发一次背景切换，避免恢复后轮播长时间停在旧帧。

## 设计原因

这个场景和 `document.visibilityState === hidden` 不同：页面仍在可见窗口中，浏览器不会自动把页面视为后台页，但用户已经不在当前 Chrome 窗口操作。实时毛玻璃和背景轮换仍可能持续触发合成和 GPU 工作。

本实现只处理成本较高、且非前台时不必保持实时的部分，避免扩大影响面：

- 不关闭登录框局部毛玻璃，避免破坏登录页玻璃质感。
- 不禁用普通卡片、弹窗或页面级过渡，避免影响恢复后的交互体感。
- 不改变轻量毛玻璃和普通透明主题规则。
- 使用 3 分钟延迟，避免短暂切换应用时频繁降级，同时对较长时间非前台停留提供节流。

## 影响路径

- `src/App.vue`

## 验证

- `git diff --check`
- `yarn typecheck`
- `yarn build`
- 已通过浏览器调试验证登录后的推荐页：实时透明主题下，节流后全局 blur 层的 `backdrop-filter` 变为 `none`；窗口重新聚焦后恢复为实时 blur，并立即恢复背景轮换。

`yarn lint` 当前未通过，失败发生在仓库现有 ESLint 配置加载阶段：项目声明为 ESM，但 `.eslintrc.js` 使用 CommonJS `module.exports`，ESLint 9 加载配置时报 `module is not defined`。该失败发生在代码检查开始前，且本次运行没有产生额外文件改动。

本 PR 为 Codex 协作提交


___

### **PR Type**
Enhancement


___

### **Description**
- 节流非前台实时渲染

- 隐藏时立即降级

- 失焦三分钟后节流

- 恢复时重启背景轮播


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>App.vue</strong><dd><code>节流非前台背景渲染</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/App.vue

<ul><li>新增窗口失焦渲染节流状态与定时器<br> <li> 页面隐藏时立即关闭高成本渲染<br> <li> 前台恢复时重启并触发背景轮换<br> <li> 节流态关闭全局模糊并暂停装饰动画</ul>


</details>


  </td>
  <td><a href="https://github.com/jxxghp/MoviePilot-Frontend/pull/511/files#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0">+79/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

