### PR TITLE
fix(layout): register cleanup hook synchronously

### DIFF
--- a/src/layouts/default/components/DefaultLayout.vue
+++ b/src/layouts/default/components/DefaultLayout.vue
@@ -422,6 +422,12 @@ function handlePluginClick() {
   showPluginQuickAccess.value = false
 }
 
+// 组件卸载时清理监听
+onBeforeUnmount(() => {
+  window.removeEventListener(THEME_CUSTOMIZER_CHANGE_EVENT, handleThemeCustomizerChange)
+  window.removeEventListener(THEME_CUSTOMIZER_OPEN_EVENT, handleThemeCustomizerOpen)
+})
+
 /** 将插件侧边栏菜单合并到对应的导航分组中。 */
 function appendPluginSidebarMenus() {
   for (const { navMenu, section } of filterPluginSidebarNavEntries(
@@ -464,12 +470,6 @@ onMounted(async () => {
 
   await pluginSidebarNavStore.ensureSidebarNav()
   appendPluginSidebarMenus()
-
-  // 组件卸载时清理监听
-  onBeforeUnmount(() => {
-    window.removeEventListener(THEME_CUSTOMIZER_CHANGE_EVENT, handleThemeCustomizerChange)
-    window.removeEventListener(THEME_CUSTOMIZER_OPEN_EVENT, handleThemeCustomizerOpen)
-  })
 })
 </script>
 

--- a/src/layouts/default/components/__tests__/DefaultLayout.spec.ts
+++ b/src/layouts/default/components/__tests__/DefaultLayout.spec.ts
@@ -1,0 +1,125 @@
+import DefaultLayout from '@/layouts/default/components/DefaultLayout.vue'
+import {
+  THEME_CUSTOMIZER_CHANGE_EVENT,
+  THEME_CUSTOMIZER_OPEN_EVENT,
+} from '@/composables/useThemeCustomizer'
+import { flushPromises, shallowMount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  emptyComponent: { template: '<div><slot /></div>' },
+  ensureSidebarNav: vi.fn(),
+}))
+
+vi.mock('@layouts/components/VerticalNavLayout.vue', () => ({ default: mocks.emptyComponent }))
+vi.mock('@layouts/components/VerticalNavLink.vue', () => ({ default: mocks.emptyComponent }))
+vi.mock('@layouts/components/VerticalNavSectionTitle.vue', () => ({ default: mocks.emptyComponent }))
+vi.mock('@/components/agent/AgentAssistantWidget.vue', () => ({ default: mocks.emptyComponent }))
+vi.mock('@/components/misc/ThemeLogoMark.vue', () => ({ default: mocks.emptyComponent }))
+vi.mock('@/components/theme/ThemeCustomizer.vue', () => ({ default: mocks.emptyComponent }))
+vi.mock('@/layouts/default/components/Footer.vue', () => ({ default: mocks.emptyComponent }))
+vi.mock('@/layouts/default/components/HeaderTab.vue', () => ({ default: mocks.emptyComponent }))
+vi.mock('@/layouts/default/components/OfflinePage.vue', () => ({ default: mocks.emptyComponent }))
+vi.mock('@/layouts/default/components/QuickAccess.vue', () => ({ default: mocks.emptyComponent }))
+vi.mock('@/layouts/default/components/SearchBar.vue', () => ({ default: mocks.emptyComponent }))
+vi.mock('@/layouts/default/components/ShortcutBar.vue', () => ({ default: mocks.emptyComponent }))
+vi.mock('@/layouts/default/components/UserNotification.vue', () => ({ default: mocks.emptyComponent }))
+vi.mock('@/layouts/default/components/UserProfile.vue', () => ({ default: mocks.emptyComponent }))
+
+vi.mock('@/stores', () => ({
+  useGlobalSettingsStore: () => ({ get: vi.fn(() => false) }),
+  usePluginSidebarNavStore: () => ({
+    ensureSidebarNav: mocks.ensureSidebarNav,
+    items: [],
+  }),
+  useUserStore: () => ({ permissions: [], superUser: true }),
+}))
+
+vi.mock('@/router/i18n-menu', () => ({ getNavMenus: () => [] }))
+vi.mock('@/utils/pluginSidebarNav', () => ({ filterPluginSidebarNavEntries: () => [] }))
+vi.mock('@/utils/permission', async importOriginal => ({
+  ...(await importOriginal<typeof import('@/utils/permission')>()),
+  buildUserPermissionContext: () => ({}),
+  filterItemsByPermission: <T>(items: T[]) => items,
+  filterMenusByPermission: () => [],
+  hasItemPermission: () => true,
+  hasPermission: () => true,
+}))
+vi.mock('@/composables/useOfflineStatus', () => ({
+  useGlobalOfflineStatus: () => ({ isOffline: { value: false } }),
+}))
+vi.mock('@/composables/usePullDownGesture', () => ({
+  usePullDownGesture: () => ({
+    config: {
+      MAX_PULL_DISTANCE: 220,
+      SHOW_INDICATOR: 80,
+      TRIGGER_THRESHOLD: 140,
+    },
+    contentTransform: { value: '' },
+    contentTransition: { value: '' },
+    indicatorOpacity: { value: 0 },
+    indicatorRotation: { value: 0 },
+    indicatorTransform: { value: '' },
+    pullDistance: { value: 0 },
+    showPullIndicator: { value: false },
+  }),
+}))
+vi.mock('@/composables/usePWA', () => ({ usePWA: () => ({ appMode: { value: false } }) }))
+vi.mock('vue-i18n', async importOriginal => ({
+  ...(await importOriginal<typeof import('vue-i18n')>()),
+  useI18n: () => ({ t: (key: string) => key }),
+}))
+vi.mock('vue-router', async importOriginal => ({
+  ...(await importOriginal<typeof import('vue-router')>()),
+  useRoute: () => ({ path: '/' }),
+  useRouter: () => ({ push: vi.fn() }),
+}))
+vi.mock('vuetify', async importOriginal => ({
+  ...(await importOriginal<typeof import('vuetify')>()),
+  useDisplay: () => ({ mdAndDown: { value: false } }),
+}))
+
+describe('DefaultLayout', () => {
+  beforeEach(() => {
+    mocks.ensureSidebarNav.mockReset()
+  })
+
+  it('removes theme customizer listeners while sidebar loading is still pending', async () => {
+    let resolveSidebarNav!: () => void
+    mocks.ensureSidebarNav.mockImplementation(
+      () =>
+        new Promise<void>(resolve => {
+          resolveSidebarNav = resolve
+        }),
+    )
+    const addEventListener = vi.spyOn(window, 'addEventListener')
+    const removeEventListener = vi.spyOn(window, 'removeEventListener')
+    const wrapper = shallowMount(DefaultLayout, {
+      global: {
+        stubs: {
+          IconBtn: mocks.emptyComponent,
+          RouterLink: mocks.emptyComponent,
+        },
+      },
+    })
+    await flushPromises()
+
+    const changeHandler = addEventListener.mock.calls.find(
+      ([event]) => String(event) === THEME_CUSTOMIZER_CHANGE_EVENT,
+    )?.[1]
+    const openHandler = addEventListener.mock.calls.find(
+      ([event]) => String(event) === THEME_CUSTOMIZER_OPEN_EVENT,
+    )?.[1]
+
+    expect(changeHandler).toBeTypeOf('function')
+    expect(openHandler).toBeTypeOf('function')
+
+    wrapper.unmount()
+
+    expect(removeEventListener).toHaveBeenCalledWith(THEME_CUSTOMIZER_CHANGE_EVENT, changeHandler)
+    expect(removeEventListener).toHaveBeenCalledWith(THEME_CUSTOMIZER_OPEN_EVENT, openHandler)
+
+    resolveSidebarNav()
+    await flushPromises()
+  })
+})


### PR DESCRIPTION
## 修改原因

Vue 生命周期注入 API 需要在组件同步初始化期间注册。原实现将 `onBeforeUnmount` 放在异步 `onMounted` 的 `await pluginSidebarNavStore.ensureSidebarNav()` 之后；异步恢复时可能已经脱离当前组件实例上下文，从而产生生命周期警告，并导致事件监听清理钩子没有成功注册。

当侧边栏数据仍在加载、组件又因路由切换或布局变化提前卸载时，这个问题还可能留下主题自定义事件监听。

## 变更说明

- 将主题自定义事件的 `onBeforeUnmount` 清理钩子移到组件同步初始化阶段注册。
- 保持事件监听的添加时机、侧边栏加载和菜单合并流程不变。
- 增加回归测试，覆盖侧边栏数据仍在加载时组件提前卸载的场景。

## 方案优势

- 符合 Vue 生命周期 API 的同步注册约束，直接消除警告根因。
- 即使异步侧边栏加载尚未完成，组件卸载时也能可靠移除监听。
- 不增加额外状态或兼容分支，运行时行为和维护成本变化很小。
- 在监听尚未添加时执行 `removeEventListener` 只是安全的空操作，不会产生额外副作用。
- 回归测试验证了异步未完成时的卸载边界，防止同类问题再次出现。

## 影响路径

- `src/layouts/default/components/DefaultLayout.vue`
- `src/layouts/default/components/__tests__/DefaultLayout.spec.ts`

## 验证结果

- `yarn test:run src/layouts/default/components/__tests__/DefaultLayout.spec.ts`：通过（1 个测试）。
- `yarn typecheck`：通过。
- `yarn build`：通过。
- `git diff --check`：通过。
- 浏览器加载默认布局后未出现 `onBeforeUnmount` 生命周期警告，页面无横向布局溢出。
- `yarn lint`：受现有 ESLint 配置阻断；ESLint 9 在 ESM package 中加载 CommonJS `.eslintrc.js` 时报告 `module is not defined`，本 PR 未调整全局 lint 配置。

本 PR 为 Codex 协作提交
