### PR TITLE
feat: 增加监控目录空文件夹清理开关

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1375,6 +1375,8 @@ export interface TransferDirectoryConf {
   monitor_type?: string
   // 监控模式 fast/compatibility
   monitor_mode?: string
+  // 是否删除源目录中的空文件夹
+  delete_empty_dirs?: boolean
   // 整理方式 move/copy/link/softlink
   transfer_type: string
   // 文件覆盖模式 always/size/never/latest

--- a/src/components/cards/DirectoryCard.vue
+++ b/src/components/cards/DirectoryCard.vue
@@ -347,13 +347,19 @@ watch(
           </VCol>
         </VRow>
         <VRow v-if="$props.directory.monitor_type">
-          <VCol cols="12" v-if="$props.directory.monitor_type == 'monitor'">
+          <VCol cols="12" md="6" v-if="$props.directory.monitor_type == 'monitor'">
             <VSelect
               v-model="props.directory.monitor_mode"
               variant="underlined"
               :items="MonitorModeItems"
               :label="t('directory.monitorMode')"
               mobile-control-width="65%"
+            />
+          </VCol>
+          <VCol cols="12" md="6" v-if="$props.directory.monitor_type == 'monitor'">
+            <VSwitch
+              v-model="props.directory.delete_empty_dirs"
+              :label="t('directory.deleteEmptyDirectories')"
             />
           </VCol>
           <VCol cols="4">

--- a/src/components/cards/__tests__/DirectoryCard.spec.ts
+++ b/src/components/cards/__tests__/DirectoryCard.spec.ts
@@ -1,0 +1,66 @@
+import type { StorageConf, TransferDirectoryConf } from '@/api/types'
+import DirectoryCard from '@/components/cards/DirectoryCard.vue'
+import { fireEvent, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { renderWithProviders } from '@tests/support/render'
+import { describe, expect, it } from 'vitest'
+
+const storages: StorageConf[] = [
+  {
+    name: '本地',
+    type: 'local',
+    config: {},
+  },
+]
+
+function createDirectory(overrides: Partial<TransferDirectoryConf> = {}): TransferDirectoryConf {
+  return {
+    name: '测试目录',
+    priority: 0,
+    storage: 'local',
+    monitor_type: 'monitor',
+    transfer_type: 'move',
+    ...overrides,
+  }
+}
+
+async function renderDirectoryCard(directory: TransferDirectoryConf) {
+  const result = await renderWithProviders(DirectoryCard, {
+    props: {
+      categories: {},
+      directory,
+      storages,
+    },
+    global: {
+      stubs: {
+        VDialogCloseBtn: true,
+        VPathField: true,
+      },
+    },
+  })
+  const expandButton = result.container.querySelector('.v-card-actions button')
+
+  expect(expandButton).not.toBeNull()
+  await fireEvent.click(expandButton as HTMLButtonElement)
+  await screen.findByLabelText('媒体类型')
+
+  return result
+}
+
+describe('DirectoryCard', () => {
+  it('allows directory monitoring to disable empty-directory cleanup', async () => {
+    const directory = createDirectory({ delete_empty_dirs: true })
+    await renderDirectoryCard(directory)
+    const cleanupSwitch = screen.getByLabelText('删除空文件夹')
+
+    expect(cleanupSwitch).toBeChecked()
+    await userEvent.click(cleanupSwitch)
+    expect(directory.delete_empty_dirs).toBe(false)
+  })
+
+  it('hides empty-directory cleanup for downloader monitoring', async () => {
+    await renderDirectoryCard(createDirectory({ delete_empty_dirs: true, monitor_type: 'downloader' }))
+
+    expect(screen.queryByLabelText('删除空文件夹')).not.toBeInTheDocument()
+  })
+})

--- a/src/locales/en-US.ts
+++ b/src/locales/en-US.ts
@@ -3917,6 +3917,7 @@ export default {
     sortByCategory: 'Sort by Category',
     autoTransfer: 'Auto Transfer',
     monitorMode: 'Monitor Mode',
+    deleteEmptyDirectories: 'Delete Empty Directories',
     libraryStorage: 'Library Storage',
     libraryDirectory: 'Library Directory',
     transferType: 'Transfer Type',

--- a/src/locales/zh-CN.ts
+++ b/src/locales/zh-CN.ts
@@ -3858,6 +3858,7 @@ export default {
     sortByCategory: '按类别分类',
     autoTransfer: '自动整理',
     monitorMode: '监控模式',
+    deleteEmptyDirectories: '删除空文件夹',
     libraryStorage: '媒体库存储',
     libraryDirectory: '媒体库目录',
     transferType: '整理方式',

--- a/src/locales/zh-TW.ts
+++ b/src/locales/zh-TW.ts
@@ -3855,6 +3855,7 @@ export default {
     sortByCategory: '按分類排序',
     autoTransfer: '自動轉移',
     monitorMode: '監控模式',
+    deleteEmptyDirectories: '刪除空資料夾',
     libraryStorage: '媒體庫存儲',
     libraryDirectory: '媒體庫目錄',
     transferType: '轉移方式',

--- a/src/views/setting/AccountSettingDirectory.vue
+++ b/src/views/setting/AccountSettingDirectory.vue
@@ -151,7 +151,10 @@ async function saveStorages() {
 async function loadDirectories() {
   try {
     const result: { [key: string]: any } = await api.get('system/setting/public/Directories')
-    directories.value = result.data?.value ?? []
+    directories.value = (result.data?.value ?? []).map((directory: TransferDirectoryConf) => ({
+      ...directory,
+      delete_empty_dirs: directory.delete_empty_dirs !== false,
+    }))
   } catch (error) {
     console.log(error)
   }
@@ -189,6 +192,7 @@ function addDirectory() {
     download_path: '',
     priority: -1,
     monitor_type: '',
+    delete_empty_dirs: true,
     media_type: '',
     media_category: '',
     transfer_type: '',


### PR DESCRIPTION
## 关联 Issue

- jxxghp/MoviePilot#5989
- 后端配套：jxxghp/MoviePilot#6134

## 变更说明

- 在目录监控配置中增加“删除空文件夹”开关
- 新目录及旧配置缺少字段时默认开启，保持原有行为
- 补充简体中文、繁体中文和英文文案
- 增加组件测试，覆盖开关交互及非目录监控场景

## 测试

- `corepack yarn test:run`（136 passed）
- `corepack yarn typecheck`

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at bf12f4c176de57aa43edf927d0ca9f3ec5a89229

- 为目录监控添加空文件夹清理开关
- 旧配置缺失字段时默认启用
- 仅 `monitor` 模式展示开关
- 补充多语言文案与组件测试

<!-- pr-agent-summary:end -->