### PR TITLE
test(recommend): 完善推荐入口与横向内容加载测试

### DIFF
--- a/src/pages/__tests__/recommend.spec.ts
+++ b/src/pages/__tests__/recommend.spec.ts
@@ -1,15 +1,18 @@
 import RecommendPage from '@/pages/recommend.vue'
+import type { RecommendSource } from '@/api/types'
 import { DEFAULT_PERMISSIONS } from '@/utils/permission'
 import { fireEvent, screen, waitFor } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { renderWithProviders } from '@tests/support/render'
 import {
+  recommendApiUrls,
   recommendConfigHandler,
   recommendSourcesHandler,
   saveRecommendConfigHandler,
 } from '@tests/support/msw/handlers/recommend'
 import { server } from '@tests/support/msw/server'
-import { defineComponent } from 'vue'
+import { HttpResponse, http } from 'msw'
+import { defineComponent, nextTick, ref, type Ref } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
@@ -72,6 +75,46 @@ async function renderRecommend(options: { superUser?: boolean; discovery?: boole
   })
 }
 
+function keepAliveHarness() {
+  return defineComponent({
+    components: { RecommendPage },
+    setup() {
+      const active = ref(true)
+      return { active }
+    },
+    template: `
+      <button type="button" @click="active = false">停用推荐页</button>
+      <button type="button" @click="active = true">启用推荐页</button>
+      <KeepAlive><RecommendPage v-if="active" /></KeepAlive>
+    `,
+  })
+}
+
+async function renderKeptAliveRecommend() {
+  return renderWithProviders(keepAliveHarness(), {
+    initialRoute: '/recommend',
+    initialState: {
+      user: {
+        permissions: { ...DEFAULT_PERMISSIONS, discovery: true },
+        superUser: false,
+      },
+    },
+    global: {
+      stubs: {
+        MediaCardSlideView: MediaCardSlideViewStub,
+        VScrollToTopBtn: true,
+      },
+    },
+  })
+}
+
+function dynamicRecommendSources(getSources: () => RecommendSource[], onRequest = vi.fn()) {
+  return http.get(recommendApiUrls.sources, () => {
+    onRequest()
+    return HttpResponse.json(getSources())
+  })
+}
+
 describe('recommend page', () => {
   beforeEach(() => {
     mocks.openSharedDialog.mockReturnValue({
@@ -99,6 +142,73 @@ describe('recommend page', () => {
     expect(screen.getAllByTestId('recommend-view')).toHaveLength(2)
     expect(screen.queryByText('重复来源')).not.toBeInTheDocument()
     expect(remoteConfigRequests).toBe(0)
+  })
+
+  it('filters by the registered category and waits until ready before showing its empty state', async () => {
+    const setTimeout = vi.spyOn(window, 'setTimeout')
+    const sourcesRequested = vi.fn()
+    localStorage.setItem('MP_RECOMMEND', JSON.stringify({ '流行趋势': true }))
+    server.use(recommendSourcesHandler([], 200, sourcesRequested))
+
+    await renderRecommend()
+    await waitFor(() => expect(sourcesRequested).toHaveBeenCalledOnce())
+    const headerTab = mocks.registerHeaderTab.mock.calls[0][0] as { modelValue: Ref<string> }
+    headerTab.modelValue.value = '电视剧'
+    await nextTick()
+
+    expect(screen.queryByText('当前分类下没有可显示的内容')).not.toBeInTheDocument()
+    const readyTimer = setTimeout.mock.calls.find(([, delay]) => delay === 400)?.[0]
+    expect(typeof readyTimer).toBe('function')
+    ;(readyTimer as () => void)()
+    await nextTick()
+
+    expect(screen.getByText('当前分类下没有可显示的内容')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '设置显示内容' })).toBeInTheDocument()
+  })
+
+  it('loads extra sources only once during the initial KeepAlive activation', async () => {
+    const requested = vi.fn()
+    let releaseResponse = () => {}
+    const responseGate = new Promise<void>(resolve => {
+      releaseResponse = resolve
+    })
+    localStorage.setItem('MP_RECOMMEND', JSON.stringify({ '流行趋势': true, '请求完成来源': true }))
+    server.use(
+      http.get(recommendApiUrls.sources, async () => {
+        requested()
+        await responseGate
+        return HttpResponse.json([{ api_path: 'recommend/completed', name: '请求完成来源', type: '扩展' }])
+      }),
+    )
+
+    await renderKeptAliveRecommend()
+    await waitFor(() => expect(requested).toHaveBeenCalled())
+    await new Promise(resolve => window.setTimeout(resolve, 25))
+
+    try {
+      expect(requested).toHaveBeenCalledOnce()
+    } finally {
+      releaseResponse()
+    }
+    expect(await screen.findByText('请求完成来源')).toBeInTheDocument()
+  })
+
+  it('removes an extra source withdrawn while the kept-alive page is inactive', async () => {
+    let sources: RecommendSource[] = [{ api_path: 'recommend/custom', name: '已撤销来源', type: '扩展' }]
+    const requested = vi.fn()
+    localStorage.setItem('MP_RECOMMEND', JSON.stringify({ '流行趋势': true, '已撤销来源': true }))
+    server.use(dynamicRecommendSources(() => sources, requested))
+
+    await renderKeptAliveRecommend()
+    expect(await screen.findByText('已撤销来源')).toBeInTheDocument()
+    const requestsBeforeReactivation = requested.mock.calls.length
+    sources = []
+
+    await fireEvent.click(screen.getByRole('button', { name: '停用推荐页' }))
+    await fireEvent.click(screen.getByRole('button', { name: '启用推荐页' }))
+
+    await waitFor(() => expect(requested).toHaveBeenCalledTimes(requestsBeforeReactivation + 1))
+    await waitFor(() => expect(screen.queryByText('已撤销来源')).not.toBeInTheDocument())
   })
 
   it('loads remote configuration when local configuration is absent', async () => {

--- a/src/pages/recommend.vue
+++ b/src/pages/recommend.vue
@@ -68,7 +68,8 @@ function openRecommendSettings() {
   )
 }
 
-const viewList = reactive<RecommendViewSource[]>(createBuiltInRecommendSources(t))
+const builtInRecommendSources = createBuiltInRecommendSources(t)
+const viewList = reactive<RecommendViewSource[]>([...builtInRecommendSources])
 
 // 计算当前分类下显示的视图
 const filteredViews = computed(() => {
@@ -96,6 +97,7 @@ function initializeColors() {
 
 // 额外的数据源
 const extraRecommendSources = ref<RecommendSource[]>([])
+let extraSourcesRequest: Promise<void> | null = null
 
 /** 只接受以标题为键、布尔值为开关的推荐配置。 */
 function normalizeEnableConfig(value: unknown): Record<string, boolean> | null {
@@ -107,14 +109,24 @@ function normalizeEnableConfig(value: unknown): Record<string, boolean> | null {
   return Object.fromEntries(entries)
 }
 
-// 加载额外的发现数据源
-async function loadExtraRecommendSources() {
-  try {
-    extraRecommendSources.value = await api.get('recommend/source')
-    mergeExtraRecommendSources(viewList, extraRecommendSources.value)
-  } catch (error) {
-    console.log(error)
-  }
+/** 刷新扩展推荐源；并发生命周期入口共享请求，成功响应按当前服务端快照替换列表。 */
+function loadExtraRecommendSources() {
+  if (extraSourcesRequest) return extraSourcesRequest
+
+  extraSourcesRequest = (async () => {
+    try {
+      extraRecommendSources.value = await api.get('recommend/source')
+      const nextViewList = [...builtInRecommendSources]
+      mergeExtraRecommendSources(nextViewList, extraRecommendSources.value)
+      viewList.splice(0, viewList.length, ...nextViewList)
+    } catch (error) {
+      console.log(error)
+    }
+  })().finally(() => {
+    extraSourcesRequest = null
+  })
+
+  return extraSourcesRequest
 }
 
 // 加载面板配置

--- a/src/views/discover/__tests__/MediaCardSlideView.spec.ts
+++ b/src/views/discover/__tests__/MediaCardSlideView.spec.ts
@@ -1,0 +1,342 @@
+import type { MediaInfo } from '@/api/types'
+import MediaCardSlideView from '@/views/discover/MediaCardSlideView.vue'
+import { fireEvent, screen, waitFor } from '@testing-library/vue'
+import { createMediaInfo } from '@tests/support/factories/media'
+import { recommendMediaHandler } from '@tests/support/msw/handlers/recommend'
+import { server } from '@tests/support/msw/server'
+import { renderWithProviders } from '@tests/support/render'
+import { defineComponent, h, type PropType, ref } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const SOURCE_PATH = 'recommend/tmdb_trending'
+
+let animationFrameCallbacks: FrameRequestCallback[] = []
+let fallbackCallbacks: Array<() => void> = []
+let intersectionCallbacks: IntersectionObserverCallback[] = []
+
+class IntersectionObserverMock implements IntersectionObserver {
+  readonly root = null
+  readonly rootMargin = '300px'
+  readonly thresholds = [0]
+
+  constructor(callback: IntersectionObserverCallback) {
+    intersectionCallbacks.push(callback)
+  }
+
+  disconnect() {}
+  observe() {}
+  takeRecords(): IntersectionObserverEntry[] {
+    return []
+  }
+  unobserve() {}
+}
+
+const VirtualSlideViewStub = defineComponent({
+  name: 'VirtualSlideView',
+  props: {
+    getItemKey: {
+      type: Function as PropType<(item: MediaInfo, index: number) => string | number>,
+      required: true,
+    },
+    items: {
+      type: Array as PropType<MediaInfo[]>,
+      required: true,
+    },
+    loading: {
+      type: Boolean,
+      required: true,
+    },
+  },
+  setup(props, { slots }) {
+    return () =>
+      h(
+        'section',
+        {
+          'aria-label': '媒体横向列表',
+          'data-item-count': String(props.items.length),
+          'data-loading': String(props.loading),
+        },
+        [
+          h(
+            'output',
+            { 'aria-label': '媒体横向列表键' },
+            props.items.map((item, index) => String(props.getItemKey(item, index))).join('|'),
+          ),
+          props.loading
+            ? h('span', { role: 'status' }, '正在加载媒体')
+            : props.items.flatMap(item => slots.item?.({ item }) ?? []),
+        ],
+      )
+  },
+})
+
+const MediaCardStub = defineComponent({
+  name: 'MediaCard',
+  props: {
+    media: {
+      type: Object as PropType<MediaInfo>,
+      required: true,
+    },
+    width: {
+      type: String,
+      required: true,
+    },
+  },
+  setup(props) {
+    return () =>
+      h(
+        'article',
+        {
+          'aria-label': `媒体卡片 ${props.media.title}`,
+          'data-width': props.width,
+        },
+        props.media.title,
+      )
+  },
+})
+
+function installLoadTriggerControls() {
+  const nativeSetTimeout = window.setTimeout.bind(window)
+  type TimeoutHandle = ReturnType<typeof window.setTimeout>
+
+  vi.stubGlobal('IntersectionObserver', IntersectionObserverMock)
+  vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+    bottom: 200,
+    height: 100,
+    left: 0,
+    right: 100,
+    toJSON: () => ({}),
+    top: 100,
+    width: 100,
+    x: 0,
+    y: 100,
+  })
+  vi.spyOn(window, 'requestAnimationFrame').mockImplementation(callback => {
+    animationFrameCallbacks.push(callback)
+    return animationFrameCallbacks.length
+  })
+  vi.spyOn(window, 'setTimeout').mockImplementation(
+    ((handler: TimerHandler, timeout?: number, ...args: unknown[]): TimeoutHandle => {
+      if (timeout === 600) {
+        fallbackCallbacks.push(() => {
+          if (typeof handler === 'function') handler(...args)
+        })
+        return fallbackCallbacks.length as unknown as TimeoutHandle
+      }
+
+      return nativeSetTimeout(handler, timeout, ...args) as unknown as TimeoutHandle
+    }) as unknown as typeof window.setTimeout,
+  )
+}
+
+async function renderSlide(props: { ready?: boolean } = {}) {
+  return renderWithProviders(MediaCardSlideView, {
+    props: {
+      apipath: SOURCE_PATH,
+      linkurl: '/browse/recommend/tmdb_trending',
+      ready: props.ready ?? true,
+      title: '流行趋势',
+    },
+    global: {
+      stubs: {
+        MediaCard: MediaCardStub,
+        VirtualSlideView: VirtualSlideViewStub,
+      },
+    },
+  })
+}
+
+function triggerIntersection(isIntersecting = true) {
+  const callback = intersectionCallbacks.at(-1)
+  const boundingClientRect = document.body.getBoundingClientRect()
+  expect(callback).toBeTypeOf('function')
+  callback?.(
+    [
+      {
+        boundingClientRect,
+        intersectionRatio: isIntersecting ? 1 : 0,
+        intersectionRect: boundingClientRect,
+        isIntersecting,
+        rootBounds: null,
+        target: document.body,
+        time: 0,
+      },
+    ],
+    {} as IntersectionObserver,
+  )
+}
+
+function triggerAnimationFrame() {
+  const callback = animationFrameCallbacks.shift()
+  expect(callback).toBeTypeOf('function')
+  callback?.(0)
+}
+
+function triggerFallback() {
+  const callback = fallbackCallbacks.shift()
+  expect(callback).toBeTypeOf('function')
+  callback?.()
+}
+
+function keepAliveHarness() {
+  return defineComponent({
+    components: { MediaCardSlideView },
+    setup() {
+      const active = ref(true)
+      return { active }
+    },
+    template: `
+      <button type="button" @click="active = false">停用横向列表</button>
+      <button type="button" @click="active = true">启用横向列表</button>
+      <KeepAlive>
+        <MediaCardSlideView
+          v-if="active"
+          apipath="recommend/tmdb_trending"
+          linkurl="/browse/recommend/tmdb_trending"
+          title="流行趋势"
+        />
+      </KeepAlive>
+    `,
+  })
+}
+
+async function renderKeptAliveSlide() {
+  return renderWithProviders(keepAliveHarness(), {
+    global: {
+      stubs: {
+        MediaCard: MediaCardStub,
+        VirtualSlideView: VirtualSlideViewStub,
+      },
+    },
+  })
+}
+
+describe('MediaCardSlideView', () => {
+  beforeEach(() => {
+    animationFrameCallbacks = []
+    fallbackCallbacks = []
+    intersectionCallbacks = []
+    installLoadTriggerControls()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  it.each([
+    ['IntersectionObserver', triggerIntersection],
+    ['requestAnimationFrame', triggerAnimationFrame],
+    ['600ms fallback', triggerFallback],
+  ])('loads media through the %s entry', async (_entry, triggerLoad) => {
+    const media = createMediaInfo({ title: `${_entry} 媒体` })
+    const requested = vi.fn()
+    server.use(recommendMediaHandler(SOURCE_PATH, [media], 200, requested))
+
+    await renderSlide()
+    await waitFor(() => {
+      expect(animationFrameCallbacks).toHaveLength(1)
+      expect(fallbackCallbacks).toHaveLength(1)
+      expect(intersectionCallbacks).toHaveLength(1)
+    })
+    triggerLoad()
+
+    expect(await screen.findByRole('article', { name: `媒体卡片 ${media.title}` })).toBeInTheDocument()
+    expect(requested).toHaveBeenCalledOnce()
+  })
+
+  it('deduplicates competing observer, animation frame, and fallback loads', async () => {
+    const media = createMediaInfo({ title: '竞争入口媒体' })
+    const requested = vi.fn()
+    server.use(recommendMediaHandler(SOURCE_PATH, [media], 200, requested))
+
+    await renderSlide()
+    await waitFor(() => expect(intersectionCallbacks).toHaveLength(1))
+    triggerIntersection()
+    triggerAnimationFrame()
+    triggerFallback()
+
+    expect(await screen.findByRole('article', { name: '媒体卡片 竞争入口媒体' })).toBeInTheDocument()
+    expect(requested).toHaveBeenCalledOnce()
+  })
+
+  it('keeps non-empty data loading until ready and then projects cards', async () => {
+    const media = createMediaInfo({ title: '等待页面就绪' })
+    const requested = vi.fn()
+    server.use(recommendMediaHandler(SOURCE_PATH, [media], 200, requested))
+
+    const { rerender } = await renderSlide({ ready: false })
+    triggerAnimationFrame()
+    await waitFor(() => expect(requested).toHaveBeenCalledOnce())
+
+    expect(screen.getByLabelText('媒体横向列表')).toHaveAttribute('data-loading', 'true')
+    expect(screen.queryByRole('article', { name: '媒体卡片 等待页面就绪' })).not.toBeInTheDocument()
+
+    await rerender({ ready: true })
+
+    expect(await screen.findByRole('article', { name: '媒体卡片 等待页面就绪' })).toBeInTheDocument()
+    expect(screen.getByLabelText('媒体横向列表')).toHaveAttribute('data-loading', 'false')
+  })
+
+  it('finishes an empty response without waiting for ready', async () => {
+    const requested = vi.fn()
+    server.use(recommendMediaHandler(SOURCE_PATH, [], 200, requested))
+
+    await renderSlide({ ready: false })
+    triggerAnimationFrame()
+
+    await waitFor(() => expect(screen.getByLabelText('媒体横向列表')).toHaveAttribute('data-loading', 'false'))
+    expect(screen.getByLabelText('媒体横向列表')).toHaveAttribute('data-item-count', '0')
+    expect(requested).toHaveBeenCalledOnce()
+  })
+
+  it.each([
+    ['empty response', 200],
+    ['HTTP failure', 500],
+  ])('retries after an initial %s when the kept-alive view is activated', async (_case, firstStatus) => {
+    const requested = vi.fn()
+    const recovered = createMediaInfo({ title: `恢复于 ${_case}` })
+    server.use(recommendMediaHandler(SOURCE_PATH, [], firstStatus, requested))
+
+    await renderKeptAliveSlide()
+    await waitFor(() => expect(requested).toHaveBeenCalledOnce())
+    await waitFor(() => expect(screen.getByLabelText('媒体横向列表')).toHaveAttribute('data-loading', 'false'))
+    server.use(recommendMediaHandler(SOURCE_PATH, [recovered], 200, requested))
+
+    await fireEvent.click(screen.getByRole('button', { name: '停用横向列表' }))
+    await fireEvent.click(screen.getByRole('button', { name: '启用横向列表' }))
+
+    expect(await screen.findByRole('article', { name: `媒体卡片 ${recovered.title}` })).toBeInTheDocument()
+    expect(requested).toHaveBeenCalledTimes(2)
+  })
+
+  it('projects items, stable key fallbacks, and fixed card width', async () => {
+    const media = [
+      createMediaInfo({ douban_id: 'unused-douban', title: 'TMDB 媒体', tmdb_id: 101 }),
+      createMediaInfo({ douban_id: 'douban-202', title: '豆瓣媒体', tmdb_id: undefined }),
+      createMediaInfo({ bangumi_id: 'bangumi-303', douban_id: undefined, title: 'Bangumi 媒体', tmdb_id: undefined }),
+      createMediaInfo({
+        bangumi_id: undefined,
+        douban_id: undefined,
+        media_id: 'custom-404',
+        title: '自定义媒体',
+        tmdb_id: undefined,
+      }),
+      createMediaInfo({
+        bangumi_id: undefined,
+        douban_id: undefined,
+        media_id: undefined,
+        title: '标题回退',
+        tmdb_id: undefined,
+      }),
+    ]
+    server.use(recommendMediaHandler(SOURCE_PATH, media))
+
+    await renderSlide()
+    triggerAnimationFrame()
+
+    await waitFor(() => expect(screen.getByLabelText('媒体横向列表')).toHaveAttribute('data-loading', 'false'))
+    expect(screen.getByLabelText('媒体横向列表')).toHaveAttribute('data-item-count', '5')
+    expect(screen.getByLabelText('媒体横向列表键')).toHaveTextContent(
+      '101|douban-202|bangumi-303|custom-404|标题回退',
+    )
+    expect(screen.getAllByRole('article')).toHaveLength(5)
+    screen.getAllByRole('article').forEach(card => expect(card).toHaveAttribute('data-width', '9rem'))
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -278,6 +278,7 @@ export default defineConfig(({ mode }) => ({
         'src/pages/recommend.vue',
         'src/pages/subscribe.vue',
         'src/views/dashboard/MediaRecommend.vue',
+        'src/views/discover/MediaCardSlideView.vue',
         'src/views/subscribe/FullCalendarView.vue',
         'src/views/subscribe/SubscribeListView.vue',
         'src/views/subscribe/SubscribePopularView.vue',
@@ -392,6 +393,12 @@ export default defineConfig(({ mode }) => ({
           statements: 80,
         },
         'src/views/dashboard/MediaRecommend.vue': {
+          branches: 75,
+          functions: 80,
+          lines: 80,
+          statements: 80,
+        },
+        'src/views/discover/MediaCardSlideView.vue': {
           branches: 75,
           functions: 80,
           lines: 80,


### PR DESCRIPTION
## 变更说明

- 补充推荐页分类、ready/空态和 KeepAlive 来源刷新测试，覆盖首次生命周期请求复用及扩展来源撤销。
- 补充 `MediaCardSlideView` 的视口懒加载、RAF/fallback 竞争、请求去重、ready、失败重试、稳定 key 和滑轨投影测试。
- 将 `MediaCardSlideView.vue` 纳入核心 coverage 清单并设置单文件门禁。
- 推荐页的 `onMounted` 与 `onActivated` 复用同一在途来源请求；成功响应按当前服务端快照更新来源，HTTP 失败时保留现有列表。

## 影响范围

- 推荐页扩展来源的加载与 KeepAlive 激活刷新。
- 横向媒体内容组件的单元测试覆盖与覆盖率门禁。
- 不修改后端接口、路由、文案或插件代码。

## 验证

- `yarn test:run`：26 个测试文件、315 个用例通过。
- `yarn test:coverage`：Statements/Lines `97.35%`、Functions `95.65%`、Branches `86.73%`；新增核心文件满足单文件门禁。
- `yarn typecheck` 通过。
- `yarn build` 通过。
- Chrome 桌面与移动回归通过：首次加载与每次 KeepAlive 重新激活均只请求一次扩展来源，动态分类、横向轨道、图片、空态、触摸滚动及页面横向溢出均正常。
- 针对生产差异的性能检查通过：KeepAlive 来源刷新仅发出一次请求，并保留现有滑轨节点。

本 PR 为 Codex 协作提交
