### PR TITLE
feat: 高亮词表注释行

### DIFF
--- a/src/ace-config.ts
+++ b/src/ace-config.ts
@@ -530,6 +530,56 @@ function registerJinja2Mode() {
   )
 }
 
+function registerWordListMode() {
+  aceModule.define?.(
+    'ace/mode/word_list_highlight_rules',
+    ['require', 'exports', 'module', 'ace/lib/oop', 'ace/mode/text_highlight_rules'],
+    (require: any, exports: any) => {
+      const oop = require('../lib/oop')
+      const TextHighlightRules = require('./text_highlight_rules').TextHighlightRules
+
+      const WordListHighlightRules = function (this: any) {
+        this.$rules = {
+          start: [
+            {
+              token: 'comment.word-list',
+              regex: /^#.*/,
+            },
+          ],
+        }
+
+        this.normalizeRules()
+      }
+
+      oop.inherits(WordListHighlightRules, TextHighlightRules)
+      exports.WordListHighlightRules = WordListHighlightRules
+    },
+  )
+
+  aceModule.define?.(
+    'ace/mode/word_list',
+    ['require', 'exports', 'module', 'ace/lib/oop', 'ace/mode/text', 'ace/mode/word_list_highlight_rules'],
+    (require: any, exports: any) => {
+      const oop = require('../lib/oop')
+      const TextMode = require('./text').Mode
+      const WordListHighlightRules = require('./word_list_highlight_rules').WordListHighlightRules
+
+      const Mode = function (this: any) {
+        TextMode.call(this)
+        this.HighlightRules = WordListHighlightRules
+      }
+
+      oop.inherits(Mode, TextMode)
+
+      ;(function (this: any) {
+        this.$id = 'ace/mode/word_list'
+      }).call(Mode.prototype)
+
+      exports.Mode = Mode
+    },
+  )
+}
+
 ace.config.setModuleUrl('ace/mode/json', modeJsonUrl)
 ace.config.setModuleUrl('ace/mode/javascript', modeJavascriptUrl)
 ace.config.setModuleUrl('ace/mode/html', modeHtmlUrl)
@@ -555,4 +605,5 @@ ace.config.setModuleUrl('ace/snippets/css', snippertsCssUrl)
 ace.config.setModuleUrl('ace/snippets/ini', snippertsIniUrl)
 
 registerJinja2Mode()
+registerWordListMode()
 ace.require('ace/ext/language_tools')

--- a/src/views/system/WordsView.vue
+++ b/src/views/system/WordsView.vue
@@ -2,11 +2,13 @@
 import { useToast } from 'vue-toastification'
 import api from '@/api'
 import { useI18n } from 'vue-i18n'
+import { useTheme } from 'vuetify'
 
 const Draggable = defineAsyncComponent(() => import('vuedraggable').then(module => module.default))
 
 const { t } = useI18n()
 const $toast = useToast()
+const { global: globalTheme } = useTheme()
 
 type TextSectionKey = 'identifiers' | 'releaseGroups' | 'customization' | 'excludeWords'
 type WordSectionKey = TextSectionKey | 'episodeRules'
@@ -43,6 +45,16 @@ const episodeFormatRules = ref<EpisodeFormatRule[]>([])
 const activeSection = ref<WordSectionKey>('identifiers')
 const expandedHelp = ref<string | null>(null)
 const saving = ref(false)
+
+const textEditorTheme = computed(() => (globalTheme.current.value.dark ? 'github_dark' : 'github_light_default'))
+const textEditorOptions = {
+  fontSize: 13.6,
+  highlightActiveLine: false,
+  scrollPastEnd: 0,
+  showGutter: false,
+  showPrintMargin: false,
+  tabSize: 2,
+}
 
 const savedTextValues = reactive<Record<TextSectionKey, string>>({
   identifiers: '',
@@ -474,7 +486,21 @@ onMounted(() => {
               <span>{{ t('setting.words.entryCount', { count: activeSectionCount }) }}</span>
             </div>
 
+            <VAceEditor
+              v-if="activeSection === 'identifiers'"
+              v-model:value="activeTextValue"
+              lang="word_list"
+              :theme="textEditorTheme"
+              :options="textEditorOptions"
+              :placeholder="activeTextPlaceholder"
+              :print-margin="false"
+              :min-lines="11"
+              :max-lines="11"
+              wrap
+              class="words-text-editor"
+            />
             <VTextarea
+              v-else
               v-model="activeTextValue"
               class="words-textarea"
               :placeholder="activeTextPlaceholder"
@@ -842,6 +868,18 @@ onMounted(() => {
   background: transparent;
 }
 
+.words-text-editor {
+  overflow: hidden;
+  min-block-size: 15.8rem;
+  border: 1px solid rgba(var(--v-theme-on-surface), var(--v-border-opacity));
+  border-radius: var(--app-surface-radius);
+}
+
+.words-text-editor :deep(.ace_comment) {
+  color: rgb(var(--v-theme-success)) !important;
+  font-style: normal;
+}
+
 .words-inline-hint {
   display: flex;
   align-items: flex-start;
@@ -1082,6 +1120,10 @@ onMounted(() => {
   }
 
   .words-textarea :deep(.v-field__input) {
+    min-block-size: 18rem;
+  }
+
+  .words-text-editor {
     min-block-size: 18rem;
   }
 


### PR DESCRIPTION
## 变更内容

- 新增 Ace 词表语法模式，将以 `#` 开头的行识别为注释。
- 在“自定义识别词”编辑器中，以成功绿色高亮注释行。

## 变更原因

后端会忽略以 `#` 开头的自定义识别词配置行。前端高亮可明确提示该行为，避免用户将注释误认为生效规则。

## 影响范围

仅调整“自定义识别词”编辑器。其余词表分类的后端不支持注释行，继续沿用原有多行输入框，避免产生误导。

## 验证

- `yarn typecheck`

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at d0d8c6c0591c7cdaee1073ab8aa223f84272cec5

- 为 `identifiers` 启用 Ace 编辑器
- 新增 `word_list` 注释语法
- 主题跟随 Vuetify 明暗模式
- 仅影响自定义识别词编辑

<!-- pr-agent-summary:end -->