### PR TITLE
test(subscribe): cover list management workflows

### DIFF
--- a/src/composables/__tests__/useMediaSubscribe.spec.ts
+++ b/src/composables/__tests__/useMediaSubscribe.spec.ts
@@ -234,6 +234,30 @@ describe('useMediaSubscribe entry flows', () => {
     expect(mocks.doneProgress).toHaveBeenCalledOnce()
   })
 
+  it('keeps a successful creation successful when default configuration loading fails', async () => {
+    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const media = createSubscribeMovie({ title: '辅助查询失败电影', tmdb_id: 111 })
+    const created = vi.fn()
+    const configQueried = vi.fn()
+    server.use(
+      createSubscribeHandler({ data: { id: 511 }, success: true }, 200, created),
+      defaultSubscribeConfigHandler('电影', {}, 500, configQueried),
+    )
+    await renderSubscribeHarness({ media })
+
+    await fireEvent.click(screen.getByRole('button', { name: 'primary' }))
+
+    await waitFor(() => expect(created).toHaveBeenCalledOnce())
+    await waitFor(() => expect(configQueried).toHaveBeenCalledOnce())
+    await waitFor(() => expect(mocks.doneProgress).toHaveBeenCalledOnce())
+    expect(screen.getByTestId('subscribed')).toHaveTextContent('true')
+    expect(mocks.cacheStatus).toHaveBeenCalledWith('status:all', true)
+    expect(mocks.toastSuccess).toHaveBeenCalledOnce()
+    expect(mocks.toastError).not.toHaveBeenCalled()
+    expect(mocks.openSharedDialog).not.toHaveBeenCalled()
+    consoleLog.mockRestore()
+  })
+
   it('opens the mode chooser for an existing movie and creates the selected mode', async () => {
     const media = createSubscribeMovie({ title: '已入库电影', tmdb_id: 102 })
     const created = vi.fn()

--- a/src/pages/__tests__/recommend.spec.ts
+++ b/src/pages/__tests__/recommend.spec.ts
@@ -54,10 +54,6 @@ interface SharedDialogEvents {
   'update:modelValue': (value: boolean) => void
 }
 
-interface SharedDialogProps {
-  valueGetter: (item: { title: string }) => string
-}
-
 async function renderRecommend(options: { superUser?: boolean; discovery?: boolean } = {}) {
   return renderWithProviders(RecommendPage, {
     initialRoute: '/recommend',
@@ -196,7 +192,9 @@ describe('recommend page', () => {
     const settingsButton = document.querySelector<HTMLButtonElement>('.compact-fab') as HTMLButtonElement
 
     await user.click(settingsButton)
-    const dialogProps = mocks.openSharedDialog.mock.calls[0][1] as SharedDialogProps
+    const dialogProps = mocks.openSharedDialog.mock.calls[0][1] as {
+      valueGetter: (item: { title: string }) => string
+    }
     const firstDialogEvents = mocks.openSharedDialog.mock.calls[0][2] as SharedDialogEvents
     expect(dialogProps.valueGetter({ title: '流行趋势' })).toBe('流行趋势')
 

--- a/src/pages/__tests__/subscribe.spec.ts
+++ b/src/pages/__tests__/subscribe.spec.ts
@@ -1,4 +1,5 @@
 import SubscribePage from '@/pages/subscribe.vue'
+import type { DynamicButtonMenuItem } from '@/composables/useDynamicButton'
 import { DEFAULT_PERMISSIONS } from '@/utils/permission'
 import { fireEvent, screen, waitFor } from '@testing-library/vue'
 import { renderWithProviders } from '@tests/support/render'
@@ -176,15 +177,9 @@ interface HeaderTabConfig {
   appendButtons: HeaderButtonConfig[]
 }
 
-interface DynamicMenuItem {
-  titleKey?: string
-  disabled?: boolean
-  action: () => void
-}
-
 interface DynamicButtonConfig {
   icon: MaybeRef<string>
-  menuItems?: MaybeRef<DynamicMenuItem[] | undefined>
+  menuItems?: MaybeRef<DynamicButtonMenuItem[] | undefined>
   onClick?: () => void
   show?: MaybeRef<boolean>
 }

--- a/src/pages/__tests__/subscribe.spec.ts
+++ b/src/pages/__tests__/subscribe.spec.ts
@@ -1,0 +1,472 @@
+import SubscribePage from '@/pages/subscribe.vue'
+import { DEFAULT_PERMISSIONS } from '@/utils/permission'
+import { fireEvent, screen, waitFor } from '@testing-library/vue'
+import { renderWithProviders } from '@tests/support/render'
+import {
+  computed,
+  defineComponent,
+  h,
+  nextTick,
+  ref,
+  unref,
+  type ComputedRef,
+  type Ref,
+} from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  appMode: false,
+  openSharedDialog: vi.fn(),
+  registerHeaderTab: vi.fn(),
+  useDynamicButton: vi.fn(),
+}))
+
+vi.mock('@/composables/useDynamicHeaderTab', () => ({
+  useDynamicHeaderTab: () => ({ registerHeaderTab: mocks.registerHeaderTab }),
+}))
+
+vi.mock('@/composables/useDynamicButton', () => ({
+  useDynamicButton: (options: unknown) => mocks.useDynamicButton(options),
+}))
+
+vi.mock('@/composables/usePWA', async () => {
+  const { computed } = await import('vue')
+  return {
+    usePWA: () => ({ appMode: computed(() => mocks.appMode) }),
+  }
+})
+
+vi.mock('@/composables/useSharedDialog', () => ({
+  openSharedDialog: (...args: unknown[]) => mocks.openSharedDialog(...args),
+}))
+
+interface SubscribeBatchState {
+  enabled: boolean
+  selectedCount: number
+  totalCount: number
+  allSelected: boolean
+}
+
+const SubscribeListViewStub = defineComponent({
+  name: 'SubscribeListView',
+  props: {
+    type: String,
+    subid: String,
+    keyword: String,
+    statusFilter: String,
+    sortMode: {
+      type: Boolean,
+      default: false,
+    },
+    sortBy: {
+      type: String,
+      default: '',
+    },
+    active: {
+      type: Boolean,
+      default: true,
+    },
+  },
+  emits: ['update:sortMode', 'update:sortBy', 'batch-state-change'],
+  setup(props, { emit, expose }) {
+    const lastCommand = ref('none')
+    const batchState = ref<SubscribeBatchState>({
+      enabled: false,
+      selectedCount: 0,
+      totalCount: 0,
+      allSelected: false,
+    })
+
+    const runCommand = (command: string) => {
+      lastCommand.value = command
+    }
+    const publishBatchState = (state: SubscribeBatchState) => {
+      batchState.value = state
+      emit('batch-state-change', state)
+    }
+
+    expose({
+      enterBatchMode: () => runCommand('enter-batch'),
+      exitBatchMode: () => runCommand('exit-batch'),
+      toggleSelectAll: () => runCommand('toggle-select-all'),
+      batchEnableSubscribes: () => runCommand('batch-enable'),
+      batchPauseSubscribes: () => runCommand('batch-pause'),
+      batchDeleteSubscribes: () => runCommand('batch-delete'),
+      openHistoryDialog: () => runCommand('open-history'),
+    })
+
+    return () =>
+      h('section', { 'aria-label': 'subscription list stub' }, [
+        h('button', { 'data-menu-activator': 'filter-btn', type: 'button' }, 'filter activator'),
+        h('output', { 'aria-label': 'list type' }, props.type ?? ''),
+        h('output', { 'aria-label': 'list subscription id' }, props.subid ?? ''),
+        h('output', { 'aria-label': 'list keyword' }, props.keyword ?? ''),
+        h('output', { 'aria-label': 'list status filter' }, props.statusFilter ?? ''),
+        h('output', { 'aria-label': 'list sort mode' }, String(props.sortMode)),
+        h('output', { 'aria-label': 'list sort by' }, props.sortBy ?? ''),
+        h('output', { 'aria-label': 'list active state' }, String(props.active)),
+        h('output', { 'aria-label': 'list batch state' }, JSON.stringify(batchState.value)),
+        h('output', { 'aria-label': 'last list command' }, lastCommand.value),
+        h(
+          'button',
+          { type: 'button', onClick: () => emit('update:sortMode', true) },
+          'emit sort mode on',
+        ),
+        h(
+          'button',
+          { type: 'button', onClick: () => emit('update:sortMode', false) },
+          'emit sort mode off',
+        ),
+        h('button', { type: 'button', onClick: () => emit('update:sortBy', 'date') }, 'emit date sort'),
+        h(
+          'button',
+          {
+            type: 'button',
+            onClick: () =>
+              publishBatchState({ enabled: true, selectedCount: 2, totalCount: 3, allSelected: false }),
+          },
+          'publish batch selection',
+        ),
+        h(
+          'button',
+          {
+            type: 'button',
+            onClick: () =>
+              publishBatchState({ enabled: true, selectedCount: 3, totalCount: 3, allSelected: true }),
+          },
+          'publish all selected batch',
+        ),
+      ])
+  },
+})
+
+const SubscribePopularViewStub = defineComponent({
+  name: 'SubscribePopularView',
+  props: { type: String },
+  setup(props) {
+    return () => h('section', { 'aria-label': 'popular subscription stub' }, props.type ?? '')
+  },
+})
+
+const SubscribeShareViewStub = defineComponent({
+  name: 'SubscribeShareView',
+  props: { keyword: String },
+  setup(props) {
+    return () =>
+      h('section', { 'aria-label': 'shared subscription stub' }, [
+        h('button', { 'data-menu-activator': 'share-filter-btn', type: 'button' }, 'share filter activator'),
+        h('output', { 'aria-label': 'share keyword' }, props.keyword ?? ''),
+      ])
+  },
+})
+
+type MaybeRef<T> = T | Ref<T> | ComputedRef<T>
+
+interface HeaderButtonConfig {
+  icon: string
+  dataAttr?: string
+  action?: () => void
+  color?: MaybeRef<string>
+  show?: MaybeRef<boolean>
+}
+
+interface HeaderTabConfig {
+  items: MaybeRef<Array<{ title: string; tab: string }>>
+  modelValue: Ref<string>
+  appendButtons: HeaderButtonConfig[]
+}
+
+interface DynamicMenuItem {
+  titleKey?: string
+  disabled?: boolean
+  action: () => void
+}
+
+interface DynamicButtonConfig {
+  icon: MaybeRef<string>
+  menuItems?: MaybeRef<DynamicMenuItem[] | undefined>
+  onClick?: () => void
+  show?: MaybeRef<boolean>
+}
+
+interface RenderSubscribeOptions {
+  appMode?: boolean
+  initialRoute?: string
+  subType?: '电影' | '电视剧'
+  subscribePermission?: boolean
+  superUser?: boolean
+}
+
+async function renderSubscribe(options: RenderSubscribeOptions = {}) {
+  const subType = options.subType ?? '电影'
+  mocks.appMode = options.appMode ?? false
+
+  return renderWithProviders(SubscribePage, {
+    initialRoute: options.initialRoute ?? `/subscribe/${subType === '电影' ? 'movie' : 'tv'}`,
+    initialRouteMeta: { subType },
+    initialState: {
+      user: {
+        permissions: {
+          ...DEFAULT_PERMISSIONS,
+          subscribe: options.subscribePermission ?? true,
+        },
+        superUser: options.superUser ?? false,
+      },
+    },
+    global: {
+      stubs: {
+        SubscribeListView: SubscribeListViewStub,
+        SubscribePopularView: SubscribePopularViewStub,
+        SubscribeShareView: SubscribeShareViewStub,
+      },
+    },
+  })
+}
+
+function getHeaderConfig() {
+  return mocks.registerHeaderTab.mock.calls.at(-1)?.[0] as HeaderTabConfig
+}
+
+function getDynamicButtonConfig() {
+  return mocks.useDynamicButton.mock.calls.at(-1)?.[0] as DynamicButtonConfig
+}
+
+function getHeaderButton(predicate: (button: HeaderButtonConfig) => boolean) {
+  const button = getHeaderConfig().appendButtons.find(predicate)
+  if (!button) throw new Error('Expected dynamic header button was not registered')
+  return button
+}
+
+function getListOutput(label: string) {
+  return screen.getByLabelText(label)
+}
+
+describe('subscribe page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.appMode = false
+  })
+
+  it('uses movie route meta and query values to register the movie page contract', async () => {
+    const { router } = await renderSubscribe({ initialRoute: '/subscribe/movie?id=42' })
+
+    await waitFor(() => expect(getListOutput('list active state')).toHaveTextContent('true'))
+    const header = getHeaderConfig()
+
+    expect(router.currentRoute.value.meta.subType).toBe('电影')
+    expect(unref(header.items).map(item => item.tab)).toEqual(['mysub', 'popular'])
+    expect(header.modelValue.value).toBe('mysub')
+    expect(getListOutput('list type')).toHaveTextContent('电影')
+    expect(getListOutput('list subscription id')).toHaveTextContent('42')
+  })
+
+  it('uses TV route meta and tab query to expose the share page contract', async () => {
+    const { router } = await renderSubscribe({
+      initialRoute: '/subscribe/tv?tab=share&id=73',
+      subType: '电视剧',
+    })
+    const header = getHeaderConfig()
+
+    expect(router.currentRoute.value.meta.subType).toBe('电视剧')
+    expect(unref(header.items).map(item => item.tab)).toEqual(['mysub', 'popular', 'share'])
+    expect(header.modelValue.value).toBe('share')
+    expect(screen.getByLabelText('share keyword')).toHaveTextContent('')
+  })
+
+  it.each([
+    ['movie value', '电影' as const, 'last_update', 'last_update'],
+    ['TV-only value', '电视剧' as const, 'lack_episode', 'lack_episode'],
+    ['invalid value', '电视剧' as const, 'unexpected', ''],
+    ['TV-only value on movies', '电影' as const, 'lack_episode', ''],
+  ])('normalizes stored sorting for %s', async (_case, subType, storedSort, expectedSort) => {
+    localStorage.setItem(`MPSubscribeSortBy:${subType}`, storedSort)
+
+    await renderSubscribe({ subType })
+
+    expect(getListOutput('list sort by')).toHaveTextContent(expectedSort)
+  })
+
+  it('keeps page state usable when sort storage reads or writes fail', async () => {
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const getItem = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('storage read failed')
+    })
+
+    await renderSubscribe()
+
+    expect(getListOutput('list sort by')).toHaveTextContent('')
+    expect(consoleWarn).toHaveBeenCalledWith('读取订阅排序方式失败:', expect.any(Error))
+    getItem.mockRestore()
+
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('storage write failed')
+    })
+    await fireEvent.click(screen.getByRole('button', { name: 'emit date sort' }))
+
+    await waitFor(() => expect(getListOutput('list sort by')).toHaveTextContent('date'))
+    expect(consoleWarn).toHaveBeenCalledWith('保存订阅排序方式失败:', expect.any(Error))
+  })
+
+  it('coordinates filter and sort state through header actions and list emits', async () => {
+    await renderSubscribe({ subType: '电视剧' })
+    const filterButton = getHeaderButton(button => button.dataAttr === 'filter-btn')
+    const sortButton = getHeaderButton(button => button.icon === 'mdi-sort-variant')
+
+    filterButton.action?.()
+    await nextTick()
+    const nameInput = await screen.findByPlaceholderText('名称')
+    await fireEvent.update(nameInput, 'Matrix')
+    expect(getListOutput('list keyword')).toHaveTextContent('Matrix')
+
+    await fireEvent.click(screen.getByText('暂停'))
+    expect(getListOutput('list status filter')).toHaveTextContent('paused')
+
+    sortButton.action?.()
+    await nextTick()
+    expect(getListOutput('list sort mode')).toHaveTextContent('true')
+    expect(getListOutput('list sort by')).toHaveTextContent('custom')
+
+    await fireEvent.click(screen.getByRole('button', { name: 'emit sort mode off' }))
+    await fireEvent.click(screen.getByRole('button', { name: 'emit date sort' }))
+    expect(getListOutput('list sort mode')).toHaveTextContent('false')
+    expect(getListOutput('list sort by')).toHaveTextContent('date')
+  })
+
+  it('exits batch management before entering drag sorting', async () => {
+    await renderSubscribe({ appMode: true })
+    const sortButton = getHeaderButton(button => button.icon === 'mdi-sort-variant')
+    const batchButton = getHeaderButton(button => button.icon === 'mdi-checkbox-multiple-marked-outline')
+
+    await fireEvent.click(screen.getByRole('button', { name: 'publish batch selection' }))
+    expect(unref(getDynamicButtonConfig().show)).toBe(true)
+
+    sortButton.action?.()
+    await nextTick()
+    expect(getListOutput('last list command')).toHaveTextContent('exit-batch')
+    expect(getListOutput('list sort mode')).toHaveTextContent('true')
+    expect(getListOutput('list sort by')).toHaveTextContent('custom')
+    expect(unref(batchButton.color)).toBe('gray')
+    expect(unref(getDynamicButtonConfig().show)).toBe(false)
+  })
+
+  it('delegates PWA batch actions to the list public API', async () => {
+    await renderSubscribe({ appMode: true })
+    const batchButton = getHeaderButton(button => button.icon === 'mdi-checkbox-multiple-marked-outline')
+
+    batchButton.action?.()
+    await nextTick()
+    expect(getListOutput('last list command')).toHaveTextContent('enter-batch')
+
+    await fireEvent.click(screen.getByRole('button', { name: 'publish batch selection' }))
+    const dynamicButton = getDynamicButtonConfig()
+    const menuItems = unref(dynamicButton.menuItems) ?? []
+
+    expect(unref(dynamicButton.show)).toBe(true)
+    expect(unref(dynamicButton.icon)).toBe('mdi-checkbox-multiple-marked-outline')
+    expect(menuItems.find(item => item.titleKey === 'subscribe.batchSelectAll')?.disabled).toBe(false)
+
+    for (const [titleKey, command] of [
+      ['subscribe.batchSelectAll', 'toggle-select-all'],
+      ['subscribe.batchEnable', 'batch-enable'],
+      ['subscribe.batchPause', 'batch-pause'],
+      ['subscribe.batchDelete', 'batch-delete'],
+    ] as const) {
+      menuItems.find(item => item.titleKey === titleKey)?.action()
+      await nextTick()
+      expect(getListOutput('last list command')).toHaveTextContent(command)
+    }
+
+    dynamicButton.onClick?.()
+    await nextTick()
+    expect(getListOutput('last list command')).toHaveTextContent('exit-batch')
+  })
+
+  it('exits batch mode when the header leaves the personal subscription tab', async () => {
+    await renderSubscribe({ appMode: true, subType: '电视剧' })
+    await fireEvent.click(screen.getByRole('button', { name: 'publish batch selection' }))
+
+    getHeaderConfig().modelValue.value = 'popular'
+    await nextTick()
+
+    expect(getListOutput('last list command')).toHaveTextContent('exit-batch')
+    expect(getListOutput('list active state')).toHaveTextContent('false')
+    expect(unref(getDynamicButtonConfig().icon)).toBe('mdi-clipboard-edit-outline')
+  })
+
+  it('exposes administrator history and default-rule actions on desktop and PWA', async () => {
+    const { unmount } = await renderSubscribe({ superUser: true })
+
+    await waitFor(() => expect(document.querySelectorAll('.compact-fab button')).toHaveLength(2))
+    const [historyButton, defaultRuleButton] = document.querySelectorAll<HTMLButtonElement>('.compact-fab button')
+
+    await fireEvent.click(historyButton)
+    expect(getListOutput('last list command')).toHaveTextContent('open-history')
+    await fireEvent.click(defaultRuleButton)
+    expect(mocks.openSharedDialog).toHaveBeenCalledWith(
+      expect.any(Object),
+      { default: true, type: '电影' },
+      {},
+      { closeOn: ['close', 'save'] },
+    )
+    unmount()
+
+    await renderSubscribe({ appMode: true, superUser: true })
+    const dynamicButton = getDynamicButtonConfig()
+    expect(unref(dynamicButton.show)).toBe(true)
+    expect(unref(dynamicButton.icon)).toBe('mdi-history')
+    expect(unref(dynamicButton.menuItems)?.map(item => item.titleKey)).toEqual([
+      'dialog.subscribeHistory.title',
+      'dialog.subscribeEdit.titleDefault',
+    ])
+  })
+
+  it.each([
+    [true, true],
+    [false, false],
+  ])('gates the PWA share statistics action by subscribe permission=%s', async (permission, visible) => {
+    await renderSubscribe({
+      appMode: true,
+      initialRoute: '/subscribe/tv?tab=share',
+      subType: '电视剧',
+      subscribePermission: permission,
+    })
+    const dynamicButton = getDynamicButtonConfig()
+
+    expect(unref(dynamicButton.show)).toBe(visible)
+    if (visible) {
+      expect(unref(dynamicButton.icon)).toBe('mdi-chart-line')
+      dynamicButton.onClick?.()
+      expect(mocks.openSharedDialog).toHaveBeenCalledWith(
+        expect.any(Object),
+        {},
+        {},
+        { closeOn: ['close'] },
+      )
+    }
+  })
+
+  it('debounces and trims share search, then cancels pending work on unmount', async () => {
+    const { unmount } = await renderSubscribe({
+      initialRoute: '/subscribe/tv?tab=share',
+      subType: '电视剧',
+    })
+    getHeaderButton(button => button.dataAttr === 'share-filter-btn').action?.()
+    await nextTick()
+    const keywordInput = await screen.findByPlaceholderText('关键词')
+
+    vi.useFakeTimers()
+    await fireEvent.update(keywordInput, '  science fiction  ')
+    expect(getListOutput('share keyword')).toHaveTextContent('')
+    vi.advanceTimersByTime(299)
+    await nextTick()
+    expect(getListOutput('share keyword')).toHaveTextContent('')
+    vi.advanceTimersByTime(1)
+    await nextTick()
+    expect(getListOutput('share keyword')).toHaveTextContent('science fiction')
+
+    await fireEvent.update(keywordInput, 'pending')
+    expect(vi.getTimerCount()).toBeGreaterThan(0)
+    unmount()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+})

--- a/src/pages/subscribe.vue
+++ b/src/pages/subscribe.vue
@@ -282,12 +282,18 @@ function batchDeleteSelectedSubscribes() {
   subscribeListViewRef.value?.batchDeleteSubscribes()
 }
 
-// 切换订阅拖拽排序模式，进入时固定使用自定义排序。
+// 批量选择与拖拽排序互斥，进入排序模式时清空批量选择。
 function toggleSubscribeSortMode() {
-  if (!subscribeSortMode.value) {
+  const nextSortMode = !subscribeSortMode.value
+
+  if (nextSortMode) {
+    if (subscribeBatchState.value.enabled) {
+      exitSubscribeBatchMode()
+    }
     subscribeSortBy.value = 'custom'
   }
-  subscribeSortMode.value = !subscribeSortMode.value
+
+  subscribeSortMode.value = nextSortMode
 }
 
 const shareKeywordUpdater = debounce((keyword: string) => {

--- a/src/views/subscribe/SubscribeListView.vue
+++ b/src/views/subscribe/SubscribeListView.vue
@@ -62,6 +62,26 @@ const emit = defineEmits<{
 
 type SubscribeSortBy = 'custom' | 'last_update' | 'date' | 'lack_episode'
 
+// 自定义顺序的持久化条目，只允许有限数值 ID 参与排序。
+interface SubscribeOrderItem {
+  id: number
+}
+
+// 订阅写操作的业务结果；HTTP 成功不代表业务操作成功。
+interface SubscribeMutationResponse {
+  message?: string
+  success: boolean
+}
+
+// 批量操作的确认文案、请求执行器和结果文案契约。
+interface BatchOperationOptions {
+  confirmKey: string
+  errorKey: string
+  failedKey: string
+  request: (id: number) => Promise<unknown>
+  successKey: string
+}
+
 // 订阅批量模式状态快照，供父页面渲染外部批量操作按钮。
 interface SubscribeBatchState {
   enabled: boolean
@@ -76,11 +96,17 @@ let isRefreshed = ref(false)
 // 刷新状态
 const loading = ref(false)
 
+// 最近一次列表请求是否失败，用于保留旧数据时持续展示错误状态。
+const loadError = ref(false)
+
 // 数据列表
 const dataList = ref<Subscribe[]>([])
 
 // 订阅顺序配置
-const orderConfig = ref<{ id: number }[]>([])
+const orderConfig = ref<SubscribeOrderItem[]>([])
+
+// 顺序保存期间锁定拖拽，避免并发请求覆盖最后确认的顺序。
+const orderSaving = ref(false)
 
 // 显示的订阅列表
 const displayList = ref<Subscribe[]>([])
@@ -88,12 +114,14 @@ const displayList = ref<Subscribe[]>([])
 // 批量管理相关状态
 const isBatchMode = ref(false)
 const selectedSubscribes = ref<number[]>([])
+// 每次进入批量模式创建新会话，迟到请求不得修改后续会话的选择状态。
+let batchModeSessionId = 0
 
 const normalizedKeyword = computed(() => props.keyword?.trim().toLowerCase() || '')
 const selectedSubscribesSet = computed(() => new Set(selectedSubscribes.value))
 const hasCustomOrder = computed(() => orderConfig.value.length > 0)
 const isAllSubscribesSelected = computed(
-  () => displayList.value.length > 0 && selectedSubscribes.value.length === displayList.value.length,
+  () => displayList.value.length > 0 && displayList.value.every(item => selectedSubscribesSet.value.has(item.id)),
 )
 
 // 归一化订阅排序方式，电影订阅不使用缺失集数排序。
@@ -185,6 +213,25 @@ function getSubscribeTimeValue(value?: string) {
   return Number.isNaN(compatibleTime) ? 0 : compatibleTime
 }
 
+// 顺序配置属于通用 JSON 存储，只有完整的数值 ID 数组才能参与排序。
+function normalizeSubscribeOrderConfig(value: unknown): SubscribeOrderItem[] {
+  if (
+    !Array.isArray(value) ||
+    !value.every(
+      item =>
+        typeof item === 'object' &&
+        item !== null &&
+        'id' in item &&
+        typeof item.id === 'number' &&
+        Number.isFinite(item.id),
+    )
+  ) {
+    return []
+  }
+
+  return value.map(item => ({ id: item.id }))
+}
+
 // 按自定义顺序排序订阅，未配置顺序的订阅按添加时间倒序补齐。
 function sortByCustomOrder(a: Subscribe, b: Subscribe, orderIndexMap: Map<number, number>) {
   const aIndex = orderIndexMap.get(a.id) ?? Number.MAX_SAFE_INTEGER
@@ -253,6 +300,8 @@ watch(
     sortSubscribeList(nextDisplayList)
 
     displayList.value = nextDisplayList
+    const visibleIds = new Set(nextDisplayList.map(item => item.id))
+    selectedSubscribes.value = selectedSubscribes.value.filter(id => visibleIds.has(id))
   },
   { immediate: true },
 )
@@ -277,9 +326,7 @@ watch(
 async function loadSubscribeOrderConfig() {
   try {
     const response = await api.get(`/user/config/${orderRequestKey.value}`)
-    if (response && response.data && response.data.value) {
-      orderConfig.value = response.data.value
-    }
+    orderConfig.value = normalizeSubscribeOrderConfig(response?.data?.value)
     syncDefaultSortBy()
   } catch (error) {
     console.error('Failed to load subscribe order config:', error)
@@ -290,31 +337,64 @@ async function loadSubscribeOrderConfig() {
 
 // 保存顺序设置
 async function saveSubscribeOrder() {
-  // 顺序配置
-  const orderObj = displayList.value.map(item => ({ id: item.id }))
-  orderConfig.value = orderObj
-  emit('update:sortBy', 'custom')
+  if (orderSaving.value) {
+    const restoredDisplayList = [...displayList.value]
+    sortSubscribeList(restoredDisplayList)
+    displayList.value = restoredDisplayList
+    return
+  }
 
-  // 保存到服务端
+  const confirmedOrder = orderConfig.value.map(item => ({ ...item }))
+  const orderObj = displayList.value.map(item => ({ id: item.id }))
+  orderSaving.value = true
+
   try {
-    await api.post(`/user/config/${orderRequestKey.value}`, orderObj)
+    const response = (await api.post(
+      `/user/config/${orderRequestKey.value}`,
+      orderObj,
+    )) as unknown as SubscribeMutationResponse
+    if (response?.success !== true) {
+      throw new Error(response?.message || 'Failed to save subscribe order')
+    }
+
+    orderConfig.value = orderObj
+    // 保存响应不得覆盖请求期间由父页面选择的新排序方式。
+    if (effectiveSortBy.value === 'custom') {
+      emit('update:sortBy', 'custom')
+    }
   } catch (error) {
     console.error(error)
+    orderConfig.value = confirmedOrder
+    const restoredDisplayList = [...displayList.value]
+    sortSubscribeList(restoredDisplayList)
+    displayList.value = restoredDisplayList
+    $toast.error(t('subscribe.requestFailed'))
+  } finally {
+    orderSaving.value = false
   }
 }
 
 // 获取订阅列表数据
 async function fetchData(context: KeepAliveRefreshContext = {}) {
   const showLoading = !context.silent || !isRefreshed.value
+  const isInitialLoad = !isRefreshed.value
 
   try {
     if (showLoading) {
       loading.value = true
     }
     dataList.value = await api.get('subscribe/')
+    loadError.value = false
     isRefreshed.value = true
   } catch (error) {
     console.error(error)
+    loadError.value = true
+    if (isInitialLoad) {
+      isRefreshed.value = true
+    }
+    if (!context.silent || isInitialLoad) {
+      $toast.error(t('subscribe.requestFailed'))
+    }
   } finally {
     if (showLoading) {
       loading.value = false
@@ -350,6 +430,9 @@ function emitBatchStateChange() {
 
 // 进入批量模式。
 function enterBatchMode() {
+  if (!isBatchMode.value) {
+    batchModeSessionId += 1
+  }
   isBatchMode.value = true
 }
 
@@ -388,121 +471,96 @@ function toggleSelectSubscribe(id: number) {
   }
 }
 
-// 批量删除已选中的订阅。
-async function batchDeleteSubscribes() {
+function isSuccessfulMutationResult(result: PromiseSettledResult<unknown>) {
+  return (
+    result.status === 'fulfilled' &&
+    typeof result.value === 'object' &&
+    result.value !== null &&
+    'success' in result.value &&
+    result.value.success === true
+  )
+}
+
+// 批量结果必须与开始操作时的 ID 快照对应，避免异步期间筛选或选择变化造成目标错配。
+async function runBatchOperation(options: BatchOperationOptions) {
   if (selectedSubscribes.value.length === 0) {
     $toast.warning(t('subscribe.noSelectedItems'))
     return
   }
 
+  const targetIds = [...selectedSubscribes.value]
+  const operationBatchSessionId = batchModeSessionId
   const isConfirmed = await createConfirm({
     title: t('common.confirm'),
-    content: t('subscribe.batchDeleteConfirm', { count: selectedSubscribes.value.length }),
+    content: t(options.confirmKey, { count: targetIds.length }),
   })
 
-  if (!isConfirmed) return
+  if (!isConfirmed || !isBatchMode.value || batchModeSessionId !== operationBatchSessionId) return
 
   try {
     loading.value = true
-    const promises = selectedSubscribes.value.map(id => api.delete(`subscribe/${id}`))
-    const results = await Promise.allSettled(promises)
-
-    const successCount = results.filter(result => result.status === 'fulfilled').length
-    const failedCount = results.length - successCount
+    const results = await Promise.allSettled(targetIds.map(id => options.request(id)))
+    const failedIds = targetIds.filter((_id, index) => !isSuccessfulMutationResult(results[index]))
+    const successCount = targetIds.length - failedIds.length
 
     if (successCount > 0) {
-      $toast.success(t('subscribe.batchDeleteSuccess', { count: successCount }))
+      $toast.success(t(options.successKey, { count: successCount }))
     }
-    if (failedCount > 0) {
-      $toast.error(t('subscribe.batchDeleteFailed', { count: failedCount }))
+    if (failedIds.length > 0) {
+      $toast.error(t(options.failedKey, { count: failedIds.length }))
     }
 
     await fetchData()
-    exitBatchMode()
+    await nextTick()
+
+    if (!isBatchMode.value || batchModeSessionId !== operationBatchSessionId) return
+
+    if (failedIds.length === 0) {
+      exitBatchMode()
+      return
+    }
+
+    const visibleIds = new Set(displayList.value.map(item => item.id))
+    selectedSubscribes.value = failedIds.filter(id => visibleIds.has(id))
   } catch (error) {
     console.error(error)
-    $toast.error(t('subscribe.batchDeleteError'))
+    $toast.error(t(options.errorKey))
   } finally {
     loading.value = false
   }
+}
+
+// 批量删除已选中的订阅。
+async function batchDeleteSubscribes() {
+  await runBatchOperation({
+    confirmKey: 'subscribe.batchDeleteConfirm',
+    errorKey: 'subscribe.batchDeleteError',
+    failedKey: 'subscribe.batchDeleteFailed',
+    request: id => api.delete(`subscribe/${id}`),
+    successKey: 'subscribe.batchDeleteSuccess',
+  })
 }
 
 // 批量启用已选中的订阅。
 async function batchEnableSubscribes() {
-  if (selectedSubscribes.value.length === 0) {
-    $toast.warning(t('subscribe.noSelectedItems'))
-    return
-  }
-
-  const isConfirmed = await createConfirm({
-    title: t('common.confirm'),
-    content: t('subscribe.batchEnableConfirm', { count: selectedSubscribes.value.length }),
+  await runBatchOperation({
+    confirmKey: 'subscribe.batchEnableConfirm',
+    errorKey: 'subscribe.batchEnableError',
+    failedKey: 'subscribe.batchEnableFailed',
+    request: id => api.put(`subscribe/status/${id}?state=R`),
+    successKey: 'subscribe.batchEnableSuccess',
   })
-
-  if (!isConfirmed) return
-
-  try {
-    loading.value = true
-    const promises = selectedSubscribes.value.map(id => api.put(`subscribe/status/${id}?state=R`))
-    const results = await Promise.allSettled(promises)
-
-    const successCount = results.filter(result => result.status === 'fulfilled').length
-    const failedCount = results.length - successCount
-
-    if (successCount > 0) {
-      $toast.success(t('subscribe.batchEnableSuccess', { count: successCount }))
-    }
-    if (failedCount > 0) {
-      $toast.error(t('subscribe.batchEnableFailed', { count: failedCount }))
-    }
-
-    await fetchData()
-    exitBatchMode()
-  } catch (error) {
-    console.error(error)
-    $toast.error(t('subscribe.batchEnableError'))
-  } finally {
-    loading.value = false
-  }
 }
 
 // 批量暂停已选中的订阅。
 async function batchPauseSubscribes() {
-  if (selectedSubscribes.value.length === 0) {
-    $toast.warning(t('subscribe.noSelectedItems'))
-    return
-  }
-
-  const isConfirmed = await createConfirm({
-    title: t('common.confirm'),
-    content: t('subscribe.batchPauseConfirm', { count: selectedSubscribes.value.length }),
+  await runBatchOperation({
+    confirmKey: 'subscribe.batchPauseConfirm',
+    errorKey: 'subscribe.batchPauseError',
+    failedKey: 'subscribe.batchPauseFailed',
+    request: id => api.put(`subscribe/status/${id}?state=S`),
+    successKey: 'subscribe.batchPauseSuccess',
   })
-
-  if (!isConfirmed) return
-
-  try {
-    loading.value = true
-    const promises = selectedSubscribes.value.map(id => api.put(`subscribe/status/${id}?state=S`))
-    const results = await Promise.allSettled(promises)
-
-    const successCount = results.filter(result => result.status === 'fulfilled').length
-    const failedCount = results.length - successCount
-
-    if (successCount > 0) {
-      $toast.success(t('subscribe.batchPauseSuccess', { count: successCount }))
-    }
-    if (failedCount > 0) {
-      $toast.error(t('subscribe.batchPauseFailed', { count: failedCount }))
-    }
-
-    await fetchData()
-    exitBatchMode()
-  } catch (error) {
-    console.error(error)
-    $toast.error(t('subscribe.batchPauseError'))
-  } finally {
-    loading.value = false
-  }
 }
 
 // 错误描述
@@ -554,6 +612,10 @@ defineExpose({
 <template>
   <LoadingBanner v-if="!isRefreshed" class="mt-12" />
 
+  <VAlert v-if="loadError" type="error" variant="tonal" class="mb-4 mx-2">
+    {{ t('subscribe.requestFailed') }}
+  </VAlert>
+
   <VAlert v-if="sortMode" color="warning" variant="tonal" class="mb-4 mx-2 py-0 app-surface-static">
     <div class="d-flex flex-wrap align-center justify-space-between gap-2 py-5">
       <span>{{ t('common.sortModeHint') }}</span>
@@ -567,6 +629,7 @@ defineExpose({
     v-if="displayList.length > 0 && canDragSort"
     v-model="displayList"
     @end="saveSubscribeOrder"
+    :disabled="orderSaving"
     item-key="id"
     tag="div"
     :component-data="{ class: 'grid gap-4 grid-subscribe-card px-2' }"
@@ -608,7 +671,7 @@ defineExpose({
     </template>
   </ProgressiveCardGrid>
   <NoDataFound
-    v-if="displayList.length === 0 && isRefreshed"
+    v-if="displayList.length === 0 && isRefreshed && !loadError"
     error-code="404"
     :error-title="errorTitle"
     :error-description="errorDescription"

--- a/src/views/subscribe/SubscribeListView.vue
+++ b/src/views/subscribe/SubscribeListView.vue
@@ -62,26 +62,6 @@ const emit = defineEmits<{
 
 type SubscribeSortBy = 'custom' | 'last_update' | 'date' | 'lack_episode'
 
-// 自定义顺序的持久化条目，只允许有限数值 ID 参与排序。
-interface SubscribeOrderItem {
-  id: number
-}
-
-// 订阅写操作的业务结果；HTTP 成功不代表业务操作成功。
-interface SubscribeMutationResponse {
-  message?: string
-  success: boolean
-}
-
-// 批量操作的确认文案、请求执行器和结果文案契约。
-interface BatchOperationOptions {
-  confirmKey: string
-  errorKey: string
-  failedKey: string
-  request: (id: number) => Promise<unknown>
-  successKey: string
-}
-
 // 订阅批量模式状态快照，供父页面渲染外部批量操作按钮。
 interface SubscribeBatchState {
   enabled: boolean
@@ -103,10 +83,7 @@ const loadError = ref(false)
 const dataList = ref<Subscribe[]>([])
 
 // 订阅顺序配置
-const orderConfig = ref<SubscribeOrderItem[]>([])
-
-// 顺序保存期间锁定拖拽，避免并发请求覆盖最后确认的顺序。
-const orderSaving = ref(false)
+const orderConfig = ref<{ id: number }[]>([])
 
 // 显示的订阅列表
 const displayList = ref<Subscribe[]>([])
@@ -114,8 +91,6 @@ const displayList = ref<Subscribe[]>([])
 // 批量管理相关状态
 const isBatchMode = ref(false)
 const selectedSubscribes = ref<number[]>([])
-// 每次进入批量模式创建新会话，迟到请求不得修改后续会话的选择状态。
-let batchModeSessionId = 0
 
 const normalizedKeyword = computed(() => props.keyword?.trim().toLowerCase() || '')
 const selectedSubscribesSet = computed(() => new Set(selectedSubscribes.value))
@@ -213,25 +188,6 @@ function getSubscribeTimeValue(value?: string) {
   return Number.isNaN(compatibleTime) ? 0 : compatibleTime
 }
 
-// 顺序配置属于通用 JSON 存储，只有完整的数值 ID 数组才能参与排序。
-function normalizeSubscribeOrderConfig(value: unknown): SubscribeOrderItem[] {
-  if (
-    !Array.isArray(value) ||
-    !value.every(
-      item =>
-        typeof item === 'object' &&
-        item !== null &&
-        'id' in item &&
-        typeof item.id === 'number' &&
-        Number.isFinite(item.id),
-    )
-  ) {
-    return []
-  }
-
-  return value.map(item => ({ id: item.id }))
-}
-
 // 按自定义顺序排序订阅，未配置顺序的订阅按添加时间倒序补齐。
 function sortByCustomOrder(a: Subscribe, b: Subscribe, orderIndexMap: Map<number, number>) {
   const aIndex = orderIndexMap.get(a.id) ?? Number.MAX_SAFE_INTEGER
@@ -326,7 +282,9 @@ watch(
 async function loadSubscribeOrderConfig() {
   try {
     const response = await api.get(`/user/config/${orderRequestKey.value}`)
-    orderConfig.value = normalizeSubscribeOrderConfig(response?.data?.value)
+    if (response && response.data && response.data.value) {
+      orderConfig.value = response.data.value
+    }
     syncDefaultSortBy()
   } catch (error) {
     console.error('Failed to load subscribe order config:', error)
@@ -337,31 +295,13 @@ async function loadSubscribeOrderConfig() {
 
 // 保存顺序设置
 async function saveSubscribeOrder() {
-  if (orderSaving.value) {
-    const restoredDisplayList = [...displayList.value]
-    sortSubscribeList(restoredDisplayList)
-    displayList.value = restoredDisplayList
-    return
-  }
-
   const confirmedOrder = orderConfig.value.map(item => ({ ...item }))
   const orderObj = displayList.value.map(item => ({ id: item.id }))
-  orderSaving.value = true
+  orderConfig.value = orderObj
+  emit('update:sortBy', 'custom')
 
   try {
-    const response = (await api.post(
-      `/user/config/${orderRequestKey.value}`,
-      orderObj,
-    )) as unknown as SubscribeMutationResponse
-    if (response?.success !== true) {
-      throw new Error(response?.message || 'Failed to save subscribe order')
-    }
-
-    orderConfig.value = orderObj
-    // 保存响应不得覆盖请求期间由父页面选择的新排序方式。
-    if (effectiveSortBy.value === 'custom') {
-      emit('update:sortBy', 'custom')
-    }
+    await api.post(`/user/config/${orderRequestKey.value}`, orderObj)
   } catch (error) {
     console.error(error)
     orderConfig.value = confirmedOrder
@@ -369,8 +309,6 @@ async function saveSubscribeOrder() {
     sortSubscribeList(restoredDisplayList)
     displayList.value = restoredDisplayList
     $toast.error(t('subscribe.requestFailed'))
-  } finally {
-    orderSaving.value = false
   }
 }
 
@@ -430,9 +368,6 @@ function emitBatchStateChange() {
 
 // 进入批量模式。
 function enterBatchMode() {
-  if (!isBatchMode.value) {
-    batchModeSessionId += 1
-  }
   isBatchMode.value = true
 }
 
@@ -471,96 +406,129 @@ function toggleSelectSubscribe(id: number) {
   }
 }
 
-function isSuccessfulMutationResult(result: PromiseSettledResult<unknown>) {
-  return (
-    result.status === 'fulfilled' &&
-    typeof result.value === 'object' &&
-    result.value !== null &&
-    'success' in result.value &&
-    result.value.success === true
-  )
-}
-
-// 批量结果必须与开始操作时的 ID 快照对应，避免异步期间筛选或选择变化造成目标错配。
-async function runBatchOperation(options: BatchOperationOptions) {
+// 批量删除已选中的订阅。
+async function batchDeleteSubscribes() {
   if (selectedSubscribes.value.length === 0) {
     $toast.warning(t('subscribe.noSelectedItems'))
     return
   }
 
-  const targetIds = [...selectedSubscribes.value]
-  const operationBatchSessionId = batchModeSessionId
   const isConfirmed = await createConfirm({
     title: t('common.confirm'),
-    content: t(options.confirmKey, { count: targetIds.length }),
+    content: t('subscribe.batchDeleteConfirm', { count: selectedSubscribes.value.length }),
   })
 
-  if (!isConfirmed || !isBatchMode.value || batchModeSessionId !== operationBatchSessionId) return
+  if (!isConfirmed) return
 
   try {
     loading.value = true
-    const results = await Promise.allSettled(targetIds.map(id => options.request(id)))
-    const failedIds = targetIds.filter((_id, index) => !isSuccessfulMutationResult(results[index]))
-    const successCount = targetIds.length - failedIds.length
+    const promises = selectedSubscribes.value.map(id => api.delete(`subscribe/${id}`))
+    const results = await Promise.allSettled(promises)
+
+    const successCount = results.filter(result => result.status === 'fulfilled').length
+    const failedCount = results.length - successCount
 
     if (successCount > 0) {
-      $toast.success(t(options.successKey, { count: successCount }))
+      $toast.success(t('subscribe.batchDeleteSuccess', { count: successCount }))
     }
-    if (failedIds.length > 0) {
-      $toast.error(t(options.failedKey, { count: failedIds.length }))
+    if (failedCount > 0) {
+      $toast.error(t('subscribe.batchDeleteFailed', { count: failedCount }))
     }
 
     await fetchData()
-    await nextTick()
-
-    if (!isBatchMode.value || batchModeSessionId !== operationBatchSessionId) return
-
-    if (failedIds.length === 0) {
-      exitBatchMode()
-      return
-    }
-
-    const visibleIds = new Set(displayList.value.map(item => item.id))
-    selectedSubscribes.value = failedIds.filter(id => visibleIds.has(id))
+    exitBatchMode()
   } catch (error) {
     console.error(error)
-    $toast.error(t(options.errorKey))
+    $toast.error(t('subscribe.batchDeleteError'))
   } finally {
     loading.value = false
   }
 }
 
-// 批量删除已选中的订阅。
-async function batchDeleteSubscribes() {
-  await runBatchOperation({
-    confirmKey: 'subscribe.batchDeleteConfirm',
-    errorKey: 'subscribe.batchDeleteError',
-    failedKey: 'subscribe.batchDeleteFailed',
-    request: id => api.delete(`subscribe/${id}`),
-    successKey: 'subscribe.batchDeleteSuccess',
-  })
-}
-
 // 批量启用已选中的订阅。
 async function batchEnableSubscribes() {
-  await runBatchOperation({
-    confirmKey: 'subscribe.batchEnableConfirm',
-    errorKey: 'subscribe.batchEnableError',
-    failedKey: 'subscribe.batchEnableFailed',
-    request: id => api.put(`subscribe/status/${id}?state=R`),
-    successKey: 'subscribe.batchEnableSuccess',
+  if (selectedSubscribes.value.length === 0) {
+    $toast.warning(t('subscribe.noSelectedItems'))
+    return
+  }
+
+  const isConfirmed = await createConfirm({
+    title: t('common.confirm'),
+    content: t('subscribe.batchEnableConfirm', { count: selectedSubscribes.value.length }),
   })
+
+  if (!isConfirmed) return
+
+  try {
+    loading.value = true
+    const promises = selectedSubscribes.value.map(
+      id => api.put(`subscribe/status/${id}?state=R`) as unknown as Promise<{ success: boolean }>,
+    )
+    const results = await Promise.allSettled(promises)
+
+    const successCount = results.filter(
+      result => result.status === 'fulfilled' && result.value?.success === true,
+    ).length
+    const failedCount = results.length - successCount
+
+    if (successCount > 0) {
+      $toast.success(t('subscribe.batchEnableSuccess', { count: successCount }))
+    }
+    if (failedCount > 0) {
+      $toast.error(t('subscribe.batchEnableFailed', { count: failedCount }))
+    }
+
+    await fetchData()
+    exitBatchMode()
+  } catch (error) {
+    console.error(error)
+    $toast.error(t('subscribe.batchEnableError'))
+  } finally {
+    loading.value = false
+  }
 }
 
 // 批量暂停已选中的订阅。
 async function batchPauseSubscribes() {
-  await runBatchOperation({
-    confirmKey: 'subscribe.batchPauseConfirm',
-    errorKey: 'subscribe.batchPauseError',
-    failedKey: 'subscribe.batchPauseFailed',
-    request: id => api.put(`subscribe/status/${id}?state=S`),
-    successKey: 'subscribe.batchPauseSuccess',
+  if (selectedSubscribes.value.length === 0) {
+    $toast.warning(t('subscribe.noSelectedItems'))
+    return
+  }
+
+  const isConfirmed = await createConfirm({
+    title: t('common.confirm'),
+    content: t('subscribe.batchPauseConfirm', { count: selectedSubscribes.value.length }),
   })
+
+  if (!isConfirmed) return
+
+  try {
+    loading.value = true
+    const promises = selectedSubscribes.value.map(
+      id => api.put(`subscribe/status/${id}?state=S`) as unknown as Promise<{ success: boolean }>,
+    )
+    const results = await Promise.allSettled(promises)
+
+    const successCount = results.filter(
+      result => result.status === 'fulfilled' && result.value?.success === true,
+    ).length
+    const failedCount = results.length - successCount
+
+    if (successCount > 0) {
+      $toast.success(t('subscribe.batchPauseSuccess', { count: successCount }))
+    }
+    if (failedCount > 0) {
+      $toast.error(t('subscribe.batchPauseFailed', { count: failedCount }))
+    }
+
+    await fetchData()
+    exitBatchMode()
+  } catch (error) {
+    console.error(error)
+    $toast.error(t('subscribe.batchPauseError'))
+  } finally {
+    loading.value = false
+  }
 }
 
 // 错误描述
@@ -629,7 +597,6 @@ defineExpose({
     v-if="displayList.length > 0 && canDragSort"
     v-model="displayList"
     @end="saveSubscribeOrder"
-    :disabled="orderSaving"
     item-key="id"
     tag="div"
     :component-data="{ class: 'grid gap-4 grid-subscribe-card px-2' }"

--- a/src/views/subscribe/__tests__/SubscribeListView.spec.ts
+++ b/src/views/subscribe/__tests__/SubscribeListView.spec.ts
@@ -13,7 +13,6 @@ import {
 } from '@tests/support/msw/handlers/subscribe'
 import { server } from '@tests/support/msw/server'
 import { renderWithProviders } from '@tests/support/render'
-import { flushPromises } from '@vue/test-utils'
 import { defineComponent, h, nextTick, ref, watch, type PropType } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -93,14 +92,11 @@ const ProgressiveCardGridStub = defineComponent({
 const DraggableStub = defineComponent({
   name: 'Draggable',
   props: {
-    disabled: Boolean,
     modelValue: { type: Array as PropType<Subscribe[]>, required: true },
   },
   emits: ['end', 'update:modelValue'],
   setup(props, { emit, slots }) {
-    async function reverseOrder(ignoreDisabled = false) {
-      if (props.disabled && !ignoreDisabled) return
-
+    async function reverseOrder() {
       emit('update:modelValue', [...props.modelValue].reverse())
       await nextTick()
       emit('end')
@@ -109,8 +105,7 @@ const DraggableStub = defineComponent({
     return () =>
       h('section', { 'data-testid': 'draggable-list' }, [
         ...props.modelValue.flatMap(element => slots.item?.({ element }) ?? []),
-        h('button', { disabled: props.disabled, onClick: () => reverseOrder(), type: 'button' }, 'reverse-order'),
-        h('button', { onClick: () => reverseOrder(true), type: 'button' }, 'force-reverse-order'),
+        h('button', { onClick: reverseOrder, type: 'button' }, 'reverse-order'),
       ])
   },
 })
@@ -449,19 +444,6 @@ describe('SubscribeListView sorting and refresh boundaries', () => {
     expect(displayedNames()).toEqual(expected)
   })
 
-  it('falls back from a damaged order config without throwing', async () => {
-    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
-    await renderList({
-      listResponse: [movie(1, 'Older', { date: '2024-01-01' }), movie(2, 'Newer', { date: '2025-01-01' })],
-      orderValue: 'damaged-order',
-      sortBy: 'custom',
-    })
-
-    expect(await screen.findByText('Newer')).toBeInTheDocument()
-    expect(displayedNames()).toEqual(['Newer', 'Older'])
-    expect(consoleError).not.toHaveBeenCalled()
-  })
-
   it('marks and scrolls to the initial subscription id', async () => {
     await renderList({ listResponse: [movie(1, 'First'), movie(2, 'Target')], subid: '2' })
 
@@ -509,70 +491,9 @@ describe('SubscribeListView sorting and refresh boundaries', () => {
     expect(screen.getByTestId('sort-mode-state')).toHaveTextContent('true')
   })
 
-  it('locks dragging while saving and ignores a repeated end event', async () => {
-    let releaseSave = () => {}
-    const pendingSave = new Promise<void>(resolve => {
-      releaseSave = resolve
-    })
-    const saved = vi.fn(async () => pendingSave)
-    server.use(saveSubscribeOrderConfigHandler('电影', { success: true }, 200, saved))
-    await renderList({
-      listResponse: [movie(1, 'First'), movie(2, 'Second')],
-      orderValue: [{ id: 1 }, { id: 2 }],
-      sortBy: 'custom',
-      sortMode: true,
-    })
-    await screen.findByText('First')
-
-    const reverseButton = screen.getByRole('button', { name: 'reverse-order' })
-    await fireEvent.click(reverseButton)
-
-    await waitFor(() => expect(saved).toHaveBeenCalledOnce())
-    expect(reverseButton).toBeDisabled()
-
-    await fireEvent.click(screen.getByRole('button', { name: 'force-reverse-order' }))
-
-    expect(saved).toHaveBeenCalledOnce()
-    expect(displayedNames()).toEqual(['First', 'Second'])
-
-    releaseSave()
-    await waitFor(() => expect(reverseButton).not.toBeDisabled())
-    expect(displayedNames()).toEqual(['Second', 'First'])
-  })
-
-  it('preserves a newer parent sort choice while a custom order save finishes', async () => {
-    let releaseSave = () => {}
-    const pendingSave = new Promise<void>(resolve => {
-      releaseSave = resolve
-    })
-    const saved = vi.fn(async () => pendingSave)
-    server.use(saveSubscribeOrderConfigHandler('电影', { success: true }, 200, saved))
-    const { rerender } = await renderList({
-      listResponse: [movie(1, 'First'), movie(2, 'Second')],
-      orderValue: [{ id: 1 }, { id: 2 }],
-      sortBy: 'custom',
-      sortMode: true,
-    })
-    await screen.findByText('First')
-
-    await fireEvent.click(screen.getByRole('button', { name: 'reverse-order' }))
-    await waitFor(() => expect(saved).toHaveBeenCalledOnce())
-
-    await rerender({ sortBy: 'date' })
-    await waitFor(() => expect(screen.getByTestId('sort-by-state')).toHaveTextContent('date'))
-
-    releaseSave()
-    await flushPromises()
-
-    expect(screen.getByTestId('sort-by-state')).toHaveTextContent('date')
-  })
-
-  it.each([
-    ['business failure', 200, { message: 'rejected', success: false }],
-    ['HTTP failure', 500, { message: 'server error', success: false }],
-  ])('rolls back the confirmed order and remains sortable after a %s', async (_case, status, response) => {
+  it('rolls back the confirmed order and remains sortable after a request failure', async () => {
     vi.spyOn(console, 'error').mockImplementation(() => {})
-    server.use(saveSubscribeOrderConfigHandler('电影', response, status))
+    server.use(saveSubscribeOrderConfigHandler('电影', { message: 'server error', success: false }, 500))
     await renderList({
       listResponse: [movie(1, 'First'), movie(2, 'Second')],
       orderValue: [{ id: 1 }, { id: 2 }],
@@ -693,7 +614,10 @@ describe('SubscribeListView batch operations', () => {
     await waitFor(() => expect(batchState()).toMatchObject({ enabled: false, selectedCount: 0 }))
   })
 
-  it('classifies HTTP 200 success false as a failure and keeps it selected for retry', async () => {
+  it.each([
+    ['enable', 'host-batch-enable', '启用'],
+    ['pause', 'host-batch-pause', '暂停'],
+  ])('classifies a %s success false response as a failure', async (_case, buttonName, actionName) => {
     const requested = vi.fn()
     server.use(updateSubscribeStatusHandler(1, { message: 'rejected', success: false }, 200, requested))
     await renderList({ listResponse: [movie(1, 'Alpha')] })
@@ -701,30 +625,17 @@ describe('SubscribeListView batch operations', () => {
     await fireEvent.click(screen.getByRole('button', { name: 'host-enter-batch' }))
     await fireEvent.click(screen.getByRole('button', { name: 'select-1' }))
 
-    await fireEvent.click(screen.getByRole('button', { name: 'host-batch-enable' }))
+    await fireEvent.click(screen.getByRole('button', { name: buttonName }))
 
     await waitFor(() => expect(requested).toHaveBeenCalledOnce())
-    await waitFor(() => expect(mocks.toastError).toHaveBeenCalledWith('启用失败 1 个订阅'))
+    await waitFor(() => expect(mocks.toastError).toHaveBeenCalledWith(`${actionName}失败 1 个订阅`))
     expect(mocks.toastSuccess).not.toHaveBeenCalled()
-    expect(card(1)).toHaveAttribute('data-selected', 'true')
-    expect(batchState()).toMatchObject({ enabled: true, selectedCount: 1 })
+    await waitFor(() => expect(batchState()).toMatchObject({ enabled: false, selectedCount: 0 }))
   })
 
-  it('maps partial HTTP failures to a fixed target snapshot and preserves only failed ids', async () => {
+  it('reports mixed status results without changing the existing completion flow', async () => {
     vi.spyOn(console, 'error').mockImplementation(() => {})
-    let releaseFirst: () => void = () => {}
-    let markFirstStarted: () => void = () => {}
-    const firstStarted = new Promise<void>(resolve => {
-      markFirstStarted = resolve
-    })
-    const firstResponseGate = new Promise<void>(resolve => {
-      releaseFirst = resolve
-    })
-    const firstRequested = vi.fn(async (url: URL) => {
-      markFirstStarted()
-      await firstResponseGate
-      expect(url.pathname).toBe(new URL(subscribeApiUrls.statusById(1)).pathname)
-    })
+    const firstRequested = vi.fn()
     const secondRequested = vi.fn()
     server.use(
       updateSubscribeStatusHandler(1, { success: true }, 200, firstRequested),
@@ -736,54 +647,11 @@ describe('SubscribeListView batch operations', () => {
     await fireEvent.click(screen.getByRole('button', { name: 'host-toggle-select-all' }))
 
     await fireEvent.click(screen.getByRole('button', { name: 'host-batch-enable' }))
-    await firstStarted
-    await fireEvent.click(screen.getByRole('button', { name: 'select-2' }))
-    releaseFirst()
 
+    await waitFor(() => expect(firstRequested).toHaveBeenCalledOnce())
     await waitFor(() => expect(secondRequested).toHaveBeenCalledOnce())
     await waitFor(() => expect(mocks.toastSuccess).toHaveBeenCalledWith('成功启用 1 个订阅'))
     expect(mocks.toastError).toHaveBeenCalledWith('启用失败 1 个订阅')
-    expect(firstRequested.mock.calls[0][0].searchParams.get('state')).toBe('R')
-    expect(secondRequested.mock.calls[0][0].searchParams.get('state')).toBe('R')
-    await waitFor(() => expect(card(1)).toHaveAttribute('data-selected', 'false'))
-    expect(card(2)).toHaveAttribute('data-selected', 'true')
-    expect(batchState()).toMatchObject({ enabled: true, selectedCount: 1, totalCount: 2 })
-  })
-
-  it.each([
-    ['successful', { success: true }],
-    ['failed', { message: 'rejected', success: false }],
-  ])('does not let a delayed %s response mutate a newer batch session', async (_case, response) => {
-    let markRequestStarted: () => void = () => {}
-    let releaseRequest: () => void = () => {}
-    const requestStarted = new Promise<void>(resolve => {
-      markRequestStarted = resolve
-    })
-    const responseGate = new Promise<void>(resolve => {
-      releaseRequest = resolve
-    })
-    const listRequested = vi.fn()
-    const statusRequested = vi.fn(async () => {
-      markRequestStarted()
-      await responseGate
-    })
-    server.use(updateSubscribeStatusHandler(1, response, 200, statusRequested))
-    await renderList({ listResponse: [movie(1, 'Alpha')], onListRequest: listRequested })
-    await screen.findByText('Alpha')
-    await fireEvent.click(screen.getByRole('button', { name: 'host-enter-batch' }))
-    await fireEvent.click(screen.getByRole('button', { name: 'select-1' }))
-
-    await fireEvent.click(screen.getByRole('button', { name: 'host-batch-enable' }))
-    await requestStarted
-    await fireEvent.click(screen.getByRole('button', { name: 'host-exit-batch' }))
-    await fireEvent.click(screen.getByRole('button', { name: 'host-enter-batch' }))
-    expect(batchState()).toMatchObject({ enabled: true, selectedCount: 0 })
-
-    releaseRequest()
-    await waitFor(() => expect(listRequested).toHaveBeenCalledTimes(2))
-    await flushPromises()
-
-    expect(card(1)).toHaveAttribute('data-selected', 'false')
-    expect(batchState()).toMatchObject({ enabled: true, selectedCount: 0 })
+    await waitFor(() => expect(batchState()).toMatchObject({ enabled: false, selectedCount: 0 }))
   })
 })

--- a/src/views/subscribe/__tests__/SubscribeListView.spec.ts
+++ b/src/views/subscribe/__tests__/SubscribeListView.spec.ts
@@ -1,0 +1,789 @@
+import type { Subscribe } from '@/api/types'
+import SubscribeListView from '@/views/subscribe/SubscribeListView.vue'
+import { fireEvent, screen, waitFor } from '@testing-library/vue'
+import { createSubscribe } from '@tests/support/factories/subscribe'
+import {
+  deleteSubscribeByIdHandler,
+  saveSubscribeOrderConfigHandler,
+  subscribeApiUrls,
+  subscribeListHandler,
+  subscribeOrderConfigHandler,
+  updateSubscribeStatusHandler,
+  type SubscribeMediaType,
+} from '@tests/support/msw/handlers/subscribe'
+import { server } from '@tests/support/msw/server'
+import { renderWithProviders } from '@tests/support/render'
+import { flushPromises } from '@vue/test-utils'
+import { defineComponent, h, nextTick, ref, watch, type PropType } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  confirm: vi.fn(),
+  openSharedDialog: vi.fn(),
+  toastError: vi.fn(),
+  toastSuccess: vi.fn(),
+  toastWarning: vi.fn(),
+}))
+
+vi.mock('vue-toastification', () => ({
+  useToast: () => ({
+    error: mocks.toastError,
+    success: mocks.toastSuccess,
+    warning: mocks.toastWarning,
+  }),
+}))
+
+vi.mock('@/composables/useConfirm', () => ({
+  useConfirm: () => mocks.confirm,
+}))
+
+vi.mock('@/composables/useSharedDialog', () => ({
+  openSharedDialog: (...args: unknown[]) => mocks.openSharedDialog(...args),
+}))
+
+const SubscribeCardStub = defineComponent({
+  name: 'SubscribeCard',
+  props: {
+    batchMode: Boolean,
+    media: { type: Object as PropType<Subscribe>, required: true },
+    selected: Boolean,
+    sortable: Boolean,
+  },
+  emits: ['remove', 'save', 'select'],
+  setup(props, { emit }) {
+    return () =>
+      h(
+        'article',
+        {
+          'data-batch': String(props.batchMode),
+          'data-page-open': String(Boolean(props.media.page_open)),
+          'data-selected': String(props.selected),
+          'data-sortable': String(props.sortable),
+          'data-testid': `subscribe-card-${props.media.id}`,
+        },
+        [
+          h('span', props.media.name),
+          h('button', { 'aria-label': `select-${props.media.id}`, onClick: () => emit('select'), type: 'button' }, 'select'),
+          h('button', { 'aria-label': `save-${props.media.id}`, onClick: () => emit('save'), type: 'button' }, 'save'),
+          h('button', { 'aria-label': `remove-${props.media.id}`, onClick: () => emit('remove'), type: 'button' }, 'remove'),
+        ],
+      )
+  },
+})
+
+const ProgressiveCardGridStub = defineComponent({
+  name: 'ProgressiveCardGrid',
+  props: {
+    items: { type: Array as PropType<Subscribe[]>, required: true },
+    scrollToIndex: Number,
+  },
+  setup(props, { slots }) {
+    return () =>
+      h(
+        'section',
+        {
+          'data-scroll-to-index': props.scrollToIndex ?? '',
+          'data-testid': 'progressive-grid',
+        },
+        props.items.flatMap(item => slots.default?.({ item }) ?? []),
+      )
+  },
+})
+
+const DraggableStub = defineComponent({
+  name: 'Draggable',
+  props: {
+    disabled: Boolean,
+    modelValue: { type: Array as PropType<Subscribe[]>, required: true },
+  },
+  emits: ['end', 'update:modelValue'],
+  setup(props, { emit, slots }) {
+    async function reverseOrder(ignoreDisabled = false) {
+      if (props.disabled && !ignoreDisabled) return
+
+      emit('update:modelValue', [...props.modelValue].reverse())
+      await nextTick()
+      emit('end')
+    }
+
+    return () =>
+      h('section', { 'data-testid': 'draggable-list' }, [
+        ...props.modelValue.flatMap(element => slots.item?.({ element }) ?? []),
+        h('button', { disabled: props.disabled, onClick: () => reverseOrder(), type: 'button' }, 'reverse-order'),
+        h('button', { onClick: () => reverseOrder(true), type: 'button' }, 'force-reverse-order'),
+      ])
+  },
+})
+
+const LoadingBannerStub = defineComponent({
+  name: 'LoadingBanner',
+  template: '<div role="status" data-testid="loading-banner">loading</div>',
+})
+
+const NoDataFoundStub = defineComponent({
+  name: 'NoDataFound',
+  props: {
+    errorDescription: String,
+    errorTitle: String,
+  },
+  template: '<section data-testid="no-data">{{ errorTitle }} {{ errorDescription }}</section>',
+})
+
+interface BatchState {
+  allSelected: boolean
+  enabled: boolean
+  selectedCount: number
+  totalCount: number
+}
+
+interface ListActions {
+  batchDeleteSubscribes: () => Promise<void>
+  batchEnableSubscribes: () => Promise<void>
+  batchPauseSubscribes: () => Promise<void>
+  enterBatchMode: () => void
+  exitBatchMode: () => void
+  openHistoryDialog: () => void
+  toggleBatchMode: () => void
+  toggleSelectAll: () => void
+}
+
+const SubscribeListHost = defineComponent({
+  name: 'SubscribeListHost',
+  components: { SubscribeListView },
+  props: {
+    active: { type: Boolean, default: true },
+    keyword: { type: String, default: '' },
+    sortBy: { type: String, default: '' },
+    sortMode: { type: Boolean, default: false },
+    statusFilter: { type: String, default: 'all' },
+    subid: { type: String, default: '' },
+    type: { type: String as PropType<SubscribeMediaType>, default: '电影' },
+  },
+  setup(props) {
+    const list = ref<ListActions | null>(null)
+    const currentSortBy = ref(props.sortBy)
+    const currentSortMode = ref(props.sortMode)
+    const batchState = ref<BatchState>({ allSelected: false, enabled: false, selectedCount: 0, totalCount: 0 })
+
+    watch(
+      () => props.sortBy,
+      value => {
+        currentSortBy.value = value
+      },
+    )
+    watch(
+      () => props.sortMode,
+      value => {
+        currentSortMode.value = value
+      },
+    )
+
+    function call(action: keyof ListActions) {
+      return list.value?.[action]()
+    }
+
+    return { batchState, call, currentSortBy, currentSortMode, list }
+  },
+  template: `
+    <SubscribeListView
+      ref="list"
+      :active="active"
+      :keyword="keyword"
+      :sort-by="currentSortBy"
+      :sort-mode="currentSortMode"
+      :status-filter="statusFilter"
+      :subid="subid"
+      :type="type"
+      @batch-state-change="batchState = $event"
+      @update:sort-by="currentSortBy = $event"
+      @update:sort-mode="currentSortMode = $event"
+    />
+    <button type="button" @click="call('enterBatchMode')">host-enter-batch</button>
+    <button type="button" @click="call('exitBatchMode')">host-exit-batch</button>
+    <button type="button" @click="call('toggleBatchMode')">host-toggle-batch</button>
+    <button type="button" @click="call('toggleSelectAll')">host-toggle-select-all</button>
+    <button type="button" @click="call('batchEnableSubscribes')">host-batch-enable</button>
+    <button type="button" @click="call('batchPauseSubscribes')">host-batch-pause</button>
+    <button type="button" @click="call('batchDeleteSubscribes')">host-batch-delete</button>
+    <button type="button" @click="call('openHistoryDialog')">host-open-history</button>
+    <output data-testid="batch-state">{{ JSON.stringify(batchState) }}</output>
+    <output data-testid="sort-by-state">{{ currentSortBy }}</output>
+    <output data-testid="sort-mode-state">{{ String(currentSortMode) }}</output>
+  `,
+})
+
+interface RenderListOptions {
+  active?: boolean
+  keyword?: string
+  listResponse?: Subscribe[]
+  listStatus?: number
+  onListRequest?: (url: URL) => void
+  onOrderRequest?: (url: URL) => void
+  orderStatus?: number
+  orderValue?: Parameters<typeof subscribeOrderConfigHandler>[1]
+  sortBy?: string
+  sortMode?: boolean
+  statusFilter?: string
+  subid?: string
+  superUser?: boolean
+  type?: SubscribeMediaType
+  userName?: string
+}
+
+async function renderList(options: RenderListOptions = {}) {
+  const type = options.type ?? '电影'
+  server.use(
+    subscribeOrderConfigHandler(
+      type,
+      options.orderValue,
+      options.orderStatus ?? 200,
+      options.onOrderRequest,
+    ),
+    subscribeListHandler(options.listResponse ?? [], options.listStatus ?? 200, options.onListRequest),
+  )
+
+  return renderWithProviders(SubscribeListHost, {
+    props: {
+      active: options.active ?? true,
+      keyword: options.keyword ?? '',
+      sortBy: options.sortBy ?? '',
+      sortMode: options.sortMode ?? false,
+      statusFilter: options.statusFilter ?? 'all',
+      subid: options.subid ?? '',
+      type,
+    },
+    initialState: {
+      user: {
+        superUser: options.superUser ?? false,
+        userName: options.userName ?? 'tester',
+      },
+    },
+    global: {
+      stubs: {
+        Draggable: DraggableStub,
+        LoadingBanner: LoadingBannerStub,
+        NoDataFound: NoDataFoundStub,
+        ProgressiveCardGrid: ProgressiveCardGridStub,
+        SubscribeCard: SubscribeCardStub,
+        draggable: DraggableStub,
+      },
+    },
+  })
+}
+
+function movie(id: number, name: string, overrides: Partial<Subscribe> = {}) {
+  return createSubscribe({ id, name, type: '电影', username: 'tester', ...overrides })
+}
+
+function tv(id: number, name: string, overrides: Partial<Subscribe> = {}) {
+  return createSubscribe({ id, name, type: '电视剧', username: 'tester', ...overrides })
+}
+
+function card(id: number) {
+  return screen.getByTestId(`subscribe-card-${id}`)
+}
+
+function displayedNames() {
+  return screen.queryAllByTestId(/^subscribe-card-/).map(element => element.querySelector('span')?.textContent)
+}
+
+function batchState(): BatchState {
+  return JSON.parse(screen.getByTestId('batch-state').textContent || '{}') as BatchState
+}
+
+beforeEach(() => {
+  Object.values(mocks).forEach(mock => mock.mockReset())
+  mocks.confirm.mockResolvedValue(true)
+  mocks.openSharedDialog.mockReturnValue({ close: vi.fn(), id: 1, updateProps: vi.fn() })
+})
+
+describe('SubscribeListView loading and filtering', () => {
+  it('loads exact endpoints and restricts a normal user by owner and media type', async () => {
+    const listRequested = vi.fn()
+    const orderRequested = vi.fn()
+    await renderList({
+      listResponse: [movie(1, 'Own movie'), movie(2, 'Other movie', { username: 'other' }), tv(3, 'Own TV')],
+      onListRequest: listRequested,
+      onOrderRequest: orderRequested,
+    })
+
+    expect(await screen.findByText('Own movie')).toBeInTheDocument()
+    expect(screen.queryByText('Other movie')).not.toBeInTheDocument()
+    expect(screen.queryByText('Own TV')).not.toBeInTheDocument()
+    expect(orderRequested.mock.calls[0][0].href).toBe(subscribeApiUrls.orderConfig('电影'))
+    expect(listRequested.mock.calls[0][0].href).toBe(subscribeApiUrls.list)
+    expect(screen.getByTestId('sort-by-state')).toHaveTextContent('date')
+  })
+
+  it('lets a superuser see subscriptions from every owner while retaining type defense', async () => {
+    await renderList({
+      listResponse: [movie(1, 'Own movie'), movie(2, 'Other movie', { username: 'other' }), tv(3, 'Other TV')],
+      superUser: true,
+    })
+
+    expect(await screen.findByText('Own movie')).toBeInTheDocument()
+    expect(screen.getByText('Other movie')).toBeInTheDocument()
+    expect(screen.queryByText('Other TV')).not.toBeInTheDocument()
+  })
+
+  it('normalizes keyword filtering', async () => {
+    await renderList({ keyword: '  ALPHA  ', listResponse: [movie(1, 'Alpha One'), movie(2, 'Beta Two')] })
+
+    expect(await screen.findByText('Alpha One')).toBeInTheDocument()
+    expect(screen.queryByText('Beta Two')).not.toBeInTheDocument()
+  })
+
+  it.each([
+    ['best_version', 'Best'],
+    ['pending', 'Pending'],
+    ['paused', 'Paused'],
+    ['completed', 'Completed'],
+    ['subscribing', 'Subscribing'],
+    ['not_started', 'Not started'],
+  ])('derives the %s status defensively', async (statusFilter, expectedName) => {
+    const subscriptions = [
+      tv(11, 'Best', { best_version: 1 }),
+      tv(12, 'Pending', { state: 'P' }),
+      tv(13, 'Paused', { state: 'S' }),
+      tv(14, 'Completed', { completed_episode: 10, lack_episode: 0, total_episode: 10 }),
+      tv(15, 'Subscribing', { completed_episode: 6, lack_episode: 4, total_episode: 10 }),
+      tv(16, 'Not started', { completed_episode: 0, lack_episode: 10, total_episode: 10 }),
+    ]
+    await renderList({ listResponse: subscriptions, statusFilter, type: '电视剧' })
+
+    expect(await screen.findByText(expectedName)).toBeInTheDocument()
+    expect(displayedNames()).toEqual([expectedName])
+  })
+
+  it('shows the empty state after a successful empty list response', async () => {
+    await renderList({ listResponse: [] })
+
+    expect(await screen.findByTestId('no-data')).toBeInTheDocument()
+    expect(screen.queryByTestId('loading-banner')).not.toBeInTheDocument()
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  it('finishes the initial loading state and shows a visible error when the list request fails', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const listRequested = vi.fn()
+    await renderList({ listResponse: [], listStatus: 500, onListRequest: listRequested })
+
+    await waitFor(() => expect(listRequested).toHaveBeenCalledOnce())
+    await waitFor(() => expect(screen.queryByTestId('loading-banner')).not.toBeInTheDocument())
+    expect(screen.getByRole('alert')).toHaveTextContent('请求失败，请稍后重试')
+    expect(screen.queryByTestId('no-data')).not.toBeInTheDocument()
+    expect(mocks.toastError).toHaveBeenCalledWith('请求失败，请稍后重试')
+  })
+
+  it('keeps old data through a silent refresh failure and clears the error after recovery', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const failedRequest = vi.fn()
+    const recoveredRequest = vi.fn()
+    const { rerender } = await renderList({ listResponse: [movie(1, 'Cached movie')] })
+    await screen.findByText('Cached movie')
+
+    await rerender({ active: false })
+    server.use(subscribeListHandler([], 500, failedRequest))
+    await rerender({ active: true })
+
+    await waitFor(() => expect(failedRequest).toHaveBeenCalledOnce())
+    expect(screen.getByText('Cached movie')).toBeInTheDocument()
+    expect(screen.getByRole('alert')).toHaveTextContent('请求失败，请稍后重试')
+    expect(screen.queryByTestId('loading-banner')).not.toBeInTheDocument()
+
+    await rerender({ active: false })
+    server.use(subscribeListHandler([movie(2, 'Recovered movie')], 200, recoveredRequest))
+    await rerender({ active: true })
+
+    await waitFor(() => expect(recoveredRequest).toHaveBeenCalledOnce())
+    expect(await screen.findByText('Recovered movie')).toBeInTheDocument()
+    expect(screen.queryByText('Cached movie')).not.toBeInTheDocument()
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+})
+
+describe('SubscribeListView sorting and refresh boundaries', () => {
+  it('applies custom order first and appends unconfigured subscriptions by date', async () => {
+    await renderList({
+      listResponse: [
+        movie(1, 'Old unconfigured', { date: '2024-01-01' }),
+        movie(2, 'Configured', { date: '2023-01-01' }),
+        movie(3, 'New unconfigured', { date: '2025-01-01' }),
+      ],
+      orderValue: [{ id: 2 }],
+      sortBy: 'custom',
+    })
+
+    await screen.findByText('Configured')
+    expect(displayedNames()).toEqual(['Configured', 'New unconfigured', 'Old unconfigured'])
+  })
+
+  it.each([
+    [
+      'date',
+      [movie(1, 'Invalid date', { date: 'not-a-date' }), movie(2, 'Newest', { date: '2025-02-01' })],
+      ['Newest', 'Invalid date'],
+    ],
+    [
+      'last_update',
+      [movie(1, 'Invalid update', { last_update: 'bad' }), movie(2, 'Latest update', { last_update: '2025-02-01' })],
+      ['Latest update', 'Invalid update'],
+    ],
+    [
+      'lack_episode',
+      [
+        tv(1, 'Few missing', { date: '2025-03-01', lack_episode: 1 }),
+        tv(2, 'Many missing', { date: '2024-01-01', lack_episode: 8 }),
+        tv(3, 'Few newer', { date: '2025-04-01', lack_episode: 1 }),
+      ],
+      ['Many missing', 'Few newer', 'Few missing'],
+    ],
+  ])('sorts by %s and treats invalid dates as zero', async (sortBy, subscriptions, expected) => {
+    await renderList({
+      listResponse: subscriptions,
+      sortBy,
+      type: sortBy === 'lack_episode' ? '电视剧' : '电影',
+    })
+
+    await screen.findByText(expected[0])
+    expect(displayedNames()).toEqual(expected)
+  })
+
+  it('falls back from a damaged order config without throwing', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    await renderList({
+      listResponse: [movie(1, 'Older', { date: '2024-01-01' }), movie(2, 'Newer', { date: '2025-01-01' })],
+      orderValue: 'damaged-order',
+      sortBy: 'custom',
+    })
+
+    expect(await screen.findByText('Newer')).toBeInTheDocument()
+    expect(displayedNames()).toEqual(['Newer', 'Older'])
+    expect(consoleError).not.toHaveBeenCalled()
+  })
+
+  it('marks and scrolls to the initial subscription id', async () => {
+    await renderList({ listResponse: [movie(1, 'First'), movie(2, 'Target')], subid: '2' })
+
+    await screen.findByText('Target')
+    expect(card(2)).toHaveAttribute('data-page-open', 'true')
+    expect(screen.getByTestId('progressive-grid')).toHaveAttribute('data-scroll-to-index', '1')
+  })
+
+  it('refreshes from card save/remove and the history save boundary', async () => {
+    const listRequested = vi.fn()
+    await renderList({ listResponse: [movie(1, 'Refresh target')], onListRequest: listRequested })
+    await screen.findByText('Refresh target')
+    expect(listRequested).toHaveBeenCalledTimes(1)
+
+    await fireEvent.click(screen.getByRole('button', { name: 'save-1' }))
+    await waitFor(() => expect(listRequested).toHaveBeenCalledTimes(2))
+    await fireEvent.click(screen.getByRole('button', { name: 'remove-1' }))
+    await waitFor(() => expect(listRequested).toHaveBeenCalledTimes(3))
+    await fireEvent.click(screen.getByRole('button', { name: 'host-open-history' }))
+
+    expect(mocks.openSharedDialog).toHaveBeenCalledOnce()
+    expect(mocks.openSharedDialog.mock.calls[0][1]).toEqual({ type: '电影' })
+    const events = mocks.openSharedDialog.mock.calls[0][2] as { save: () => void }
+    events.save()
+    await waitFor(() => expect(listRequested).toHaveBeenCalledTimes(4))
+  })
+
+  it('commits a custom order only after a successful response', async () => {
+    const saved = vi.fn()
+    server.use(saveSubscribeOrderConfigHandler('电影', { success: true }, 200, saved))
+    await renderList({
+      listResponse: [movie(1, 'First'), movie(2, 'Second')],
+      orderValue: [{ id: 1 }, { id: 2 }],
+      sortBy: 'custom',
+      sortMode: true,
+    })
+    await screen.findByText('First')
+
+    await fireEvent.click(screen.getByRole('button', { name: 'reverse-order' }))
+
+    await waitFor(() => expect(saved).toHaveBeenCalledOnce())
+    expect(saved.mock.calls[0][0]).toEqual([{ id: 2 }, { id: 1 }])
+    expect(saved.mock.calls[0][1].href).toBe(subscribeApiUrls.orderConfig('电影'))
+    expect(displayedNames()).toEqual(['Second', 'First'])
+    expect(screen.getByTestId('sort-mode-state')).toHaveTextContent('true')
+  })
+
+  it('locks dragging while saving and ignores a repeated end event', async () => {
+    let releaseSave = () => {}
+    const pendingSave = new Promise<void>(resolve => {
+      releaseSave = resolve
+    })
+    const saved = vi.fn(async () => pendingSave)
+    server.use(saveSubscribeOrderConfigHandler('电影', { success: true }, 200, saved))
+    await renderList({
+      listResponse: [movie(1, 'First'), movie(2, 'Second')],
+      orderValue: [{ id: 1 }, { id: 2 }],
+      sortBy: 'custom',
+      sortMode: true,
+    })
+    await screen.findByText('First')
+
+    const reverseButton = screen.getByRole('button', { name: 'reverse-order' })
+    await fireEvent.click(reverseButton)
+
+    await waitFor(() => expect(saved).toHaveBeenCalledOnce())
+    expect(reverseButton).toBeDisabled()
+
+    await fireEvent.click(screen.getByRole('button', { name: 'force-reverse-order' }))
+
+    expect(saved).toHaveBeenCalledOnce()
+    expect(displayedNames()).toEqual(['First', 'Second'])
+
+    releaseSave()
+    await waitFor(() => expect(reverseButton).not.toBeDisabled())
+    expect(displayedNames()).toEqual(['Second', 'First'])
+  })
+
+  it('preserves a newer parent sort choice while a custom order save finishes', async () => {
+    let releaseSave = () => {}
+    const pendingSave = new Promise<void>(resolve => {
+      releaseSave = resolve
+    })
+    const saved = vi.fn(async () => pendingSave)
+    server.use(saveSubscribeOrderConfigHandler('电影', { success: true }, 200, saved))
+    const { rerender } = await renderList({
+      listResponse: [movie(1, 'First'), movie(2, 'Second')],
+      orderValue: [{ id: 1 }, { id: 2 }],
+      sortBy: 'custom',
+      sortMode: true,
+    })
+    await screen.findByText('First')
+
+    await fireEvent.click(screen.getByRole('button', { name: 'reverse-order' }))
+    await waitFor(() => expect(saved).toHaveBeenCalledOnce())
+
+    await rerender({ sortBy: 'date' })
+    await waitFor(() => expect(screen.getByTestId('sort-by-state')).toHaveTextContent('date'))
+
+    releaseSave()
+    await flushPromises()
+
+    expect(screen.getByTestId('sort-by-state')).toHaveTextContent('date')
+  })
+
+  it.each([
+    ['business failure', 200, { message: 'rejected', success: false }],
+    ['HTTP failure', 500, { message: 'server error', success: false }],
+  ])('rolls back the confirmed order and remains sortable after a %s', async (_case, status, response) => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    server.use(saveSubscribeOrderConfigHandler('电影', response, status))
+    await renderList({
+      listResponse: [movie(1, 'First'), movie(2, 'Second')],
+      orderValue: [{ id: 1 }, { id: 2 }],
+      sortBy: 'custom',
+      sortMode: true,
+    })
+    await screen.findByText('First')
+
+    await fireEvent.click(screen.getByRole('button', { name: 'reverse-order' }))
+
+    await waitFor(() => expect(mocks.toastError).toHaveBeenCalledWith('请求失败，请稍后重试'))
+    expect(displayedNames()).toEqual(['First', 'Second'])
+    expect(screen.getByTestId('sort-mode-state')).toHaveTextContent('true')
+  })
+})
+
+describe('SubscribeListView batch operations', () => {
+  it('exits drag sorting when batch mode makes the list unsortable', async () => {
+    await renderList({
+      listResponse: [movie(1, 'Alpha'), movie(2, 'Beta')],
+      orderValue: [{ id: 1 }, { id: 2 }],
+      sortBy: 'custom',
+      sortMode: true,
+    })
+    await screen.findByText('Alpha')
+    expect(screen.getByTestId('sort-mode-state')).toHaveTextContent('true')
+
+    await fireEvent.click(screen.getByRole('button', { name: 'host-enter-batch' }))
+
+    await waitFor(() => expect(screen.getByTestId('sort-mode-state')).toHaveTextContent('false'))
+    expect(batchState()).toMatchObject({ enabled: true, selectedCount: 0, totalCount: 2 })
+  })
+
+  it('intersects selection with the visible list and never treats equal lengths as equal ids', async () => {
+    const statusRequested = vi.fn()
+    server.use(updateSubscribeStatusHandler(1, { success: true }, 200, statusRequested))
+    const { rerender } = await renderList({ listResponse: [movie(1, 'Alpha'), movie(2, 'Beta')] })
+    await screen.findByText('Alpha')
+
+    await fireEvent.click(screen.getByRole('button', { name: 'host-enter-batch' }))
+    await fireEvent.click(screen.getByRole('button', { name: 'select-1' }))
+    expect(batchState()).toMatchObject({ allSelected: false, enabled: true, selectedCount: 1, totalCount: 2 })
+
+    await rerender({ keyword: 'Beta' })
+    await waitFor(() => expect(displayedNames()).toEqual(['Beta']))
+    expect(card(2)).toHaveAttribute('data-selected', 'false')
+    expect(batchState()).toMatchObject({ allSelected: false, enabled: true, selectedCount: 0, totalCount: 1 })
+
+    await fireEvent.click(screen.getByRole('button', { name: 'host-batch-enable' }))
+    expect(mocks.toastWarning).toHaveBeenCalledWith('请先选择要操作的订阅')
+    expect(statusRequested).not.toHaveBeenCalled()
+  })
+
+  it('selects and deselects the exact visible id set', async () => {
+    await renderList({ listResponse: [movie(1, 'Alpha'), movie(2, 'Beta')] })
+    await screen.findByText('Alpha')
+    await fireEvent.click(screen.getByRole('button', { name: 'host-enter-batch' }))
+
+    await fireEvent.click(screen.getByRole('button', { name: 'host-toggle-select-all' }))
+    expect(card(1)).toHaveAttribute('data-selected', 'true')
+    expect(card(2)).toHaveAttribute('data-selected', 'true')
+    expect(batchState()).toMatchObject({ allSelected: true, selectedCount: 2, totalCount: 2 })
+
+    await fireEvent.click(screen.getByRole('button', { name: 'host-toggle-select-all' }))
+    expect(card(1)).toHaveAttribute('data-selected', 'false')
+    expect(card(2)).toHaveAttribute('data-selected', 'false')
+    expect(batchState()).toMatchObject({ allSelected: false, selectedCount: 0, totalCount: 2 })
+  })
+
+  it('does not request a mutation without selection or after confirmation is cancelled', async () => {
+    const requested = vi.fn()
+    server.use(updateSubscribeStatusHandler(1, { success: true }, 200, requested))
+    await renderList({ listResponse: [movie(1, 'Alpha')] })
+    await screen.findByText('Alpha')
+    await fireEvent.click(screen.getByRole('button', { name: 'host-enter-batch' }))
+
+    await fireEvent.click(screen.getByRole('button', { name: 'host-batch-enable' }))
+    expect(mocks.toastWarning).toHaveBeenCalledWith('请先选择要操作的订阅')
+    expect(requested).not.toHaveBeenCalled()
+
+    mocks.confirm.mockResolvedValueOnce(false)
+    await fireEvent.click(screen.getByRole('button', { name: 'select-1' }))
+    await fireEvent.click(screen.getByRole('button', { name: 'host-batch-enable' }))
+    expect(requested).not.toHaveBeenCalled()
+    expect(card(1)).toHaveAttribute('data-selected', 'true')
+  })
+
+  it.each([
+    ['enable', 'host-batch-enable', 'R'],
+    ['pause', 'host-batch-pause', 'S'],
+  ])('completes a successful batch %s and sends the expected state query', async (_case, buttonName, state) => {
+    const requested = vi.fn()
+    server.use(updateSubscribeStatusHandler(1, { success: true }, 200, requested))
+    await renderList({ listResponse: [movie(1, 'Alpha')] })
+    await screen.findByText('Alpha')
+    await fireEvent.click(screen.getByRole('button', { name: 'host-enter-batch' }))
+    await fireEvent.click(screen.getByRole('button', { name: 'select-1' }))
+
+    await fireEvent.click(screen.getByRole('button', { name: buttonName }))
+
+    await waitFor(() => expect(requested).toHaveBeenCalledOnce())
+    expect(requested.mock.calls[0][0].pathname).toBe(new URL(subscribeApiUrls.statusById(1)).pathname)
+    expect(requested.mock.calls[0][0].searchParams.get('state')).toBe(state)
+    await waitFor(() => expect(batchState()).toMatchObject({ enabled: false, selectedCount: 0 }))
+  })
+
+  it('completes a successful batch delete through the id endpoint', async () => {
+    const deleted = vi.fn()
+    server.use(deleteSubscribeByIdHandler(1, { success: true }, 200, deleted))
+    await renderList({ listResponse: [movie(1, 'Alpha')] })
+    await screen.findByText('Alpha')
+    await fireEvent.click(screen.getByRole('button', { name: 'host-enter-batch' }))
+    await fireEvent.click(screen.getByRole('button', { name: 'select-1' }))
+
+    await fireEvent.click(screen.getByRole('button', { name: 'host-batch-delete' }))
+
+    await waitFor(() => expect(deleted).toHaveBeenCalledOnce())
+    await waitFor(() => expect(batchState()).toMatchObject({ enabled: false, selectedCount: 0 }))
+  })
+
+  it('classifies HTTP 200 success false as a failure and keeps it selected for retry', async () => {
+    const requested = vi.fn()
+    server.use(updateSubscribeStatusHandler(1, { message: 'rejected', success: false }, 200, requested))
+    await renderList({ listResponse: [movie(1, 'Alpha')] })
+    await screen.findByText('Alpha')
+    await fireEvent.click(screen.getByRole('button', { name: 'host-enter-batch' }))
+    await fireEvent.click(screen.getByRole('button', { name: 'select-1' }))
+
+    await fireEvent.click(screen.getByRole('button', { name: 'host-batch-enable' }))
+
+    await waitFor(() => expect(requested).toHaveBeenCalledOnce())
+    await waitFor(() => expect(mocks.toastError).toHaveBeenCalledWith('启用失败 1 个订阅'))
+    expect(mocks.toastSuccess).not.toHaveBeenCalled()
+    expect(card(1)).toHaveAttribute('data-selected', 'true')
+    expect(batchState()).toMatchObject({ enabled: true, selectedCount: 1 })
+  })
+
+  it('maps partial HTTP failures to a fixed target snapshot and preserves only failed ids', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    let releaseFirst: () => void = () => {}
+    let markFirstStarted: () => void = () => {}
+    const firstStarted = new Promise<void>(resolve => {
+      markFirstStarted = resolve
+    })
+    const firstResponseGate = new Promise<void>(resolve => {
+      releaseFirst = resolve
+    })
+    const firstRequested = vi.fn(async (url: URL) => {
+      markFirstStarted()
+      await firstResponseGate
+      expect(url.pathname).toBe(new URL(subscribeApiUrls.statusById(1)).pathname)
+    })
+    const secondRequested = vi.fn()
+    server.use(
+      updateSubscribeStatusHandler(1, { success: true }, 200, firstRequested),
+      updateSubscribeStatusHandler(2, { message: 'failed', success: false }, 500, secondRequested),
+    )
+    await renderList({ listResponse: [movie(1, 'Alpha'), movie(2, 'Beta')] })
+    await screen.findByText('Alpha')
+    await fireEvent.click(screen.getByRole('button', { name: 'host-enter-batch' }))
+    await fireEvent.click(screen.getByRole('button', { name: 'host-toggle-select-all' }))
+
+    await fireEvent.click(screen.getByRole('button', { name: 'host-batch-enable' }))
+    await firstStarted
+    await fireEvent.click(screen.getByRole('button', { name: 'select-2' }))
+    releaseFirst()
+
+    await waitFor(() => expect(secondRequested).toHaveBeenCalledOnce())
+    await waitFor(() => expect(mocks.toastSuccess).toHaveBeenCalledWith('成功启用 1 个订阅'))
+    expect(mocks.toastError).toHaveBeenCalledWith('启用失败 1 个订阅')
+    expect(firstRequested.mock.calls[0][0].searchParams.get('state')).toBe('R')
+    expect(secondRequested.mock.calls[0][0].searchParams.get('state')).toBe('R')
+    await waitFor(() => expect(card(1)).toHaveAttribute('data-selected', 'false'))
+    expect(card(2)).toHaveAttribute('data-selected', 'true')
+    expect(batchState()).toMatchObject({ enabled: true, selectedCount: 1, totalCount: 2 })
+  })
+
+  it.each([
+    ['successful', { success: true }],
+    ['failed', { message: 'rejected', success: false }],
+  ])('does not let a delayed %s response mutate a newer batch session', async (_case, response) => {
+    let markRequestStarted: () => void = () => {}
+    let releaseRequest: () => void = () => {}
+    const requestStarted = new Promise<void>(resolve => {
+      markRequestStarted = resolve
+    })
+    const responseGate = new Promise<void>(resolve => {
+      releaseRequest = resolve
+    })
+    const listRequested = vi.fn()
+    const statusRequested = vi.fn(async () => {
+      markRequestStarted()
+      await responseGate
+    })
+    server.use(updateSubscribeStatusHandler(1, response, 200, statusRequested))
+    await renderList({ listResponse: [movie(1, 'Alpha')], onListRequest: listRequested })
+    await screen.findByText('Alpha')
+    await fireEvent.click(screen.getByRole('button', { name: 'host-enter-batch' }))
+    await fireEvent.click(screen.getByRole('button', { name: 'select-1' }))
+
+    await fireEvent.click(screen.getByRole('button', { name: 'host-batch-enable' }))
+    await requestStarted
+    await fireEvent.click(screen.getByRole('button', { name: 'host-exit-batch' }))
+    await fireEvent.click(screen.getByRole('button', { name: 'host-enter-batch' }))
+    expect(batchState()).toMatchObject({ enabled: true, selectedCount: 0 })
+
+    releaseRequest()
+    await waitFor(() => expect(listRequested).toHaveBeenCalledTimes(2))
+    await flushPromises()
+
+    expect(card(1)).toHaveAttribute('data-selected', 'false')
+    expect(batchState()).toMatchObject({ enabled: true, selectedCount: 0 })
+  })
+})

--- a/tests/support/msw/handlers/subscribe.ts
+++ b/tests/support/msw/handlers/subscribe.ts
@@ -26,12 +26,64 @@ export const subscribeApiUrls = {
   episodeGroups: (tmdbId: number) => new URL(`media/groups/${tmdbId}`, API_BASE_URL).href,
   filterRuleGroups: new URL('system/setting/UserFilterRuleGroups', API_BASE_URL).href,
   queryByMedia: (mediaId: string) => new URL(`subscribe/media/${mediaId}`, API_BASE_URL).href,
+  list: new URL('subscribe/', API_BASE_URL).href,
+  orderConfig: (type: SubscribeMediaType) =>
+    new URL(`user/config/${type === '电影' ? 'SubscribeMovieOrder' : 'SubscribeTvOrder'}`, API_BASE_URL).href,
   sites: new URL('site/rss', API_BASE_URL).href,
+  statusById: (id: number) => new URL(`subscribe/status/${id}`, API_BASE_URL).href,
   update: new URL('subscribe/', API_BASE_URL).href,
 }
 
 function jsonResponse(body: JsonBodyType, status: number) {
   return HttpResponse.json(body, { status })
+}
+
+export function subscribeListHandler(
+  response: JsonBodyType = [],
+  status = 200,
+  onRequest: (url: URL) => void = () => {},
+) {
+  return http.get(subscribeApiUrls.list, ({ request }) => {
+    onRequest(new URL(request.url))
+    return jsonResponse(response, status)
+  })
+}
+
+export function subscribeOrderConfigHandler(
+  type: SubscribeMediaType,
+  value: JsonBodyType = [],
+  status = 200,
+  onRequest: (url: URL) => void = () => {},
+) {
+  return http.get(subscribeApiUrls.orderConfig(type), ({ request }) => {
+    onRequest(new URL(request.url))
+    return jsonResponse({ data: { value }, success: status < 400 }, status)
+  })
+}
+
+export function saveSubscribeOrderConfigHandler(
+  type: SubscribeMediaType,
+  response: SubscribeMutationResponse = { success: true },
+  status = 200,
+  onSave: (payload: { id: number }[], url: URL) => void | Promise<void> = () => {},
+) {
+  return http.post(subscribeApiUrls.orderConfig(type), async ({ request }) => {
+    const payload = (await request.json()) as { id: number }[]
+    await onSave(payload, new URL(request.url))
+    return jsonResponse(response, status)
+  })
+}
+
+export function updateSubscribeStatusHandler(
+  id: number,
+  response: SubscribeMutationResponse = { success: true },
+  status = 200,
+  onRequest: (url: URL) => void | Promise<void> = () => {},
+) {
+  return http.put(subscribeApiUrls.statusById(id), async ({ request }) => {
+    await onRequest(new URL(request.url))
+    return jsonResponse(response, status)
+  })
 }
 
 export function createSubscribeHandler(

--- a/tests/support/render.ts
+++ b/tests/support/render.ts
@@ -4,7 +4,7 @@ import { createTestingPinia } from '@pinia/testing'
 import { render } from '@testing-library/vue'
 import { setActivePinia } from 'pinia'
 import { defineComponent, h, type Component } from 'vue'
-import { createMemoryHistory, createRouter, type RouteLocationRaw } from 'vue-router'
+import { createMemoryHistory, createRouter, type RouteLocationRaw, type RouteMeta } from 'vue-router'
 import { vi } from 'vitest'
 
 type TestingLibraryRenderOptions = NonNullable<Parameters<typeof render>[1]>
@@ -12,7 +12,7 @@ type TestingLibraryRenderOptions = NonNullable<Parameters<typeof render>[1]>
 export interface RenderWithProvidersOptions extends Omit<TestingLibraryRenderOptions, 'global'> {
   global?: TestingLibraryRenderOptions['global']
   initialRoute?: RouteLocationRaw
-  initialRouteMeta?: { subType?: '电影' | '电视剧' }
+  initialRouteMeta?: RouteMeta
   initialState?: Record<string, Record<string, unknown>>
   stubActions?: boolean
 }

--- a/tests/support/render.ts
+++ b/tests/support/render.ts
@@ -12,6 +12,7 @@ type TestingLibraryRenderOptions = NonNullable<Parameters<typeof render>[1]>
 export interface RenderWithProvidersOptions extends Omit<TestingLibraryRenderOptions, 'global'> {
   global?: TestingLibraryRenderOptions['global']
   initialRoute?: RouteLocationRaw
+  initialRouteMeta?: { subType?: '电影' | '电视剧' }
   initialState?: Record<string, Record<string, unknown>>
   stubActions?: boolean
 }
@@ -26,13 +27,14 @@ export async function renderWithProviders(component: Component, options: RenderW
   const {
     global: globalOptions,
     initialRoute = '/',
+    initialRouteMeta = {},
     initialState = {},
     stubActions = true,
     ...renderOptions
   } = options
   const router = createRouter({
     history: createMemoryHistory(),
-    routes: [{ path: '/:pathMatch(.*)*', component: EmptyRoute }],
+    routes: [{ path: '/:pathMatch(.*)*', component: EmptyRoute, meta: initialRouteMeta }],
   })
   await router.push(initialRoute)
   i18n.global.locale.value = 'zh-CN'

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -276,7 +276,9 @@ export default defineConfig(({ mode }) => ({
         'src/utils/permission.ts',
         'src/stores/auth.ts',
         'src/pages/recommend.vue',
+        'src/pages/subscribe.vue',
         'src/views/dashboard/MediaRecommend.vue',
+        'src/views/subscribe/SubscribeListView.vue',
         'src/composables/useMediaSubscribe.ts',
         'src/components/dialog/SubscribeEditDialog.vue',
       ],
@@ -306,6 +308,12 @@ export default defineConfig(({ mode }) => ({
           lines: 80,
           statements: 80,
         },
+        'src/pages/subscribe.vue': {
+          branches: 75,
+          functions: 80,
+          lines: 80,
+          statements: 80,
+        },
         'src/stores/auth.ts': {
           branches: 75,
           functions: 80,
@@ -325,6 +333,12 @@ export default defineConfig(({ mode }) => ({
           statements: 80,
         },
         'src/views/dashboard/MediaRecommend.vue': {
+          branches: 75,
+          functions: 80,
+          lines: 80,
+          statements: 80,
+        },
+        'src/views/subscribe/SubscribeListView.vue': {
           branches: 75,
           functions: 80,
           lines: 80,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -268,6 +268,7 @@ export default defineConfig(({ mode }) => ({
       },
     },
     setupFiles: ['./tests/setup.ts'],
+    testTimeout: 10_000,
     unstubGlobals: true,
     coverage: {
       include: [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -268,7 +268,7 @@ export default defineConfig(({ mode }) => ({
       },
     },
     setupFiles: ['./tests/setup.ts'],
-    testTimeout: 10_000,
+    testTimeout: 60_000,
     unstubGlobals: true,
     coverage: {
       include: [


### PR DESCRIPTION
## 变更说明

- 为订阅页和订阅列表增加用户行为测试，覆盖电影/电视剧标签、筛选排序、批量操作、自定义顺序和错误反馈。
- 将 `src/pages/subscribe.vue` 与 `src/views/subscribe/SubscribeListView.vue` 加入核心覆盖率清单，并为两个文件设置单文件门槛。
- 将 Vitest 全局用例超时调整为 60 秒，并补充订阅创建成功后辅助配置读取失败的回归场景。

## 生产行为调整

- 批量模式与拖拽排序保持互斥：进入排序时退出批量模式并清空选择。
- 筛选后将选中项收敛到当前可见列表，全选按订阅 ID 集合判断，避免误操作隐藏项。
- 批量启用和暂停同时检查 HTTP 请求结果与业务 `success`；删除继续遵循现有幂等响应契约。
- 自定义顺序保存发生网络或非 2xx 异常时，恢复上一个已确认顺序并提示。
- 首次列表加载失败会结束 Loading 并展示错误；静默刷新失败保留已有列表。

本 PR 未修改后端、API 路径、请求方法或 payload。

## 测试架构

- 业务 spec 继续共置于 `src/**/__tests__/*.spec.ts`。
- HTTP 契约通过 `tests/support/msw` 拦截，未声明请求直接失败，测试期间无真实出站。
- 页面测试使用真实 Router/Pinia 和用户可见行为断言，不读取组件私有状态，也不使用大段快照。
- 测试宿主复用现有生产类型与 Vue Router 契约，避免重复的一次性结构。

## 验证

- `yarn test:run`：9 个测试文件、134 项测试通过。
- `yarn test:coverage`：聚合 Lines/Statements 95.11%、Functions 94.21%、Branches 85.34%。
- `src/pages/subscribe.vue`：Lines/Statements 88.83%、Functions 84.37%、Branches 83.19%。
- `src/views/subscribe/SubscribeListView.vue`：Lines/Statements 92.53%、Functions 86.66%、Branches 85.47%。
- `yarn typecheck`、`yarn build`、`git diff --check` 通过。
- `yarn lint` 仍受仓库既有 ESLint 9 与 ESM 配置加载故障阻断，失败发生在文件扫描前。
- Chrome 桌面与移动宽度已回归订阅页面、筛选排序以及批量与拖拽互斥。

本 PR 为 Codex 协作提交
