### PR TITLE
新增搜索结果磁力探测按钮

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -800,6 +800,14 @@ export interface TorrentInfo {
   freedate_diff: string
   // 种子类型
   category: string
+  // 磁力探测状态
+  probe_state?: string
+  // 磁力探测是否拿到元数据
+  probe_has_metadata?: boolean
+  // 磁力探测是否超时
+  probe_timed_out?: boolean
+  // 磁力探测可用性
+  probe_availability?: number
 }
 
 // 字幕信息

--- a/src/locales/en-US.ts
+++ b/src/locales/en-US.ts
@@ -1247,6 +1247,13 @@ export default {
     reRecommend: 'Regenerate Recommendation',
     aiRecommendError: 'AI Recommendation Failed',
     refreshSearch: 'Re-search',
+    probeResources: 'Probe {count} resources',
+    noProbeNeeded: 'No probe needed',
+    probing: 'Probing {done}/{total}',
+    probeStopping: 'Stopping {done}/{total}',
+    noProbeCandidates: 'No magnet links need probing in the current filtered results',
+    probeFinished: 'Probe completed: {done}/{total}',
+    probeStopped: 'Probe stopped: {done}/{total}',
   },
   browse: {
     actor: 'Actor',

--- a/src/locales/en-US.ts
+++ b/src/locales/en-US.ts
@@ -1253,6 +1253,7 @@ export default {
     probeStopping: 'Stopping {done}/{total}',
     noProbeCandidates: 'No magnet links need probing in the current filtered results',
     probeFinished: 'Probe completed: {done}/{total}',
+    probeFinishedWithFailed: 'Probe completed: {done}/{total}, {failed} failed',
     probeStopped: 'Probe stopped: {done}/{total}',
   },
   browse: {

--- a/src/locales/zh-CN.ts
+++ b/src/locales/zh-CN.ts
@@ -1240,6 +1240,13 @@ export default {
     reRecommend: '重新生成推荐',
     aiRecommendError: '智能推荐失败',
     refreshSearch: '重新搜索',
+    probeResources: '探测 {count} 个资源',
+    noProbeNeeded: '无需探测',
+    probing: '探测 {done}/{total}',
+    probeStopping: '终止中 {done}/{total}',
+    noProbeCandidates: '当前筛选结果没有需要探测的磁力链接',
+    probeFinished: '探测完成：{done}/{total}',
+    probeStopped: '探测已终止：{done}/{total}',
   },
   browse: {
     actor: '演员',

--- a/src/locales/zh-CN.ts
+++ b/src/locales/zh-CN.ts
@@ -1246,6 +1246,7 @@ export default {
     probeStopping: '终止中 {done}/{total}',
     noProbeCandidates: '当前筛选结果没有需要探测的磁力链接',
     probeFinished: '探测完成：{done}/{total}',
+    probeFinishedWithFailed: '探测完成：{done}/{total}，失败 {failed} 个',
     probeStopped: '探测已终止：{done}/{total}',
   },
   browse: {

--- a/src/locales/zh-TW.ts
+++ b/src/locales/zh-TW.ts
@@ -1244,6 +1244,7 @@ export default {
     probeStopping: '終止中 {done}/{total}',
     noProbeCandidates: '當前篩選結果沒有需要探測的磁力鏈接',
     probeFinished: '探測完成：{done}/{total}',
+    probeFinishedWithFailed: '探測完成：{done}/{total}，失敗 {failed} 個',
     probeStopped: '探測已終止：{done}/{total}',
   },
   browse: {

--- a/src/locales/zh-TW.ts
+++ b/src/locales/zh-TW.ts
@@ -1238,6 +1238,13 @@ export default {
     reRecommend: '重新生成推薦',
     aiRecommendError: '智能推薦失敗',
     refreshSearch: '重新搜尋',
+    probeResources: '探測 {count} 個資源',
+    noProbeNeeded: '無需探測',
+    probing: '探測 {done}/{total}',
+    probeStopping: '終止中 {done}/{total}',
+    noProbeCandidates: '當前篩選結果沒有需要探測的磁力鏈接',
+    probeFinished: '探測完成：{done}/{total}',
+    probeStopped: '探測已終止：{done}/{total}',
   },
   browse: {
     actor: '演員',

--- a/src/pages/resource.vue
+++ b/src/pages/resource.vue
@@ -66,6 +66,7 @@ interface LastSearchContextResponse {
 
 interface TorrentProbeResponse {
   success?: boolean
+  message?: string
   data?: TorrentProbeResult
 }
 
@@ -423,7 +424,7 @@ const probeButtonText = computed(() => {
 
 function patchProbeContext(item: Context | SearchTorrent, enclosure: string, result: TorrentProbeResult) {
   const torrentInfo = item?.torrent_info
-  if (torrentInfo?.enclosure === enclosure) {
+  if (torrentInfo?.enclosure === enclosure && needsTorrentProbe(torrentInfo)) {
     applyTorrentProbeResult(torrentInfo, result)
   }
 
@@ -454,10 +455,10 @@ function stopTorrentProbe() {
   probeAbortControllers.clear()
 }
 
-async function probeTorrentItem(item: Context) {
+async function probeTorrentItem(item: Context): Promise<boolean> {
   const torrentInfo = item.torrent_info
   const enclosure = torrentInfo?.enclosure
-  if (!enclosure) return
+  if (!enclosure) return false
 
   const controller = new AbortController()
   const config: ConnectionAwareRequestConfig = {
@@ -478,6 +479,10 @@ async function probeTorrentItem(item: Context) {
     )) as TorrentProbeResponse
     if (!probeStopRequested.value && result?.success && result.data) {
       applyProbeResult(enclosure, result.data as TorrentProbeResult)
+      return true
+    }
+    if (!probeStopRequested.value) {
+      console.warn('磁力探测失败:', result?.message || result)
     }
   } catch (error) {
     if (!probeStopRequested.value) {
@@ -486,6 +491,7 @@ async function probeTorrentItem(item: Context) {
   } finally {
     probeAbortControllers.delete(controller)
   }
+  return false
 }
 
 async function probeFilteredResults() {
@@ -507,14 +513,16 @@ async function probeFilteredResults() {
 
   let cursor = 0
   let done = 0
+  let failed = 0
   const worker = async () => {
     while (!probeStopRequested.value) {
       const currentIndex = cursor
       cursor += 1
       if (currentIndex >= items.length) return
 
-      await probeTorrentItem(items[currentIndex])
+      const succeeded = await probeTorrentItem(items[currentIndex])
       done += 1
+      if (!succeeded && !probeStopRequested.value) failed += 1
       probeDone.value = done
     }
   }
@@ -522,10 +530,13 @@ async function probeFilteredResults() {
   try {
     await Promise.all(Array.from({ length: Math.min(probeConcurrency, items.length) }, worker))
     applyFilter()
-    const messageKey = probeStopRequested.value ? 'resource.probeStopped' : 'resource.probeFinished'
-    const message = t(messageKey, { done, total: items.length })
-    if (probeStopRequested.value) toast.info(message)
-    else toast.success(message)
+    if (probeStopRequested.value) {
+      toast.info(t('resource.probeStopped', { done, total: items.length }))
+    } else if (failed > 0) {
+      toast.warning(t('resource.probeFinishedWithFailed', { done, total: items.length, failed }))
+    } else {
+      toast.success(t('resource.probeFinished', { done, total: items.length }))
+    }
   } finally {
     probeAbortControllers.clear()
     probeLoading.value = false

--- a/src/pages/resource.vue
+++ b/src/pages/resource.vue
@@ -2,7 +2,7 @@
 import { debounce } from 'lodash-es'
 import type { LocationQuery } from 'vue-router'
 import NoDataFound from '@/components/states/NoDataFound.vue'
-import api from '@/api'
+import api, { type ConnectionAwareRequestConfig } from '@/api'
 import type { Context, SubtitleInfo } from '@/api/types'
 import TorrentCard from '@/components/cards/TorrentCard.vue'
 import TorrentItem from '@/components/cards/TorrentItem.vue'
@@ -20,6 +20,7 @@ import { useKeepAliveRefresh } from '@/composables/useKeepAliveRefresh'
 import { useUserStore } from '@/stores'
 import { buildUserPermissionContext, hasPermission } from '@/utils/permission'
 import { getCurrentLocale } from '@/plugins/i18n'
+import { applyTorrentProbeResult, needsTorrentProbe, type TorrentProbeResult } from '@/utils/torrentProbe'
 
 // 国际化
 const { t } = useI18n()
@@ -61,6 +62,11 @@ interface LastSearchContextResponse {
     params?: Partial<SearchParams>
     results?: Array<Context | SubtitleInfo>
   }
+}
+
+interface TorrentProbeResponse {
+  success?: boolean
+  data?: TorrentProbeResult
 }
 
 const resourceSearchParamsStorageKey = 'MP_ResourceSearchParams'
@@ -271,6 +277,15 @@ useDynamicButton({
 // 是否正在重新搜索
 const isRefreshing = ref(false)
 
+// 磁力探测
+const probeConcurrency = 16
+const probeTimeoutSeconds = 30
+const probeLoading = ref(false)
+const probeStopRequested = ref(false)
+const probeDone = ref(0)
+const probeTotal = ref(0)
+const probeAbortControllers = new Set<AbortController>()
+
 // 加载进度文本
 const progressText = ref(t('common.pleaseWait'))
 
@@ -365,6 +380,156 @@ function applyFilter() {
     filteredRowDataList.value = torrentFilter.filterRowData(rawDataList.value)
   } else {
     filteredCardDataList.value = torrentFilter.filterCardData(rawDataList.value)
+  }
+}
+
+function flattenProbeCandidates(items: Array<Context | SearchTorrent>): Array<Context> {
+  const candidates: Array<Context> = []
+  const seen = new Set<string>()
+
+  for (const item of items || []) {
+    const itemCandidates = [item, ...((item as SearchTorrent).more || [])]
+    for (const candidate of itemCandidates) {
+      const enclosure = candidate?.torrent_info?.enclosure
+      if (!needsTorrentProbe(candidate?.torrent_info) || !enclosure || seen.has(enclosure)) continue
+
+      seen.add(enclosure)
+      candidates.push(candidate)
+    }
+  }
+
+  return candidates
+}
+
+function collectProbeItems() {
+  const sourceItems = viewType.value === 'row' ? filteredRowDataList.value : filteredCardDataList.value
+  return flattenProbeCandidates(sourceItems)
+}
+
+const probeCount = computed(() => collectProbeItems().length)
+const canShowProbeButton = computed(() => !isSubtitleSearch.value && isRefreshed.value && !progressActive.value)
+
+const probeButtonText = computed(() => {
+  if (probeLoading.value) {
+    return probeStopRequested.value
+      ? t('resource.probeStopping', { done: probeDone.value, total: probeTotal.value })
+      : t('resource.probing', { done: probeDone.value, total: probeTotal.value })
+  }
+
+  return probeCount.value > 0
+    ? t('resource.probeResources', { count: probeCount.value })
+    : t('resource.noProbeNeeded')
+})
+
+function patchProbeContext(item: Context | SearchTorrent, enclosure: string, result: TorrentProbeResult) {
+  const torrentInfo = item?.torrent_info
+  if (torrentInfo?.enclosure === enclosure) {
+    applyTorrentProbeResult(torrentInfo, result)
+  }
+
+  const moreItems = (item as SearchTorrent).more
+  if (Array.isArray(moreItems)) {
+    moreItems.forEach(moreItem => patchProbeContext(moreItem, enclosure, result))
+  }
+}
+
+function applyProbeResult(enclosure: string, result: TorrentProbeResult) {
+  const collections: Array<Array<Context | SearchTorrent>> = [
+    rawDataList.value,
+    originalDataList.value,
+    aiRecommendedList.value,
+    filteredRowDataList.value,
+    filteredCardDataList.value,
+    streamPreviewDataList.value,
+  ]
+
+  collections.forEach(items => {
+    items.forEach(item => patchProbeContext(item, enclosure, result))
+  })
+}
+
+function stopTorrentProbe() {
+  probeStopRequested.value = true
+  probeAbortControllers.forEach(controller => controller.abort())
+  probeAbortControllers.clear()
+}
+
+async function probeTorrentItem(item: Context) {
+  const torrentInfo = item.torrent_info
+  const enclosure = torrentInfo?.enclosure
+  if (!enclosure) return
+
+  const controller = new AbortController()
+  const config: ConnectionAwareRequestConfig = {
+    signal: controller.signal,
+    skipConnectionTracking: true,
+  }
+  probeAbortControllers.add(controller)
+
+  try {
+    const result = (await api.post(
+      'search/probe',
+      {
+        enclosure,
+        downloader: torrentInfo.site_downloader,
+        timeout: probeTimeoutSeconds,
+      },
+      config,
+    )) as TorrentProbeResponse
+    if (!probeStopRequested.value && result?.success && result.data) {
+      applyProbeResult(enclosure, result.data as TorrentProbeResult)
+    }
+  } catch (error) {
+    if (!probeStopRequested.value) {
+      console.warn('磁力探测失败:', error)
+    }
+  } finally {
+    probeAbortControllers.delete(controller)
+  }
+}
+
+async function probeFilteredResults() {
+  if (probeLoading.value) {
+    stopTorrentProbe()
+    return
+  }
+
+  const items = collectProbeItems()
+  if (!items.length) {
+    toast.info(t('resource.noProbeCandidates'))
+    return
+  }
+
+  probeStopRequested.value = false
+  probeLoading.value = true
+  probeDone.value = 0
+  probeTotal.value = items.length
+
+  let cursor = 0
+  let done = 0
+  const worker = async () => {
+    while (!probeStopRequested.value) {
+      const currentIndex = cursor
+      cursor += 1
+      if (currentIndex >= items.length) return
+
+      await probeTorrentItem(items[currentIndex])
+      done += 1
+      probeDone.value = done
+    }
+  }
+
+  try {
+    await Promise.all(Array.from({ length: Math.min(probeConcurrency, items.length) }, worker))
+    applyFilter()
+    const messageKey = probeStopRequested.value ? 'resource.probeStopped' : 'resource.probeFinished'
+    const message = t(messageKey, { done, total: items.length })
+    if (probeStopRequested.value) toast.info(message)
+    else toast.success(message)
+  } finally {
+    probeAbortControllers.clear()
+    probeLoading.value = false
+    probeStopRequested.value = false
   }
 }
 
@@ -583,6 +748,7 @@ function buildSearchStreamUrl(params: SearchParams, requestToken?: string) {
 
 // 重置搜索结果
 function resetSearchResults() {
+  stopTorrentProbe()
   clearStreamPreviewState(true)
   // 新搜索开始时先回到未完成态，避免上一轮空态在 SSE 返回前抢先显示。
   isRefreshed.value = false
@@ -1289,6 +1455,7 @@ useKeepAliveRefresh(async () => {
 
 // 卸载时停止轮询
 onUnmounted(() => {
+  stopTorrentProbe()
   closeSearchEventSource()
   stopLoadingProgress()
   clearProgressResetTimer()
@@ -1386,6 +1553,25 @@ onUnmounted(() => {
             {{ t('resource.refreshSearch') }}
           </VTooltip>
         </IconBtn>
+
+        <VBtn
+          v-if="canShowProbeButton"
+          variant="tonal"
+          :color="probeLoading ? 'error' : 'secondary'"
+          :disabled="!probeLoading && probeCount <= 0"
+          size="small"
+          height="40"
+          class="ai-action-group__primary"
+          @click="probeFilteredResults"
+        >
+          <template #prepend>
+            <VIcon :icon="probeLoading ? 'mdi-stop' : 'mdi-radar'" size="18" />
+          </template>
+          <span class="ai-action-group__label">{{ probeButtonText }}</span>
+          <VTooltip activator="parent" location="top">
+            {{ probeButtonText }}
+          </VTooltip>
+        </VBtn>
 
         <!-- AI操作按钮组 -->
         <div

--- a/src/utils/torrentProbe.ts
+++ b/src/utils/torrentProbe.ts
@@ -1,0 +1,65 @@
+import type { TorrentInfo } from '@/api/types'
+
+export interface TorrentProbeResult {
+  size?: number
+  seeders?: number
+  peers?: number
+  state?: string
+  has_metadata?: boolean
+  timed_out?: boolean
+  availability?: number
+}
+
+function toFiniteNumber(value: unknown): number | undefined {
+  if (typeof value === 'number') return Number.isFinite(value) ? value : undefined
+
+  if (typeof value === 'string' && value.trim()) {
+    const numberValue = Number(value)
+    return Number.isFinite(numberValue) ? numberValue : undefined
+  }
+
+  return undefined
+}
+
+export function isMagnetLink(value?: string | null): boolean {
+  return Boolean(value?.toLowerCase().startsWith('magnet:'))
+}
+
+export function needsTorrentProbe(torrent?: Partial<TorrentInfo> | null): boolean {
+  if (!isMagnetLink(torrent?.enclosure)) return false
+
+  const hasProbeResult =
+    torrent?.probe_has_metadata !== undefined ||
+    torrent?.probe_timed_out !== undefined ||
+    Boolean(torrent?.probe_state)
+  if (hasProbeResult) return false
+
+  const size = toFiniteNumber(torrent?.size)
+  const seeders = toFiniteNumber(torrent?.seeders)
+
+  return size === undefined || size <= 1 || seeders === undefined || seeders <= 0
+}
+
+export function applyTorrentProbeResult(torrent: TorrentInfo, result: TorrentProbeResult) {
+  const size = toFiniteNumber(result.size)
+  const seeders = toFiniteNumber(result.seeders)
+  const peers = toFiniteNumber(result.peers)
+  const availability = toFiniteNumber(result.availability)
+
+  if (size !== undefined && size > 1) {
+    torrent.size = size
+  }
+  if (seeders !== undefined) {
+    torrent.seeders = seeders
+  }
+  if (peers !== undefined) {
+    torrent.peers = peers
+  }
+  if (availability !== undefined) {
+    torrent.probe_availability = availability
+  }
+
+  torrent.probe_state = result.state
+  torrent.probe_has_metadata = result.has_metadata
+  torrent.probe_timed_out = result.timed_out
+}


### PR DESCRIPTION
## 变更
- 在资源搜索结果增加磁力探测按钮，搜索完成后显示。
- 仅探测当前筛选结果中缺少可靠大小或做种信息的 magnet。
- 批量探测使用 16 并发，运行中可终止，并回填大小、做种数、下载者和状态。

## 边界
本次仅包含搜索页磁力探测交互、类型和多语言文案，不包含用户私有站点配置、Cookie、下载器路径或本地资源包内容。

## 验证
- `npm run typecheck`
- `npm run build`
- `git diff --check origin/v2..HEAD`