### PR TITLE
feat: 重新设计捷径识别与规则测试结果页面

### DIFF
--- a/src/views/system/NameTestView.vue
+++ b/src/views/system/NameTestView.vue
@@ -5,13 +5,7 @@ import api from '@/api'
 import type { Context } from '@/api/types'
 import { useI18n } from 'vue-i18n'
 
-interface SummaryItem {
-  icon: string
-  label: string
-  value: string
-}
-
-interface AnalysisStep {
+interface PipelineStep {
   icon: string
   title: string
   value: string
@@ -60,29 +54,7 @@ const resourceChips = computed(() => {
     metaInfo.value?.resource_team,
   ].filter(Boolean) as string[]
 })
-const summaryItems = computed<SummaryItem[]>(() => [
-  {
-    icon: 'mdi-calendar-range',
-    label: t('nameTest.summary.year'),
-    value: mediaInfo.value?.year || metaInfo.value?.year || '-',
-  },
-  {
-    icon: 'mdi-format-list-numbered',
-    label: t('nameTest.summary.episode'),
-    value: metaInfo.value?.season_episode || metaInfo.value?.episode || '-',
-  },
-  {
-    icon: 'mdi-shape-outline',
-    label: t('nameTest.summary.type'),
-    value: mediaInfo.value?.type || metaInfo.value?.type || '-',
-  },
-  {
-    icon: 'mdi-database-search',
-    label: t('nameTest.summary.source'),
-    value: mediaInfo.value?.source || mediaInfo.value?.tmdb_id?.toString() || mediaInfo.value?.douban_id || '-',
-  },
-])
-const analysisSteps = computed<AnalysisStep[]>(() => [
+const pipelineSteps = computed<PipelineStep[]>(() => [
   {
     icon: 'mdi-file-document-outline',
     title: t('nameTest.steps.original.title'),
@@ -91,12 +63,7 @@ const analysisSteps = computed<AnalysisStep[]>(() => [
   {
     icon: 'mdi-puzzle-check-outline',
     title: t('nameTest.steps.meta.title'),
-    value: [
-      metaInfo.value?.name,
-      metaInfo.value?.season_episode,
-      metaInfo.value?.resource_term,
-      metaInfo.value?.release_group,
-    ]
+    value: [metaInfo.value?.name, metaInfo.value?.resource_term, metaInfo.value?.release_group]
       .filter(Boolean)
       .join(' · ') || '-',
   },
@@ -107,7 +74,7 @@ const analysisSteps = computed<AnalysisStep[]>(() => [
       ? `TMDB ${mediaInfo.value.tmdb_id}`
       : mediaInfo.value?.douban_id
         ? `Douban ${mediaInfo.value.douban_id}`
-        : mediaInfo.value?.title || '-',
+        : mediaInfo.value?.title || t('nameTest.unrecognized'),
   },
 ])
 
@@ -202,31 +169,35 @@ async function nameTest() {
 
     <section class="shortcut-panel shortcut-result-panel">
       <div v-if="showResult" class="result-stack">
-        <div class="media-result-card" :class="{ 'media-result-card--failed': !isRecognized }">
-          <div v-if="mediaInfo?.poster_path" class="poster-frame">
+        <div class="result-hero" :class="{ 'result-hero--failed': !isRecognized }">
+          <div v-if="mediaInfo?.poster_path" class="hero-poster">
             <VImg :src="getPosterImage(mediaInfo.poster_path)" aspect-ratio="2/3" cover>
               <template #placeholder>
                 <VSkeletonLoader class="h-100 w-100" />
               </template>
             </VImg>
           </div>
-          <div v-else class="poster-frame poster-frame--empty">
+          <div v-else class="hero-poster hero-poster--empty">
             <VIcon :icon="isRecognized ? 'mdi-movie-open-check' : 'mdi-movie-open-remove'" size="32" />
           </div>
 
-          <div class="min-w-0">
-            <div class="result-heading">
-              <VIcon :icon="isRecognized ? 'mdi-check-circle-outline' : 'mdi-alert-circle-outline'" color="primary" />
-              <span class="result-title-text text-subtitle-1 font-weight-medium text-truncate">{{ resultTitle }}</span>
+          <div class="min-w-0 hero-body">
+            <div class="hero-heading">
+              <VIcon
+                :icon="isRecognized ? 'mdi-check-circle-outline' : 'mdi-alert-circle-outline'"
+                color="primary"
+                size="20"
+              />
+              <span class="hero-title-text text-subtitle-1 font-weight-medium text-truncate">{{ resultTitle }}</span>
             </div>
             <div class="text-body-2 text-medium-emphasis mt-1">
               {{ resultSubtitle }}
             </div>
-            <div class="chip-row mt-3">
+            <div v-if="resourceChips.length" class="hero-chips mt-3">
               <VChip
                 v-for="chip in resourceChips"
                 :key="chip"
-                class="result-chip"
+                class="hero-chip"
                 color="primary"
                 size="small"
                 variant="tonal"
@@ -237,17 +208,36 @@ async function nameTest() {
           </div>
         </div>
 
-        <div class="summary-grid">
-          <div v-for="item in summaryItems" :key="item.label" class="summary-tile">
-            <VIcon :icon="item.icon" size="18" class="summary-icon" />
-            <div class="min-w-0">
-              <div class="text-caption text-medium-emphasis">
-                {{ item.label }}
+        <div class="pipeline">
+          <div v-for="(step, idx) in pipelineSteps" :key="step.title" class="pipeline-step">
+            <div class="pipeline-marker">
+              <VIcon :icon="step.icon" color="primary" size="18" />
+              <span v-if="idx < pipelineSteps.length - 1" class="pipeline-connector" />
+            </div>
+            <div class="pipeline-body">
+              <div class="text-caption text-medium-emphasis pipeline-label">
+                {{ step.title }}
               </div>
-              <div class="text-body-2 font-weight-medium text-truncate">
-                {{ item.value }}
+              <div class="text-body-2 font-weight-medium pipeline-value">
+                {{ step.value }}
               </div>
             </div>
+          </div>
+        </div>
+
+        <div v-if="metaInfo?.apply_words?.length" class="applied-words">
+          <div class="text-caption text-medium-emphasis applied-words-label">
+            {{ t('nameTest.steps.words.title') }}
+          </div>
+          <div class="words-chips">
+            <VChip
+              v-for="word in metaInfo.apply_words"
+              :key="word"
+              size="small"
+              variant="tonal"
+            >
+              {{ word }}
+            </VChip>
           </div>
         </div>
       </div>
@@ -259,54 +249,6 @@ async function nameTest() {
       </div>
     </section>
   </div>
-
-  <section v-if="showResult" class="shortcut-panel analysis-panel mt-4">
-    <div class="panel-heading">
-      <div>
-        <div class="text-subtitle-1 font-weight-medium">
-          {{ t('nameTest.analysisTitle') }}
-        </div>
-        <div class="text-caption text-medium-emphasis">
-          {{ t('nameTest.analysisSubtitle') }}
-        </div>
-      </div>
-    </div>
-
-    <div class="analysis-flow">
-      <div v-for="step in analysisSteps" :key="step.title" class="analysis-step">
-        <VIcon :icon="step.icon" color="primary" size="20" />
-        <div class="min-w-0">
-          <div class="text-body-2 font-weight-medium">
-            {{ step.title }}
-          </div>
-          <div class="text-body-2 step-value">
-            {{ step.value }}
-          </div>
-        </div>
-      </div>
-    </div>
-
-  </section>
-
-  <section v-if="showResult && metaInfo?.apply_words?.length" class="shortcut-panel applied-words-panel mt-4">
-    <div class="panel-heading">
-      <div>
-        <div class="text-subtitle-1 font-weight-medium">
-          {{ t('nameTest.steps.words.title') }}
-        </div>
-      </div>
-    </div>
-
-    <div class="words-list">
-      <div v-if="metaInfo.org_string" class="word-row word-row--source">
-        <span class="text-caption text-medium-emphasis">{{ t('nameTest.steps.original.title') }}</span>
-        <span class="word-text">{{ metaInfo.org_string }}</span>
-      </div>
-      <div v-for="word in metaInfo.apply_words" :key="word" class="word-row">
-        <span class="word-text">{{ word }}</span>
-      </div>
-    </div>
-  </section>
 </template>
 
 <style scoped>
@@ -352,10 +294,10 @@ async function nameTest() {
 
 .result-stack {
   display: grid;
-  gap: 0.9rem;
+  gap: 1rem;
 }
 
-.media-result-card {
+.result-hero {
   display: grid;
   grid-template-columns: 5rem minmax(0, 1fr);
   gap: 0.85rem;
@@ -366,11 +308,11 @@ async function nameTest() {
   padding: 0.75rem;
 }
 
-.media-result-card--failed {
+.result-hero--failed {
   background: rgba(var(--v-theme-error), 0.08);
 }
 
-.poster-frame {
+.hero-poster {
   overflow: hidden;
   border: var(--app-surface-border);
   border-radius: var(--app-control-radius);
@@ -378,50 +320,94 @@ async function nameTest() {
   background: rgba(var(--v-theme-surface-variant), 0.35);
 }
 
-.poster-frame--empty {
+.hero-poster--empty {
   display: grid;
   place-items: center;
 }
 
-.chip-row {
+.hero-body {
+  min-inline-size: 0;
+}
+
+.hero-heading {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.hero-title-text {
+  min-inline-size: 0;
+}
+
+.hero-chips {
   display: flex;
   flex-wrap: wrap;
   gap: 0.35rem;
 }
 
-.result-chip {
+.hero-chip {
   max-inline-size: 100%;
 }
 
-.result-heading {
+.pipeline {
   display: flex;
-  gap: 0.5rem;
-  align-items: center;
+  flex-direction: column;
 }
 
-.result-title-text {
+.pipeline-step {
+  display: grid;
+  grid-template-columns: 1.75rem minmax(0, 1fr);
+  gap: 0.75rem;
+}
+
+.pipeline-marker {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-block-size: 100%;
+}
+
+.pipeline-connector {
+  flex: 1;
+  inline-size: 2px;
+  margin-block-start: 0.3rem;
+  background: rgba(var(--v-theme-primary), 0.25);
+}
+
+.pipeline-body {
+  padding-block-end: 0.9rem;
   min-inline-size: 0;
 }
 
-.summary-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.55rem;
+.pipeline-step:last-child .pipeline-body {
+  padding-block-end: 0;
 }
 
-.summary-tile {
+.pipeline-label {
+  letter-spacing: 0.02em;
+}
+
+.pipeline-value {
+  margin-block-start: 0.2rem;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.applied-words {
   display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
   gap: 0.5rem;
-  align-items: center;
-  border: var(--app-surface-border);
-  border-radius: var(--app-surface-radius);
-  background: rgba(var(--v-theme-surface-variant), 0.22);
-  padding: 0.65rem;
+  padding-block: 0.4rem;
+  border-block-start: var(--app-surface-border);
 }
 
-.summary-icon {
-  color: rgb(var(--v-theme-primary));
+.applied-words-label {
+  letter-spacing: 0.02em;
+}
+
+.words-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
 }
 
 .empty-state {
@@ -434,70 +420,16 @@ async function nameTest() {
   text-align: center;
 }
 
-.analysis-flow {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 0.6rem;
-}
-
-.analysis-step {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
-  gap: 0.55rem;
-  border: var(--app-surface-border);
-  border-radius: var(--app-surface-radius);
-  background: rgba(var(--v-theme-surface-variant), 0.2);
-  padding: 0.7rem;
-}
-
-.step-value {
-  overflow: hidden;
-  margin-block-start: 0.35rem;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.words-list {
-  display: grid;
-  gap: 0.5rem;
-}
-
-.word-row {
-  display: grid;
-  gap: 0.25rem;
-  border: var(--app-surface-border);
-  border-radius: var(--app-surface-radius);
-  background: rgba(var(--v-theme-surface-variant), 0.2);
-  padding: 0.65rem;
-}
-
-.word-row--source {
-  background: rgba(var(--v-theme-primary), 0.08);
-}
-
-.word-text {
-  overflow-wrap: anywhere;
-  word-break: break-word;
-}
-
 @media (max-width: 760px) {
-  .shortcut-workbench,
-  .analysis-flow {
+  .shortcut-workbench {
     grid-template-columns: minmax(0, 1fr);
   }
 
-  .summary-grid {
-    grid-template-columns: minmax(0, 1fr);
+  .hero-heading {
+    flex-wrap: wrap;
   }
 
-  .result-heading {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr);
-    gap: 0.35rem;
-    align-items: start;
-  }
-
-  .result-title-text {
+  .hero-title-text {
     overflow: visible;
     text-overflow: clip;
     white-space: normal;
@@ -509,7 +441,7 @@ async function nameTest() {
     padding: 0.8rem;
   }
 
-  .media-result-card {
+  .result-hero {
     grid-template-columns: 4.25rem minmax(0, 1fr);
   }
 }

--- a/src/views/system/RuleTestView.vue
+++ b/src/views/system/RuleTestView.vue
@@ -5,16 +5,11 @@ import api from '@/api'
 import type { ApiResponse, FilterRuleGroup, RuleTestData } from '@/api/types'
 import { useI18n } from 'vue-i18n'
 
-interface SummaryItem {
-  icon: string
-  label: string
-  value: string
-}
-
-interface AnalysisStep {
+interface PipelineStep {
   icon: string
   title: string
   value: string
+  tone?: 'success' | 'warning' | 'primary'
 }
 
 interface FormValidationResult {
@@ -78,6 +73,7 @@ const priorityText = computed(() => {
   const priority = ruleTestData.value?.priority
   return typeof priority === 'number' ? priority.toString() : '-'
 })
+const hasPriority = computed(() => typeof ruleTestData.value?.priority === 'number')
 const resultTitle = computed(() => {
   if (isMatched.value) return t('ruleTest.matched')
   return ruleTestResponse.value?.message || t('ruleTest.noPriorityRule')
@@ -91,6 +87,11 @@ const resultSubtitle = computed(() => {
   return parts.filter(Boolean).join(' · ') || t('ruleTest.waitingResult')
 })
 const ruleCount = computed(() => countRules(ruleTestData.value?.rulegroup?.rule_string || selectedRuleGroup.value?.rule_string))
+const ruleCountLabel = computed(() => {
+  const count = ruleCount.value
+  if (!count) return t('ruleTest.steps.group.empty')
+  return t('ruleTest.ruleCount', { count })
+})
 const resourceChips = computed(() => {
   return [
     mediaInfo.value?.type || metaInfo.value?.type,
@@ -100,50 +101,29 @@ const resourceChips = computed(() => {
     metaInfo.value?.resource_team,
   ].filter(Boolean) as string[]
 })
-const summaryItems = computed<SummaryItem[]>(() => [
-  {
-    icon: 'mdi-sort-numeric-descending',
-    label: t('ruleTest.summary.priority'),
-    value: priorityText.value,
-  },
-  {
-    icon: 'mdi-filter-cog-outline',
-    label: t('ruleTest.summary.ruleGroup'),
-    value: ruleTestData.value?.rulegroup_name || ruleTestForm.rulegroup || '-',
-  },
-  {
-    icon: 'mdi-format-list-numbered',
-    label: t('ruleTest.summary.ruleCount'),
-    value: ruleCount.value ? t('ruleTest.ruleCount', { count: ruleCount.value }) : '-',
-  },
-  {
-    icon: 'mdi-movie-search-outline',
-    label: t('ruleTest.summary.media'),
-    value: mediaInfo.value?.title || metaInfo.value?.name || '-',
-  },
-])
-const analysisSteps = computed<AnalysisStep[]>(() => [
+const pipelineSteps = computed<PipelineStep[]>(() => [
   {
     icon: 'mdi-filter-settings-outline',
     title: t('ruleTest.steps.group.title'),
-    value: ruleTestData.value?.rulegroup_name || ruleTestForm.rulegroup || '-',
+    value: ruleTestData.value?.rulegroup_name || ruleTestForm.rulegroup
+      ? `${ruleTestData.value?.rulegroup_name || ruleTestForm.rulegroup} · ${ruleCountLabel.value}`
+      : '-',
+    tone: 'primary',
   },
   {
     icon: 'mdi-movie-search-outline',
     title: t('ruleTest.steps.media.title'),
     value: mediaInfo.value?.title || metaInfo.value?.name || t('ruleTest.steps.media.none'),
+    tone: mediaInfo.value?.title ? 'primary' : 'warning',
   },
   {
     icon: resultIcon.value,
     title: t('ruleTest.steps.filter.title'),
-    value:
-      ruleTestResponse.value?.message ||
-      (isMatched.value ? torrentInfo.value?.title || ruleTestForm.title : t('ruleTest.steps.filter.pending')),
-  },
-  {
-    icon: 'mdi-sort-numeric-descending',
-    title: t('ruleTest.steps.priority.title'),
-    value: priorityText.value,
+    value: ruleTestResponse.value?.message
+      || (isMatched.value
+        ? torrentInfo.value?.title || ruleTestForm.title
+        : t('ruleTest.steps.filter.pending')),
+    tone: isMatched.value ? 'success' : 'warning',
   },
 ])
 
@@ -266,26 +246,26 @@ onMounted(() => {
 
     <section class="shortcut-panel shortcut-result-panel">
       <div v-if="showResult" class="result-stack">
-        <div class="rule-result-card" :class="{ 'rule-result-card--matched': isMatched }">
-          <div class="priority-badge" :class="{ 'priority-badge--matched': isMatched }">
+        <div class="result-hero" :class="{ 'result-hero--matched': isMatched }">
+          <div class="priority-badge" :class="{ 'priority-badge--matched': isMatched, 'priority-badge--empty': !hasPriority }">
             <span class="text-caption text-medium-emphasis">{{ t('ruleTest.priorityLabel') }}</span>
             <span class="priority-value">{{ priorityText }}</span>
           </div>
-          <div class="min-w-0">
-            <div class="result-heading">
-              <VIcon :icon="resultIcon" :color="resultColor" />
-              <span class="result-title-text text-subtitle-1 font-weight-medium text-truncate">{{ resultTitle }}</span>
+          <div class="min-w-0 hero-body">
+            <div class="hero-heading">
+              <VIcon :icon="resultIcon" :color="resultColor" size="20" />
+              <span class="hero-title-text text-subtitle-1 font-weight-medium text-truncate">{{ resultTitle }}</span>
             </div>
             <div class="text-body-2 text-medium-emphasis mt-1">
               {{ resultSubtitle }}
             </div>
-            <div class="chip-row mt-3">
+            <div v-if="resourceChips.length" class="hero-chips mt-3">
               <VChip
                 v-for="chip in resourceChips"
                 :key="chip"
-                color="primary"
                 size="small"
                 variant="tonal"
+                :color="resultColor"
               >
                 {{ chip }}
               </VChip>
@@ -293,15 +273,18 @@ onMounted(() => {
           </div>
         </div>
 
-        <div class="summary-grid">
-          <div v-for="item in summaryItems" :key="item.label" class="summary-tile">
-            <VIcon :icon="item.icon" size="18" class="summary-icon" />
-            <div class="min-w-0">
-              <div class="text-caption text-medium-emphasis">
-                {{ item.label }}
+        <div class="pipeline">
+          <div v-for="(step, idx) in pipelineSteps" :key="step.title" class="pipeline-step">
+            <div class="pipeline-marker">
+              <VIcon :icon="step.icon" :color="step.tone || 'primary'" size="18" />
+              <span v-if="idx < pipelineSteps.length - 1" class="pipeline-connector" />
+            </div>
+            <div class="pipeline-body">
+              <div class="text-caption text-medium-emphasis pipeline-label">
+                {{ step.title }}
               </div>
-              <div class="text-body-2 font-weight-medium text-truncate">
-                {{ item.value }}
+              <div class="text-body-2 font-weight-medium pipeline-value">
+                {{ step.value }}
               </div>
             </div>
           </div>
@@ -315,33 +298,6 @@ onMounted(() => {
       </div>
     </section>
   </div>
-
-  <section v-if="showResult" class="shortcut-panel analysis-panel mt-4">
-    <div class="panel-heading">
-      <div>
-        <div class="text-subtitle-1 font-weight-medium">
-          {{ t('ruleTest.analysisTitle') }}
-        </div>
-        <div class="text-caption text-medium-emphasis">
-          {{ t('ruleTest.analysisSubtitle') }}
-        </div>
-      </div>
-    </div>
-
-    <div class="analysis-flow">
-      <div v-for="step in analysisSteps" :key="step.title" class="analysis-step">
-        <VIcon :icon="step.icon" color="primary" size="20" />
-        <div class="min-w-0">
-          <div class="text-body-2 font-weight-medium">
-            {{ step.title }}
-          </div>
-          <div class="text-body-2 step-value">
-            {{ step.value }}
-          </div>
-        </div>
-      </div>
-    </div>
-  </section>
 </template>
 
 <style scoped>
@@ -387,10 +343,10 @@ onMounted(() => {
 
 .result-stack {
   display: grid;
-  gap: 0.9rem;
+  gap: 1rem;
 }
 
-.rule-result-card {
+.result-hero {
   display: grid;
   grid-template-columns: 5rem minmax(0, 1fr);
   gap: 0.85rem;
@@ -401,7 +357,7 @@ onMounted(() => {
   padding: 0.75rem;
 }
 
-.rule-result-card--matched {
+.result-hero--matched {
   background: rgba(var(--v-theme-success), 0.08);
 }
 
@@ -412,11 +368,16 @@ onMounted(() => {
   border: var(--app-surface-border);
   border-radius: var(--app-surface-radius);
   background: rgba(var(--v-theme-surface-variant), 0.32);
+  text-align: center;
 }
 
 .priority-badge--matched {
   border-color: rgba(var(--v-theme-success), 0.42);
   background: rgba(var(--v-theme-success), 0.1);
+}
+
+.priority-badge--empty {
+  opacity: 0.7;
 }
 
 .priority-value {
@@ -425,41 +386,68 @@ onMounted(() => {
   line-height: 1;
 }
 
-.chip-row {
+.hero-body {
+  min-inline-size: 0;
+}
+
+.hero-heading {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.hero-title-text {
+  min-inline-size: 0;
+}
+
+.hero-chips {
   display: flex;
   flex-wrap: wrap;
   gap: 0.35rem;
 }
 
-.result-heading {
+.pipeline {
   display: flex;
-  gap: 0.5rem;
-  align-items: center;
+  flex-direction: column;
 }
 
-.result-title-text {
+.pipeline-step {
+  display: grid;
+  grid-template-columns: 1.75rem minmax(0, 1fr);
+  gap: 0.75rem;
+}
+
+.pipeline-marker {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-block-size: 100%;
+}
+
+.pipeline-connector {
+  flex: 1;
+  inline-size: 2px;
+  margin-block-start: 0.3rem;
+  background: rgba(var(--v-theme-primary), 0.25);
+}
+
+.pipeline-body {
+  padding-block-end: 0.9rem;
   min-inline-size: 0;
 }
 
-.summary-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.55rem;
+.pipeline-step:last-child .pipeline-body {
+  padding-block-end: 0;
 }
 
-.summary-tile {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
-  gap: 0.5rem;
-  align-items: center;
-  border: var(--app-surface-border);
-  border-radius: var(--app-surface-radius);
-  background: rgba(var(--v-theme-surface-variant), 0.22);
-  padding: 0.65rem;
+.pipeline-label {
+  letter-spacing: 0.02em;
 }
 
-.summary-icon {
-  color: rgb(var(--v-theme-primary));
+.pipeline-value {
+  margin-block-start: 0.2rem;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .empty-state {
@@ -472,47 +460,16 @@ onMounted(() => {
   text-align: center;
 }
 
-.analysis-flow {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 0.6rem;
-}
-
-.analysis-step {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
-  gap: 0.55rem;
-  border: var(--app-surface-border);
-  border-radius: var(--app-surface-radius);
-  background: rgba(var(--v-theme-surface-variant), 0.2);
-  padding: 0.7rem;
-}
-
-.step-value {
-  overflow: hidden;
-  margin-block-start: 0.35rem;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 @media (max-width: 760px) {
-  .shortcut-workbench,
-  .analysis-flow {
+  .shortcut-workbench {
     grid-template-columns: minmax(0, 1fr);
   }
 
-  .summary-grid {
-    grid-template-columns: minmax(0, 1fr);
+  .hero-heading {
+    flex-wrap: wrap;
   }
 
-  .result-heading {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr);
-    gap: 0.35rem;
-    align-items: start;
-  }
-
-  .result-title-text {
+  .hero-title-text {
     overflow: visible;
     text-overflow: clip;
     white-space: normal;
@@ -524,8 +481,20 @@ onMounted(() => {
     padding: 0.8rem;
   }
 
-  .rule-result-card {
+  .result-hero {
     grid-template-columns: minmax(0, 1fr);
+  }
+
+  .priority-badge {
+    grid-auto-flow: column;
+    justify-content: start;
+    min-block-size: 0;
+    padding: 0.5rem 0.75rem;
+    gap: 0.5rem;
+  }
+
+  .priority-value {
+    font-size: 1.35rem;
   }
 }
 </style>


### PR DESCRIPTION
## 背景

捷径-识别 和 捷径-规则 的测试结果页面存在大量信息重复展示，且移动端适配与全局主题 token 使用需要优化。

## 问题分析

**NameTestView（识别）三处重复：**
- 年份/类型/季集同时出现在 hero 副标题、summary 网格、解析链路 meta 步骤
- 数据源（TMDB/Douban ID）同时出现在 summary 网格和解析链路 media 步骤
- 原始字符串同时出现在解析链路和应用识别词区块

**RuleTestView（规则）重复更严重：**
- 优先级同时出现在 priority-badge、summary 网格、解析链路 priority 步骤（三处）
- 规则组同时出现在 summary 网格和解析链路 group 步骤
- 媒体标题同时出现在副标题、summary 网格、解析链路 media 步骤

## 改动方案

将原来的「结果卡片 + 汇总网格 + 解析面板」三段式结构，整合为「Hero 卡片 + 垂直 Pipeline」两段式：

**NameTestView：**
- Hero 卡片：海报 + 状态图标 + 标题 + 副标题（年·类型·季集）+ 资源 chips
- Pipeline：原始标题 → 元信息 → 媒体匹配
- 应用识别词：仅当存在时显示为 chips（去掉重复的 org_string 行）

**RuleTestView：**
- Hero 卡片：优先级徽章 + 命中状态图标 + 状态文案 + 副标题 + 资源 chips
- Pipeline：规则组（含规则数）→ 媒体识别 → 过滤命中（移除独立的 priority 步骤，优先级已在 hero 徽章中突出展示）

## 移动端适配

- `<760px`：双列网格改为单列堆叠，标题允许换行不截断
- `<420px`：面板 padding 收缩至 0.8rem；RuleTestView 的 hero 改为单列，priority-badge 转为水平内联布局

## 全局主题 token

全部沿用项目 `--app-*` token，未硬编码：
- 边框/圆角：`--app-surface-border`、`--app-surface-radius`、`--app-control-radius`
- 背景/磨砂：`--app-grouped-list-background`、`--app-grouped-list-backdrop-filter`
- 阴影：`--app-surface-shadow`
- 颜色：`rgb(var(--v-theme-primary/error/success/warning/surface-variant))`
- 文本透明度：`var(--v-medium-emphasis-opacity)`

## 验证

- `yarn typecheck` 通过
- `stylelint` 无报错
- `yarn test:run` 88 个测试全部通过

## 影响范围

仅修改两个视图文件，无 API/类型/store 层改动：
- `src/views/system/NameTestView.vue`
- `src/views/system/RuleTestView.vue`

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 5e5a8834bbb107ca1f8866beadf8f485a9806d6d

- 重构捷径测试结果为 Hero 与流程链路
- 合并重复元数据、规则与优先级展示
- 增加状态色、空优先级及换行处理
- 优化窄屏布局；未新增自动化测试

<!-- pr-agent-summary:end -->