### PR TITLE
feat(plugin): support responsive federated config controls

### DIFF
--- a/src/components/dialog/PluginConfigDialog.vue
+++ b/src/components/dialog/PluginConfigDialog.vue
@@ -46,8 +46,13 @@ const isRefreshed = ref(false)
 // 渲染模式: 'vuetify' 或 'vue'
 const renderMode = ref('vuetify')
 
-// 联邦配置为导航、表单和摘要保留三栏空间，传统表单继续使用标准宽度。
-const dialogMaxWidth = computed(() => renderMode.value === 'vue' ? '68rem' : '60rem')
+// 插件未声明布局偏好时沿用标准配置弹窗宽度。
+const dialogMaxWidth = ref('60rem')
+
+interface PluginConfigLayout {
+  /** 插件配置界面期望的最大宽度，使用合法 CSS 尺寸。 */
+  maxWidth?: string
+}
 
 // Vue 模式：动态加载的组件
 const dynamicComponent = defineAsyncComponent({
@@ -92,6 +97,7 @@ async function loadPluginUIData() {
   pluginFormItems = []
   pluginConfigForm.value = {}
   renderMode.value = 'vuetify'
+  dialogMaxWidth.value = '60rem'
 
   try {
     // 获取UI定义
@@ -124,6 +130,11 @@ async function loadPluginUIData() {
 function handleVueComponentSave(newConfig: Record<string, any>) {
   pluginConfigForm.value = newConfig
   savePluginConf()
+}
+
+// 联邦配置组件可按自身布局密度覆盖宿主弹窗宽度。
+function handleVueComponentLayout(layout: PluginConfigLayout) {
+  dialogMaxWidth.value = layout.maxWidth || '60rem'
 }
 
 // 调用API保存配置数据
@@ -195,6 +206,7 @@ onBeforeMount(async () => {
           :initial-config="pluginConfigForm"
           :api="api"
           @save="handleVueComponentSave"
+          @layout="handleVueComponentLayout"
           @switch="emit('switch')"
           @close="emit('close')"
         />

--- a/src/components/dialog/PluginConfigDialog.vue
+++ b/src/components/dialog/PluginConfigDialog.vue
@@ -46,6 +46,9 @@ const isRefreshed = ref(false)
 // 渲染模式: 'vuetify' 或 'vue'
 const renderMode = ref('vuetify')
 
+// 联邦配置需要容纳分组导航和预览区，传统表单继续保持默认宽度。
+const dialogMaxWidth = computed(() => renderMode.value === 'vue' ? '68rem' : '60rem')
+
 // Vue 模式：动态加载的组件
 const dynamicComponent = defineAsyncComponent({
   // 工厂函数
@@ -148,7 +151,7 @@ onBeforeMount(async () => {
 })
 </script>
 <template>
-  <VDialog scrollable max-width="60rem" :fullscreen="!display.mdAndUp.value">
+  <VDialog scrollable :max-width="dialogMaxWidth" :fullscreen="!display.mdAndUp.value">
     <!-- Vuetify 渲染模式 -->
     <VCard v-if="renderMode === 'vuetify'" :title="`${props.plugin?.plugin_name} - ${t('dialog.pluginConfig.title')}`">
       <VDialogCloseBtn @click="emit('close')" />

--- a/src/components/dialog/PluginConfigDialog.vue
+++ b/src/components/dialog/PluginConfigDialog.vue
@@ -45,7 +45,6 @@ const isRefreshed = ref(false)
 
 // 渲染模式: 'vuetify' 或 'vue'
 const renderMode = ref('vuetify')
-const dialogMaxWidth = computed(() => (renderMode.value === 'vue' ? 'min(96vw, 118rem)' : '60rem'))
 
 // Vue 模式：动态加载的组件
 const dynamicComponent = defineAsyncComponent({
@@ -149,7 +148,7 @@ onBeforeMount(async () => {
 })
 </script>
 <template>
-  <VDialog scrollable :max-width="dialogMaxWidth" :fullscreen="!display.mdAndUp.value">
+  <VDialog scrollable max-width="60rem" :fullscreen="!display.mdAndUp.value">
     <!-- Vuetify 渲染模式 -->
     <VCard v-if="renderMode === 'vuetify'" :title="`${props.plugin?.plugin_name} - ${t('dialog.pluginConfig.title')}`">
       <VDialogCloseBtn @click="emit('close')" />

--- a/src/components/dialog/PluginConfigDialog.vue
+++ b/src/components/dialog/PluginConfigDialog.vue
@@ -45,6 +45,7 @@ const isRefreshed = ref(false)
 
 // 渲染模式: 'vuetify' 或 'vue'
 const renderMode = ref('vuetify')
+const dialogMaxWidth = computed(() => (renderMode.value === 'vue' ? 'min(96vw, 118rem)' : '60rem'))
 
 // Vue 模式：动态加载的组件
 const dynamicComponent = defineAsyncComponent({
@@ -148,7 +149,7 @@ onBeforeMount(async () => {
 })
 </script>
 <template>
-  <VDialog scrollable max-width="60rem" :fullscreen="!display.mdAndUp.value">
+  <VDialog scrollable :max-width="dialogMaxWidth" :fullscreen="!display.mdAndUp.value">
     <!-- Vuetify 渲染模式 -->
     <VCard v-if="renderMode === 'vuetify'" :title="`${props.plugin?.plugin_name} - ${t('dialog.pluginConfig.title')}`">
       <VDialogCloseBtn @click="emit('close')" />

--- a/src/components/dialog/PluginConfigDialog.vue
+++ b/src/components/dialog/PluginConfigDialog.vue
@@ -46,8 +46,8 @@ const isRefreshed = ref(false)
 // 渲染模式: 'vuetify' 或 'vue'
 const renderMode = ref('vuetify')
 
-// 插件配置统一使用标准对话框宽度，联邦组件在容器内自行响应式调整布局。
-const dialogMaxWidth = '60rem'
+// 联邦配置为导航、表单和摘要保留三栏空间，传统表单继续使用标准宽度。
+const dialogMaxWidth = computed(() => renderMode.value === 'vue' ? '68rem' : '60rem')
 
 // Vue 模式：动态加载的组件
 const dynamicComponent = defineAsyncComponent({

--- a/src/components/dialog/PluginConfigDialog.vue
+++ b/src/components/dialog/PluginConfigDialog.vue
@@ -46,8 +46,8 @@ const isRefreshed = ref(false)
 // 渲染模式: 'vuetify' 或 'vue'
 const renderMode = ref('vuetify')
 
-// 联邦配置需要容纳分组导航和预览区，传统表单继续保持默认宽度。
-const dialogMaxWidth = computed(() => renderMode.value === 'vue' ? '68rem' : '60rem')
+// 插件配置统一使用标准对话框宽度，联邦组件在容器内自行响应式调整布局。
+const dialogMaxWidth = '60rem'
 
 // Vue 模式：动态加载的组件
 const dynamicComponent = defineAsyncComponent({

--- a/src/components/dialog/PluginConfigDialog.vue
+++ b/src/components/dialog/PluginConfigDialog.vue
@@ -133,8 +133,9 @@ function handleVueComponentSave(newConfig: Record<string, any>) {
 }
 
 // 联邦配置组件可按自身布局密度覆盖宿主弹窗宽度。
-function handleVueComponentLayout(layout: PluginConfigLayout) {
-  dialogMaxWidth.value = layout.maxWidth || '60rem'
+function handleVueComponentLayout(layout?: PluginConfigLayout | null) {
+  const maxWidth = typeof layout?.maxWidth === 'string' ? layout.maxWidth.trim() : ''
+  dialogMaxWidth.value = maxWidth || '60rem'
 }
 
 // 调用API保存配置数据

--- a/src/components/field/CronField.vue
+++ b/src/components/field/CronField.vue
@@ -8,6 +8,11 @@ const props = defineProps({
     type: String,
     default: '* * * * *',
   },
+  /** 是否允许直接清空 CRON。 */
+  clearable: {
+    type: Boolean,
+    default: true,
+  },
 })
 
 const emit = defineEmits(['update:modelValue'])
@@ -39,7 +44,6 @@ function updateModelValue(value: string) {
         :modelValue="innerValue"
         @update:modelValue="updateModelValue"
         v-bind="{ ...menuprops, ...propsWithoutModelValue }"
-        clearable
       />
     </template>
   </CronInput>

--- a/src/components/input/CronInput.vue
+++ b/src/components/input/CronInput.vue
@@ -15,9 +15,10 @@ const menuRoot = ref<HTMLElement>()
 const instance = getCurrentInstance()
 const menuContentClass = `cron-input-menu-${instance?.uid ?? 'default'}`
 const menuContentSelector = `.${menuContentClass}`
-const cronLocale = computed(() => locale.value === 'en-US' ? 'en' : 'zh-cn')
+const normalizedLocale = computed(() => locale.value.toLowerCase().replace(/_/g, '-'))
+const cronLocale = computed(() => normalizedLocale.value.startsWith('zh') ? 'zh-cn' : 'en')
 // vue-js-cron 没有内置繁体中文，只需覆盖简体词典中会显示的 Cron 专有字词。
-const cronCustomLocale = computed(() => locale.value === 'zh-TW' ? {
+const cronCustomLocale = computed(() => normalizedLocale.value === 'zh-tw' ? {
   '*': {
     day: {
       value: { text: '{{value.alt}}號' },

--- a/src/components/input/CronInput.vue
+++ b/src/components/input/CronInput.vue
@@ -7,6 +7,7 @@ const props = defineProps({
 })
 
 const emit = defineEmits(['update:modelValue'])
+const { locale } = useI18n()
 
 const menu = ref(false)
 const currentCron = ref(props.modelValue)
@@ -14,6 +15,26 @@ const menuRoot = ref<HTMLElement>()
 const instance = getCurrentInstance()
 const menuContentClass = `cron-input-menu-${instance?.uid ?? 'default'}`
 const menuContentSelector = `.${menuContentClass}`
+const cronLocale = computed(() => locale.value === 'en-US' ? 'en' : 'zh-cn')
+// vue-js-cron 没有内置繁体中文，只需覆盖简体词典中会显示的 Cron 专有字词。
+const cronCustomLocale = computed(() => locale.value === 'zh-TW' ? {
+  '*': {
+    day: {
+      value: { text: '{{value.alt}}號' },
+      range: { text: '{{start.alt}}號-{{end.alt}}號' },
+    },
+    dayOfWeek: { empty: { text: '一週的每一天' } },
+    hour: { empty: { text: '每小時' } },
+    minute: { empty: { text: '每分鐘' } },
+  },
+  hour: {
+    text: '小時',
+    minute: { '*': { suffix: '分鐘' } },
+  },
+  week: { text: '週' },
+  'q-minute': { text: '分鐘' },
+  'q-hour': { text: '小時' },
+} : undefined)
 
 function isCronMenuTarget(target: EventTarget | null) {
   if (!(target instanceof Element)) return false
@@ -72,7 +93,14 @@ watch(
       </template>
       <VList>
         <VListItem>
-          <VCronVuetify v-model="currentCron" locale="zh-CN" :chip-props="{ color: 'success' }" class="mt-1" />
+          <VCronVuetify
+            :key="locale"
+            v-model="currentCron"
+            :chip-props="{ color: 'success' }"
+            class="mt-1"
+            :custom-locale="cronCustomLocale"
+            :locale="cronLocale"
+          />
         </VListItem>
       </VList>
     </VMenu>


### PR DESCRIPTION
## 变更说明

- 为 Vue 联邦插件配置组件提供可选的 `layout` 事件合同，插件可按自身布局请求弹窗最大宽度。
- 宿主默认保持 `60rem`，未声明布局偏好的 Vue/Vuetify 插件不受影响，重新载入插件时恢复默认值。
- CRON 控件跟随主程序语言，并支持插件按字段关闭清空操作。

## 影响范围

- `src/components/dialog/PluginConfigDialog.vue`
- `src/components/input/CronInput.vue`
- `src/components/field/CronField.vue`

## 联动关系

- 订阅助手增强版通过 https://github.com/InfinityPacer/MoviePilot-Plugins/pull/334 声明其 `68rem` 布局宽度。
- 两侧保持向后兼容：主前端可先合入；插件在旧版宿主上发送的未监听事件不会影响现有配置功能。

## 验证

- `yarn typecheck`
- `yarn build`
- `git diff --check`

`yarn lint` 当前在加载仓库 `.eslintrc.js` 时受 ESLint 9 与 ESM 配置冲突阻断，尚未进入源码检查。运行态浏览器复查受浏览器调试工具不可用阻断。

本 PR 为 Codex 协作提交

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 70ebafa38ea2078e8e417029ad673fd597ad70ed

- 支持插件请求弹窗宽度
  - `layout.maxWidth` 驱动 `VDialog`
- 保留默认兼容行为
  - 重新加载恢复 `60rem`
- Cron 控件本地化
  - 跟随 `useI18n` 语言
- 配置清空可控
  - 未新增测试，需回归

<!-- pr-agent-summary:end -->