### PR TITLE
fix(dashboard): refine responsive recommendation controls

### DIFF
--- a/src/views/dashboard/MediaRecommend.vue
+++ b/src/views/dashboard/MediaRecommend.vue
@@ -40,6 +40,14 @@ const selectedSource = computed(
 
 const activeMedia = computed(() => mediaItems.value[activeIndex.value])
 
+/** 根据推荐来源返回便于快速识别的媒体类别图标。 */
+function getSourceIcon(source?: RecommendViewSource) {
+  if (source?.apipath === 'recommend/tmdb_trending') return 'mdi-trending-up'
+  if (source?.apipath === 'recommend/tmdb_movies') return 'mdi-movie-outline'
+  if (source?.apipath.startsWith('recommend/tmdb_tvs')) return 'mdi-television-classic'
+  return 'mdi-movie-open-star-outline'
+}
+
 /** 将不同接口包装格式归一化为媒体数组。 */
 function normalizeMediaResponse(response: unknown): MediaInfo[] {
   if (Array.isArray(response)) return response
@@ -245,9 +253,10 @@ onBeforeUnmount(stopAutoplay)
               color="white"
               rounded="pill"
               append-icon="mdi-chevron-down"
+              :aria-label="t('dashboard.selectRecommendSource')"
             >
-              <VIcon icon="mdi-movie-open-star-outline" color="primary" start />
-              <span>{{ selectedSource.title }}</span>
+              <VIcon :icon="getSourceIcon(selectedSource)" color="primary" size="20" start />
+              <span class="dashboard-recommend-source-title">{{ selectedSource.title }}</span>
             </VBtn>
           </template>
           <VList density="compact" max-height="360" :aria-label="t('dashboard.selectRecommendSource')">
@@ -255,7 +264,7 @@ onBeforeUnmount(stopAutoplay)
               v-for="source in sources"
               :key="source.apipath"
               :active="source.apipath === selectedSourcePath"
-              prepend-icon="mdi-movie-open-star-outline"
+              :prepend-icon="getSourceIcon(source)"
               :title="source.title"
               @click="selectSource(source)"
             />
@@ -404,7 +413,7 @@ onBeforeUnmount(stopAutoplay)
   text-transform: none;
 }
 
-.dashboard-recommend-source span {
+.dashboard-recommend-source-title {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -520,6 +529,7 @@ onBeforeUnmount(stopAutoplay)
 
 @media (min-width: 741px) and (hover: hover) {
   .dashboard-recommend-topbar,
+  .dashboard-recommend-detail,
   .dashboard-recommend-arrow {
     opacity: 0;
     pointer-events: none;
@@ -534,12 +544,15 @@ onBeforeUnmount(stopAutoplay)
     transform: translateX(-4px);
   }
 
+  .dashboard-recommend-detail,
   .dashboard-recommend-arrow--next {
     transform: translateX(4px);
   }
 
   .dashboard-recommend:hover .dashboard-recommend-topbar,
   .dashboard-recommend:focus-within .dashboard-recommend-topbar,
+  .dashboard-recommend:hover .dashboard-recommend-detail,
+  .dashboard-recommend:focus-within .dashboard-recommend-detail,
   .dashboard-recommend:hover .dashboard-recommend-arrow,
   .dashboard-recommend:focus-within .dashboard-recommend-arrow {
     opacity: 1;
@@ -558,18 +571,33 @@ onBeforeUnmount(stopAutoplay)
   }
 
   .dashboard-recommend-topbar {
+    justify-content: flex-end;
     inset-block-start: 0.85rem;
     inset-inline: 0.85rem;
   }
 
   .dashboard-recommend-label {
-    padding: 0.45rem 0.65rem;
+    display: none;
   }
 
   .dashboard-recommend-source {
-    max-inline-size: 50vw;
-    min-inline-size: 0;
-    padding-inline: 0.7rem;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    max-inline-size: none;
+    min-inline-size: 40px;
+    background: rgba(8, 18, 28, 0.24) !important;
+    backdrop-filter: blur(8px);
+    block-size: 40px;
+    inline-size: 40px;
+    padding: 0;
+  }
+
+  .dashboard-recommend-source-title,
+  .dashboard-recommend-source :deep(.v-btn__append) {
+    display: none;
+  }
+
+  .dashboard-recommend-source :deep(.v-icon--start) {
+    margin-inline-end: 0;
   }
 
   .dashboard-recommend-content {
@@ -609,24 +637,6 @@ onBeforeUnmount(stopAutoplay)
   .dashboard-recommend-page.is-active {
     inline-size: 32px;
   }
-}
-
-@media (max-width: 420px) {
-  .dashboard-recommend-label span {
-    display: none;
-  }
-
-  .dashboard-recommend-label {
-    block-size: 40px;
-    inline-size: 40px;
-    justify-content: center;
-    padding: 0;
-  }
-
-  .dashboard-recommend-source {
-    max-inline-size: 68vw;
-  }
-
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## 变更说明

- 移动端隐藏仅用于说明的“推荐媒体”标签，将来源选择器收拢为 40px 半透明图标按钮，减少对媒体画面的遮挡，同时保留来源切换入口。
- 为流行趋势、热门电影和热门电视剧配置不同图标，触发按钮同步显示当前来源图标，提升来源辨识度。
- Web 端将“查看详情”纳入现有的 hover / focus-within 显示规则，使其与顶部标签和轮播箭头保持一致。
- 为移动端图标按钮补充可访问名称，隐藏文字后仍可被辅助技术识别。

## 影响范围

- `src/views/dashboard/MediaRecommend.vue`
- 仅调整仪表盘推荐媒体卡片的响应式展示与控件显隐，不改变接口、缓存、来源选择持久化或详情跳转逻辑。

## 验证

- `yarn typecheck`
- `yarn build`
- `git diff --check`
- 已在登录后的仪表盘分别验证桌面和移动视口：桌面控件 hover / focus 显隐一致；移动端标签隐藏、来源菜单可正常打开且三个来源图标可区分；页面无控制台错误。
- `yarn lint` 尚未进入源文件检查：当前 ESLint 9 会将 CommonJS 格式的 `.eslintrc.js` 按 ESM 加载，并在配置阶段退出。

本 PR 为 Codex 协作提交

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at a592afa54dd0fd714c9917935278d30cfb639ea2

- 优化移动端推荐来源控件占位
- 为不同来源显示识别图标
- 桌面端统一详情控件显隐
- 保留无障碍来源选择名称

<!-- pr-agent-summary:end -->