### PR TITLE
fix(plugin): 修正模块联邦远程入口地址解析

### DIFF
--- a/src/utils/__tests__/federationUrl.spec.ts
+++ b/src/utils/__tests__/federationUrl.spec.ts
@@ -1,0 +1,47 @@
+import { resolveFederationRemoteUrl } from '@/utils/federationUrl'
+import { describe, expect, it } from 'vitest'
+
+describe('resolveFederationRemoteUrl', () => {
+  const remotePath = '/plugin/file/example/frontend/dist/assets/remoteEntry.js'
+
+  it.each([
+    {
+      name: 'Docker 根路径 HTTP 入口',
+      apiBaseUrl: 'api/v1/',
+      documentBaseUri: 'http://moviepilot.local/',
+      expected: 'http://moviepilot.local/api/v1/plugin/file/example/frontend/dist/assets/remoteEntry.js',
+    },
+    {
+      name: 'Docker 或 local_setup 的无尾斜杠 fallback 入口',
+      apiBaseUrl: 'api/v1/',
+      documentBaseUri: 'http://moviepilot.local/dashboard',
+      expected: 'http://moviepilot.local/api/v1/plugin/file/example/frontend/dist/assets/remoteEntry.js',
+    },
+    {
+      name: 'HTTPS 反向代理入口',
+      apiBaseUrl: 'api/v1/',
+      documentBaseUri: 'https://moviepilot.example.com/dashboard',
+      expected: 'https://moviepilot.example.com/api/v1/plugin/file/example/frontend/dist/assets/remoteEntry.js',
+    },
+    {
+      name: '反向代理子路径入口',
+      apiBaseUrl: 'api/v1/',
+      documentBaseUri: 'https://moviepilot.example.com/mp/',
+      expected: 'https://moviepilot.example.com/mp/api/v1/plugin/file/example/frontend/dist/assets/remoteEntry.js',
+    },
+    {
+      name: '根路径 API 配置',
+      apiBaseUrl: '/api/v1/',
+      documentBaseUri: 'https://moviepilot.example.com/mp/',
+      expected: 'https://moviepilot.example.com/api/v1/plugin/file/example/frontend/dist/assets/remoteEntry.js',
+    },
+    {
+      name: '完整跨域 API 配置',
+      apiBaseUrl: 'https://api.example.com/api/v1',
+      documentBaseUri: 'http://moviepilot.local/dashboard',
+      expected: 'https://api.example.com/api/v1/plugin/file/example/frontend/dist/assets/remoteEntry.js',
+    },
+  ])('$name', ({ apiBaseUrl, documentBaseUri, expected }) => {
+    expect(resolveFederationRemoteUrl(remotePath, apiBaseUrl, documentBaseUri)).toBe(expected)
+  })
+})

--- a/src/utils/federationLoader.ts
+++ b/src/utils/federationLoader.ts
@@ -1,4 +1,5 @@
 import api from '@/api'
+import { resolveFederationRemoteUrl } from '@/utils/federationUrl'
 import {
   __federation_method_setRemote,
   __federation_method_getRemote,
@@ -144,18 +145,7 @@ async function fetchRemoteModules(): Promise<RemoteModule[]> {
  * @param modules 远程模块列表
  */
 export function injectRemoteModule(module: RemoteModule): void {
-  // 与 API 请求一致：使用 origin + pathname 作为前缀，子路径代理时 pathname 含 /mp 等
-  const baseUrl = new URL(window.location.href)
-  const pathBase = baseUrl.pathname.replace(/\/$/, '') || ''
-  let apiBase = import.meta.env.VITE_API_BASE_URL
-  if (apiBase.startsWith('/')) {
-    apiBase = apiBase.slice(1)
-  }
-  if (apiBase.endsWith('/')) {
-    apiBase = apiBase.slice(0, -1)
-  }
-  const pathWithoutLeadingSlash = module.url.startsWith('/') ? module.url.slice(1) : module.url
-  const remoteEntryUrl = `${baseUrl.origin}${pathBase}/${apiBase}/${pathWithoutLeadingSlash}`
+  const remoteEntryUrl = resolveFederationRemoteUrl(module.url, import.meta.env.VITE_API_BASE_URL, document.baseURI)
   __federation_method_setRemote(module.id, {
     url: () => Promise.resolve(remoteEntryUrl),
     format: 'esm',

--- a/src/utils/federationUrl.ts
+++ b/src/utils/federationUrl.ts
@@ -1,0 +1,11 @@
+/**
+ * 按页面文档基址解析插件联邦入口，使其与相对 API 请求遵循相同的部署路径规则。
+ * 相对 API 基址保留反向代理子路径，根路径或完整 URL 配置则按其显式语义解析。
+ */
+export function resolveFederationRemoteUrl(remotePath: string, apiBaseUrl: string, documentBaseUri: string): string {
+  const normalizedApiBase = apiBaseUrl.endsWith('/') ? apiBaseUrl : `${apiBaseUrl}/`
+  const apiUrl = new URL(normalizedApiBase, documentBaseUri)
+  const normalizedRemotePath = remotePath.replace(/^\/+/, '')
+
+  return new URL(normalizedRemotePath, apiUrl).href
+}


### PR DESCRIPTION
## 变更说明

- 使用浏览器标准 URL 解析规则生成插件模块联邦 `remoteEntry.js` 地址，不再把当前页面 `pathname` 直接作为部署前缀。
- 相对 API 基址继续支持反向代理子路径，根路径及完整 URL 配置保持各自的显式语义。
- 增加 Docker、local_setup、HTTP/HTTPS、无尾斜杠 fallback、子路径代理及跨域 API 基址的回归测试。

## 影响范围

- `src/utils/federationLoader.ts`
- `src/utils/federationUrl.ts`
- `src/utils/__tests__/federationUrl.spec.ts`

后端 remote 返回结构、Docker Nginx 和 local_setup Express 代理配置均无需调整。

## 验证

- `yarn test:run`：595 passed
- `yarn typecheck`
- `yarn lint`
- `yarn lint:suppressions:prune`
- `yarn build`
- `git diff --check`
- 从 `/dashboard` fallback 入口验证远程组件地址解析到根路径 `/api/v1/.../remoteEntry.js`

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at f641f62a3b902258a1608fc73a6c94a8e2b0da35

- 修正联邦远程入口 URL 解析
- 基于 `document.baseURI` 遵循浏览器规则
- 保留子路径、根路径与跨域配置语义
- 增加 Docker、代理及 HTTPS 回归测试

<!-- pr-agent-summary:end -->