### PR TITLE
fix(site): preserve dialog failure states

### DIFF
--- a/src/components/dialog/SiteResourceDialog.vue
+++ b/src/components/dialog/SiteResourceDialog.vue
@@ -401,7 +401,7 @@ onMounted(() => {
         </VAlert>
 
         <VDataTable
-          v-if="display.mdAndUp.value"
+          v-if="display.mdAndUp.value && (!resourceError || resourceDataList.length > 0)"
           v-model:page="resourcePage"
           v-model:items-per-page="resourceItemsPerPage"
           :headers="resourceHeaders"
@@ -663,7 +663,7 @@ onMounted(() => {
             </ProgressiveCardGrid>
           </div>
 
-          <div v-else class="px-4 py-10 text-center text-medium-emphasis">
+          <div v-else-if="!resourceError" class="px-4 py-10 text-center text-medium-emphasis">
             {{ t('dialog.siteResource.noData') }}
           </div>
         </div>

--- a/src/components/dialog/SiteUserDataDialog.vue
+++ b/src/components/dialog/SiteUserDataDialog.vue
@@ -36,8 +36,8 @@ const currentTheme = controlledComputed(
 // 站点数据列表
 const siteDatas = ref<SiteUserData[]>([])
 
-// 只有最近一次读取可以更新弹窗状态，避免首载慢响应覆盖手动刷新结果。
-let fetchGeneration = 0
+// 只有最近一次加载或刷新操作可以更新弹窗状态，避免异步响应覆盖较新的操作结果。
+let operationGeneration = 0
 
 // 最新一天的数据
 const siteData = computed(() => siteDatas.value[siteDatas.value.length - 1])
@@ -261,24 +261,27 @@ function getDiffClass(diff: number | undefined) {
 }
 
 // 查询站点用户数据
-async function fetchSiteUserData(failureOperation: 'load' | 'refresh' = 'load') {
-  const generation = ++fetchGeneration
+async function fetchSiteUserData(failureOperation: 'load' | 'refresh' = 'load', generation?: number) {
+  const activeGeneration = generation ?? ++operationGeneration
 
   try {
     const result = await api.get<ApiResponse<SiteUserData[]>, ApiResponse<SiteUserData[]>>(
       `site/userdata/${props.site?.id}`,
     )
-    if (generation !== fetchGeneration) return false
+    if (activeGeneration !== operationGeneration) return false
 
     if (result.success) {
       // 使用nextTick确保DOM更新完成后再更新图表数据
       await nextTick()
+      if (activeGeneration !== operationGeneration) return false
+
       siteDatas.value = result.data.sort((a, b) => (a.updated_day || '').localeCompare(b.updated_day || ''))
-      failedOperation.value = undefined
-      return true
     }
+
+    failedOperation.value = undefined
+    return true
   } catch (error) {
-    if (generation !== fetchGeneration) return false
+    if (activeGeneration !== operationGeneration) return false
 
     console.error(error)
     failedOperation.value = failureOperation
@@ -289,19 +292,26 @@ async function fetchSiteUserData(failureOperation: 'load' | 'refresh' = 'load') 
 
 // 刷新站点数据
 async function refreshSiteData() {
+  const generation = ++operationGeneration
   progressDialog.value = true
   try {
     const result = await api.post<ApiResponse<unknown>, ApiResponse<unknown>>(`site/userdata/${props.site?.id}`)
+    if (generation !== operationGeneration) return
+
     if (result.success) {
-      await fetchSiteUserData('refresh')
+      await fetchSiteUserData('refresh', generation)
     } else {
       failedOperation.value = 'refresh'
     }
   } catch (error) {
+    if (generation !== operationGeneration) return
+
     console.error(error)
     failedOperation.value = 'refresh'
   } finally {
-    progressDialog.value = false
+    if (generation === operationGeneration) {
+      progressDialog.value = false
+    }
   }
 }
 

--- a/src/components/dialog/__tests__/SiteResourceDialog.spec.ts
+++ b/src/components/dialog/__tests__/SiteResourceDialog.spec.ts
@@ -188,6 +188,41 @@ describe('SiteResourceDialog', () => {
     expect(attempts).toBe(2)
   })
 
+  it.each([
+    ['desktop', 1280],
+    ['mobile', 390],
+  ] as const)('does not show the empty state with an initial resource error on %s', async (_layout, width) => {
+    setViewport(width)
+    server.use(siteCategoriesHandler(501, []), siteResourcesHandler(501, [], 500))
+
+    await renderDialog(undefined, { VDataTable: DataTableStub })
+
+    expect(await screen.findByText('资源加载失败，请重试')).toBeInTheDocument()
+    expect(screen.queryByText('没有数据')).not.toBeInTheDocument()
+  })
+
+  it('keeps existing resources visible when a repeated search fails', async () => {
+    let attempts = 0
+    server.use(
+      siteCategoriesHandler(501, []),
+      http.get(siteApiUrls.resources(501), () => {
+        attempts += 1
+        if (attempts === 1) return HttpResponse.json([createTorrentInfo({ title: '已有资源' })])
+
+        return HttpResponse.json({ detail: 'temporary failure' }, { status: 500 })
+      }),
+    )
+    const user = userEvent.setup()
+    await renderDialog()
+    expect(await screen.findByText('已有资源')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /搜索/ }))
+
+    expect(await screen.findByText('资源加载失败，请重试')).toBeInTheDocument()
+    expect(screen.getByText('已有资源')).toBeInTheDocument()
+    expect(screen.queryByText('没有数据')).not.toBeInTheDocument()
+  })
+
   it('loads categories and resources from their direct-array endpoints', async () => {
     const categoryRequests: URL[] = []
     const resourceRequests: URL[] = []

--- a/src/components/dialog/__tests__/SiteUserDataDialog.spec.ts
+++ b/src/components/dialog/__tests__/SiteUserDataDialog.spec.ts
@@ -290,6 +290,44 @@ describe('SiteUserDataDialog refresh and recovery', () => {
     expect(screen.queryByRole('alert')).not.toBeInTheDocument()
   })
 
+  it('keeps a refresh failure visible when the initial request settles afterwards', async () => {
+    const initialRequest = deferred<void>()
+    const initialRequested = vi.fn()
+    const initialReleased = vi.fn()
+    const refreshRequested = vi.fn()
+    const { site } = await renderDialog({ data: [createSiteUserData({ bonus: 1 })], success: true }, 200, async () => {
+      initialRequested()
+      await initialRequest.promise
+      initialReleased()
+    })
+    await waitFor(() => expect(initialRequested).toHaveBeenCalledOnce())
+    server.use(
+      refreshSiteUserDataHandler(
+        site.id,
+        { data: {}, message: '站点不支持刷新', success: false },
+        200,
+        refreshRequested,
+      ),
+    )
+
+    await fireEvent.click(getRefreshButton())
+    expect(await screen.findByText(/刷新站点数据失败/)).toBeInTheDocument()
+
+    initialRequest.resolve()
+    await waitFor(() => expect(initialReleased).toHaveBeenCalledOnce())
+    await waitFor(() => expect(getActiveRequestsCount()).toBe(0))
+    await flushPromises()
+
+    expect(screen.getByText(/刷新站点数据失败/)).toBeInTheDocument()
+    expect(refreshRequested).toHaveBeenCalledOnce()
+
+    server.use(refreshSiteUserDataHandler(site.id, { data: {}, success: true }, 200, refreshRequested))
+    await fireEvent.click(getRetryButton())
+
+    await waitFor(() => expect(refreshRequested).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(screen.queryByText(/刷新站点数据失败/)).not.toBeInTheDocument())
+  })
+
   it.each([
     ['business failure', 200, { data: {}, message: '站点不支持刷新', success: false }],
     ['HTTP failure', 500, { data: {}, message: 'server down', success: false }],
@@ -330,6 +368,18 @@ describe('SiteUserDataDialog refresh and recovery', () => {
     await screen.findByText('88')
     expect(attempt).toBe(2)
     expect(screen.queryByText(/加载站点数据失败/)).not.toBeInTheDocument()
+  })
+
+  it('clears an initial HTTP error when retry returns the legal empty state', async () => {
+    const { site } = await renderDialog({ data: [], success: false }, 500)
+    expect(await screen.findByText(/加载站点数据失败/)).toBeInTheDocument()
+    server.use(siteUserDataHandler(site.id, { data: [], success: false }))
+
+    await fireEvent.click(getRetryButton())
+
+    await waitFor(() => expect(getActiveRequestsCount()).toBe(0))
+    await waitFor(() => expect(screen.queryByText(/加载站点数据失败/)).not.toBeInTheDocument())
+    expect(screen.getByText('无')).toBeInTheDocument()
   })
 
   it('emits close without mutating loaded user data', async () => {


### PR DESCRIPTION
## 变更说明

- 修正站点资源首次加载失败时错误态与空态同时显示的问题，并让桌面表格与移动列表遵循同一状态条件。
- 资源重复搜索失败时保留已有结果，避免一次失败清空用户当前可见数据。
- 将站点用户数据的请求代次覆盖完整加载与刷新操作，避免较早的首载请求覆盖较新的刷新失败状态。
- 仅允许最新操作更新数据、错误与进度；成功返回合法空数据时会清除旧错误。

## 影响范围

- `src/components/dialog/SiteResourceDialog.vue`
- `src/components/dialog/SiteUserDataDialog.vue`
- 对应 `src/components/dialog/__tests__/*.spec.ts`

不调整后端接口契约、正常成功路径、数据结构或请求数量。

## 验证

- Focused tests：29/29 通过
- 全量覆盖率：52 个测试文件、589 个测试通过
- `yarn typecheck`
- `yarn lint`
- `yarn format:check`
- `yarn lint:suppressions:prune`
- `yarn build`
- `git diff --check`
- Chrome 桌面与移动宽度回归：错误态、重试恢复、旧数据保留、合法空态、并发请求次序均符合预期

## 关联

- https://github.com/jxxghp/MoviePilot-Frontend/pull/563#discussion_r3610248084
- https://github.com/jxxghp/MoviePilot-Frontend/pull/564#discussion_r3610301432

本 PR 为 Codex 协作提交

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 146fef0e5f3f0d8720a53cad050c380b9de61706

- 修复资源错误态与空态同时显示
- 搜索失败时保留已有资源结果
- 以操作代次隔离加载刷新竞争
- 补充桌面、移动与重试回归测试

<!-- pr-agent-summary:end -->