### PR TITLE
ci: add observational ESLint check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+          cache: yarn
+          cache-dependency-path: yarn.lock
+
+      - name: Install dependencies
+        run: yarn --frozen-lockfile
+
+      - name: Lint
+        run: yarn lint
+
   unit-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/docs/code-quality.md
+++ b/docs/code-quality.md
@@ -77,11 +77,13 @@ yarn build
 
 ## ESLint CI：先观察，再强制
 
-ESLint 本地检查稳定后，Pull Request workflow 增加全仓 `yarn lint`：
+第二阶段在 Pull Request workflow 中增加独立的全仓 `yarn lint` job：
 
-1. 初始阶段作为普通 check 运行，不立即配置 required check。
-2. 观察 fork PR、依赖缓存、执行时间、误报和路径范围。
-3. 连续多个 PR 稳定通过后，再由维护者决定是否设为 required。
+1. lint 与既有 `unit-tests` 使用不同 job，避免改变现有测试 check 的名称和职责。
+2. 初始阶段作为普通 check 运行，不立即配置 required check。
+3. workflow 使用 Node 24、frozen lockfile 和只读 `yarn lint`，不执行自动修复或更新 baseline。
+4. 观察 fork PR、依赖缓存、执行时间、误报和路径范围。
+5. 连续多个 PR 稳定通过后，再由维护者决定是否设为 required。
 
 ESLint CI 必须检查全仓受管源码，而不是只检查 PR 变更文件。已有问题通过规则选择或受控基线管理，保证新问题不能借由“只检查改动行”绕过项目约束。
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -92,4 +92,4 @@ yarn lint
 yarn build
 ```
 
-Pull Request 测试工作流使用 Node 24 LTS 和 frozen lockfile，依次执行类型检查和覆盖率门禁。ESLint、Prettier 和 Node 兼容范围按[前端代码质量工具链演进](code-quality.md)渐进接入，新增测试代码不得引入新的 lint 或格式问题。
+Pull Request 工作流使用 Node 24 LTS 和 frozen lockfile。`unit-tests` job 依次执行类型检查和覆盖率门禁；独立的 `lint` job 执行全仓只读 ESLint 检查，当前处于普通 check 观察阶段，不改变既有 required checks。Prettier 和 Node 兼容范围按[前端代码质量工具链演进](code-quality.md)继续渐进接入，新增测试代码不得引入新的 lint 或格式问题。

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -107,6 +107,7 @@ export default defineConfig([
     '**/dist/**',
     '**/coverage/**',
     '**/.worktrees/**',
+    '**/vite.config.*.timestamp-*.mjs',
     'public/plugin_icon/**',
     'src/@iconify/**',
     '**/*.d.ts',
@@ -157,6 +158,10 @@ export default defineConfig([
     files: nodeFiles,
     languageOptions: {
       globals: globals.node,
+    },
+    // Node 配置可能位于浏览器源码目录；显式覆盖浏览器专用限制，避免 flat config 合并后误报。
+    rules: {
+      'no-restricted-globals': 'off',
     },
   },
   {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,9 +10,11 @@ const javascriptFiles = [
 ]
 
 const typescriptFiles = [
-  '**/*.{ts,tsx}',
+  '**/*.{ts,tsx,mts,cts}',
   '**/*.vue',
 ]
+
+const managedScriptExtensions = 'js,mjs,cjs,jsx,ts,tsx,mts,cts'
 
 const managedFiles = [
   ...javascriptFiles,
@@ -20,8 +22,8 @@ const managedFiles = [
 ]
 
 const browserFiles = [
-  'src/**/*.{js,jsx,ts,tsx,vue}',
-  'examples/**/src/**/*.{js,jsx,ts,tsx,vue}',
+  `src/**/*.{${managedScriptExtensions},vue}`,
+  `examples/**/src/**/*.{${managedScriptExtensions},vue}`,
 ]
 
 const nodeFiles = [
@@ -29,6 +31,16 @@ const nodeFiles = [
   'public/service.js',
   'scripts/**/*.{js,mjs,cjs,ts,mts,cts}',
 ]
+
+// TypeScript 关闭核心 no-undef；显式禁止浏览器域中的 Node-only globals，保证 JS、TS 与 Vue 使用同一运行时边界。
+const browserGlobalNames = new Set(Object.keys(globals.browser))
+const nodeOnlyGlobalRestrictions = Object.keys(globals.node)
+  .filter(name => !browserGlobalNames.has(name))
+  .sort()
+  .map(name => ({
+    name,
+    message: `'${name}' is only available in Node.js code.`,
+  }))
 
 const restrictedCoreSourcePattern = '/(?:^|\\/)@core(?:\\/|$)/'
 
@@ -136,6 +148,9 @@ export default defineConfig([
     languageOptions: {
       globals: globals.browser,
     },
+    rules: {
+      'no-restricted-globals': ['error', ...nodeOnlyGlobalRestrictions],
+    },
   },
   {
     name: 'moviepilot/node-globals',
@@ -154,7 +169,7 @@ export default defineConfig([
   },
   {
     name: 'moviepilot/sonarjs-locales',
-    files: ['src/locales/**/*.{js,jsx,ts,tsx}'],
+    files: [`src/locales/**/*.{${managedScriptExtensions}}`],
     rules: {
       'sonarjs/no-hardcoded-passwords': 'off',
       'sonarjs/no-hardcoded-secrets': 'off',
@@ -169,7 +184,7 @@ export default defineConfig([
   },
   {
     name: 'moviepilot/layout-boundary',
-    files: ['src/@layouts/**/*.{js,jsx,ts,tsx,vue}'],
+    files: [`src/@layouts/**/*.{${managedScriptExtensions},vue}`],
     rules: {
       'no-restricted-syntax': [
         'error',

--- a/tests/config/eslint-config.spec.ts
+++ b/tests/config/eslint-config.spec.ts
@@ -1,9 +1,15 @@
 import { ESLint } from 'eslint'
+import globals from 'globals'
 import { expect, it } from 'vitest'
 
 const eslint = new ESLint()
 const restrictedSyntaxRule = 'no-restricted-syntax'
+const restrictedGlobalsRule = 'no-restricted-globals'
 const unusedVariablesRule = '@typescript-eslint/no-unused-vars'
+const browserGlobalNames = new Set(Object.keys(globals.browser))
+const nodeOnlyGlobalNames = Object.keys(globals.node)
+  .filter(name => !browserGlobalNames.has(name))
+  .sort()
 
 /** 使用真实 flat config 检查虚拟源码，避免项目边界和新增问题门禁在依赖升级时静默丢失。 */
 async function lintRuleIds(code: string, filePath: string) {
@@ -161,11 +167,39 @@ const cases = [
     shouldReport: true,
   },
   {
+    name: '拒绝浏览器 Vue 脚本使用 Node 全局变量',
+    code: '<script setup lang="ts">const bytes = Buffer.from("x")</script><template>{{ bytes }}</template>',
+    filePath: 'src/components/invalid-node-global.vue',
+    ruleId: restrictedGlobalsRule,
+    shouldReport: true,
+  },
+  {
     name: '允许构建配置使用 Node 全局变量',
     code: 'process.env.NODE_ENV',
     filePath: 'example.config.js',
     ruleId: 'no-undef',
     shouldReport: false,
+  },
+  {
+    name: '允许 TypeScript 构建配置使用 Node 全局变量',
+    code: 'const runtime: string | undefined = process.env.NODE_ENV; console.log(runtime)',
+    filePath: 'example.config.mts',
+    ruleId: restrictedGlobalsRule,
+    shouldReport: false,
+  },
+  {
+    name: '拒绝 MTS 脚本保留 debugger',
+    code: 'const value: string = "x"; console.log(value); debugger',
+    filePath: 'scripts/invalid-debugger.mts',
+    ruleId: 'no-debugger',
+    shouldReport: true,
+  },
+  {
+    name: '拒绝 CTS 脚本保留 debugger',
+    code: 'const value: string = "x"; console.log(value); debugger',
+    filePath: 'scripts/invalid-debugger.cts',
+    ruleId: 'no-debugger',
+    shouldReport: true,
   },
   {
     name: '允许 Vuetify 点号 slot 名称',
@@ -194,4 +228,21 @@ it.each(cases)('$name', async ({ code, filePath, ruleId, shouldReport }) => {
   const ruleIds = await lintRuleIds(code, filePath)
 
   expect(ruleIds.includes(ruleId)).toBe(shouldReport)
+})
+
+it.each(nodeOnlyGlobalNames)('拒绝浏览器 TypeScript 使用 Node 全局变量 %s', async globalName => {
+  const ruleIds = await lintRuleIds(`console.log(${globalName})`, `src/components/invalid-${globalName}.ts`)
+
+  expect(ruleIds).toContain(restrictedGlobalsRule)
+})
+
+it.each([
+  'example.config.mts',
+  'example.config.cts',
+  'scripts/example.mts',
+  'scripts/example.cts',
+])('使用 TypeScript parser 解析 %s', async filePath => {
+  const ruleIds = await lintRuleIds('const value: string = "x"; console.log(value)', filePath)
+
+  expect(ruleIds).not.toContain(null)
 })

--- a/tests/config/eslint-config.spec.ts
+++ b/tests/config/eslint-config.spec.ts
@@ -188,6 +188,13 @@ const cases = [
     shouldReport: false,
   },
   {
+    name: '允许浏览器目录中的 Node 配置使用 Node 全局变量',
+    code: 'const runtime: string | undefined = process.env.NODE_ENV; console.log(runtime)',
+    filePath: 'src/tool.config.ts',
+    ruleId: restrictedGlobalsRule,
+    shouldReport: false,
+  },
+  {
     name: '拒绝 MTS 脚本保留 debugger',
     code: 'const value: string = "x"; console.log(value); debugger',
     filePath: 'scripts/invalid-debugger.mts',
@@ -245,4 +252,16 @@ it.each([
   const ruleIds = await lintRuleIds('const value: string = "x"; console.log(value)', filePath)
 
   expect(ruleIds).not.toContain(null)
+})
+
+it('忽略 Vite 生成的临时配置模块', async () => {
+  await expect(eslint.isPathIgnored('vite.config.ts.timestamp-1784340502076-0129cef6d3bbd8.mjs')).resolves.toBe(true)
+})
+
+it('不忽略普通 MJS 源码', async () => {
+  await expect(eslint.isPathIgnored('scripts/example.mjs')).resolves.toBe(false)
+})
+
+it('不忽略名称包含 timestamp 的普通 MJS 源码', async () => {
+  await expect(eslint.isPathIgnored('scripts/feature.timestamp-parser.mjs')).resolves.toBe(false)
 })


### PR DESCRIPTION
## 背景

承接 #549 的 ESLint 10 基础设施，本 PR 进入演进文档定义的第二阶段：将全仓只读 `yarn lint` 接入 Pull Request workflow 进行观察，但暂不配置 required check。

#549 合并后的自动 review 同时指出两个可复现的配置契约缺口：TypeScript/Vue 浏览器代码可以使用 Node-only globals，以及 `.mts`/`.cts` 未进入 TypeScript parser 和统一规则范围。本 PR 在接入 CI 前一并补齐，避免观察 check 建立在存在已知漏检的配置上。

自动 review 的“缺少锁文件”意见不成立：#549 已提交 `yarn.lock`，且 GitHub `unit-tests` 在干净环境执行 `yarn --frozen-lockfile` 后通过。本 PR 不修改依赖或锁文件。

## 调整内容

- 在 Pull Request workflow 新增独立的 Node 24 `lint` job
  - 使用 Yarn 缓存和 `yarn --frozen-lockfile`
  - 只执行全仓只读 `yarn lint`，不自动修复或更新 suppression
  - 保持既有 `unit-tests` job 的名称、步骤和职责不变
- 显式禁止浏览器 JavaScript、TypeScript 和 Vue 脚本引用 Node-only globals
  - 限制来自 `globals.node` 与 `globals.browser` 的差集，当前共 10 个 Node-only globals
  - 局部变量、函数参数和 import 绑定不受影响
  - Node 配置与脚本显式覆盖浏览器专用限制；即使配置文件位于 `src` 等浏览器目录也继续允许使用对应 globals
- 将 `.mts`/`.cts` 纳入 TypeScript parser、recommended、SonarJS 和源码卫生规则范围
- 统一复用受管脚本扩展范围，避免 browser、locales 与 `@layouts` 边界出现扩展名漏口
- 忽略 Vite/Vitest 加载仓库 `vite.config.*` 时生成并立即删除的 `vite.config.*.timestamp-*.mjs` 派生模块，避免 Agent 并行执行 lint 与测试时发生文件消失竞态；普通及名称包含 `timestamp` 的业务 `.mjs` 仍参与 lint
- 将 ESLint 配置契约从 25 项扩展到 47 项，覆盖 Node globals、重叠路径、Vue、MTS/CTS parser、临时配置模块和统一 `no-debugger`
- 同步代码质量演进与测试文档中的第二阶段状态

## 观察阶段边界

- `lint` 使用独立 job，不会把既有 `unit-tests` check 隐式变成 lint 门禁
- 本 PR 只新增普通 Pull Request check，不修改 GitHub ruleset 或 branch protection
- 当前上游 `v2` 没有 required check；是否将 `lint` 设为 required，需在多个真实 PR 中观察 fork 行为、缓存、耗时和误报后另行决定
- 不引入 Prettier、不格式化业务源码，也不修改后续变更文件格式门禁的阶段安排
- `eslint-suppressions.json` 保持 910 条 finding、185 个文件、31 条规则不变；新增违规仍会使 lint 失败

## 验证

- Node 20.19：`yarn test:lint-config`（47/47 通过）
- Node 20.19：`yarn lint`
- Node 24：`yarn lint`
- Node 24：`yarn typecheck`
- Node 24：`yarn test:coverage`（27 个测试文件、362 个测试通过）
- Node 24 lint、Node 24 coverage 与 Node 20.19 配置测试在同一 worktree 并行通过，未再触发 Vite 临时配置文件竞态
- Node 24：`yarn build`
- `yarn lint:suppressions:prune`（baseline 零变化）
- workflow 结构检查与 `git diff --check`
- 独立只读 Review：零未解决 substantive finding

本 PR 为 Codex 协作提交

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at e75ffbacabc9390a19ce814e44b55b94aa9fe4fc

- 新增 PR 全仓 ESLint 观察检查
- 补齐浏览器 Node 全局变量限制
- 纳入 `.mts`、`.cts` 脚本规则
- 增加配置契约与忽略路径测试

<!-- pr-agent-summary:end -->