### PR TITLE
修复识别词编辑器滚动闪烁

### DIFF
--- a/src/views/system/WordsView.vue
+++ b/src/views/system/WordsView.vue
@@ -494,8 +494,6 @@ onMounted(() => {
               :options="textEditorOptions"
               :placeholder="activeTextPlaceholder"
               :print-margin="false"
-              :min-lines="11"
-              :max-lines="11"
               wrap
               class="words-text-editor"
             />
@@ -870,9 +868,19 @@ onMounted(() => {
 
 .words-text-editor {
   overflow: hidden;
-  min-block-size: 15.8rem;
+  block-size: 15.8rem;
   border: 1px solid rgba(var(--v-theme-on-surface), var(--v-border-opacity));
   border-radius: var(--app-surface-radius);
+  contain: paint;
+  overscroll-behavior: contain;
+  transform: translateZ(0);
+}
+
+.words-text-editor :deep(.ace_scroller),
+.words-text-editor :deep(.ace_content),
+.words-text-editor :deep(.ace_text-layer) {
+  transform: translateZ(0);
+  will-change: transform;
 }
 
 .words-text-editor :deep(.ace_comment) {
@@ -1124,7 +1132,7 @@ onMounted(() => {
   }
 
   .words-text-editor {
-    min-block-size: 18rem;
+    block-size: 18rem;
   }
 
   .words-rule-toolbar {


### PR DESCRIPTION
## 变更内容

- 在自定义识别词页面中，移除 Ace 编辑器的 `min-lines` / `max-lines` 自动高度配置。
- 改为通过固定 `block-size` 控制编辑器高度，避免滚动时 Ace 虚拟渲染区域和实际容器高度不同步。
- 为 Ace 渲染层增加绘制隔离和 GPU 合成提示，降低滚动重绘时下一行短暂闪现的概率。

## 问题原因

`自定义识别词` 使用 Ace 编辑器，而其他词表使用 `VTextarea`。当词表内容较多需要滚动时，Ace 的自动高度和页面 CSS 的最小高度共同参与布局计算，可能导致可视区域与内部滚动渲染在某一帧不同步，从而出现下一行突然闪现的问题。

## 影响范围

- 仅影响 `src/views/system/WordsView.vue` 中自定义识别词编辑器的显示与滚动体验。
- 不改变词表读取、保存、统计或其他词表分类逻辑。

## 验证情况

- 已检查本地 diff，确认提交只包含 `WordsView.vue` 的滚动显示修复。
- 未运行前端构建或类型检查；当前仓库根规则文档未列出可执行的前端 yarn/npm 校验命令。

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 0f796f36e9747d7145b2e529dbb3e220d85f8bcb

- 修复识别词滚动闪烁
- 固定 Ace 编辑器高度
- 增加绘制隔离与合成
- 未见测试变更；风险较低

<!-- pr-agent-summary:end -->