### PR TITLE
fix(pwa): isolate service worker development mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "bin": "dist/service.js",
   "scripts": {
     "dev": "vite --host",
+    "dev:pwa": "vite --host --port 5174",
     "prebuild": "npm run build:icons",
     "build": "vite build",
     "preview": "vite preview --port 5050",

--- a/scripts/pwa-development.ts
+++ b/scripts/pwa-development.ts
@@ -80,7 +80,7 @@ export function createDevServiceWorkerCleanupPlugin(): Plugin {
   const retryIdentityVerification = retryMoviePilotIdentityVerification.toString()
   const entryScriptUrl = JSON.stringify(devEntryScriptUrl)
   const cleanupPath = JSON.stringify(DEV_SW_CLEANUP_PATH)
-  const cleanupAttemptKey = JSON.stringify('moviepilot:dev-sw-cleanup-attempted')
+  const cleanupAttemptKeyPrefix = JSON.stringify('moviepilot:dev-sw-cleanup')
 
   const redirectScript = `
 (() => {
@@ -105,9 +105,9 @@ export function createDevServiceWorkerCleanupPlugin(): Plugin {
   const identityAttempts = ${identityAttempts}
   const retryIdentityVerification = ${retryIdentityVerification}
   const cleanupPath = ${cleanupPath}
-  const cleanupAttemptKey = ${cleanupAttemptKey}
-  const cleanupState = sessionStorage.getItem(cleanupAttemptKey)
   const appScope = new URL('./', location.href)
+  const cleanupAttemptKey = ${cleanupAttemptKeyPrefix} + ':' + encodeURIComponent(appScope.pathname)
+  const cleanupState = sessionStorage.getItem(cleanupAttemptKey)
   const getCandidateWorker = registration => {
     if (new URL(registration.scope).href !== appScope.href) return null
     return [registration.active, registration.waiting, registration.installing].find(worker => {
@@ -142,12 +142,10 @@ export function createDevServiceWorkerCleanupPlugin(): Plugin {
     return false
   }
   const redirectToCleanup = () => {
-    if (cleanupState) return false
-    sessionStorage.setItem(cleanupAttemptKey, '1')
+    sessionStorage.setItem(cleanupAttemptKey, 'pending')
     const target = new URL(cleanupPath.slice(1), appScope)
     target.searchParams.set('return', location.href)
     location.replace(target.href)
-    return true
   }
 
   // unregister 不会立即解除当前 document 的 controller；应用模块加载前需再导航一次以脱离旧 Worker。
@@ -158,7 +156,11 @@ export function createDevServiceWorkerCleanupPlugin(): Plugin {
   }
 
   void hasVerifiedRegistration().then(hasRegistration => {
-    if (hasRegistration && redirectToCleanup()) return
+    if (hasRegistration) {
+      redirectToCleanup()
+      return
+    }
+    sessionStorage.removeItem(cleanupAttemptKey)
     startApp()
   }).catch(error => {
     console.warn('[PWA] Failed to inspect historical Service Worker state', error)
@@ -178,15 +180,15 @@ export function createDevServiceWorkerCleanupPlugin(): Plugin {
         const identityTimeoutMs = ${identityTimeoutMs}
         const identityAttempts = ${identityAttempts}
         const retryIdentityVerification = ${retryIdentityVerification}
-        const cleanupAttemptKey = ${cleanupAttemptKey}
+        const appScope = new URL('./', location.href)
+        const cleanupAttemptKey = ${cleanupAttemptKeyPrefix} + ':' + encodeURIComponent(appScope.pathname)
         const resolveReturnUrl = () => {
           const requested = new URLSearchParams(location.search).get('return')
-          if (!requested) return new URL('/', location.origin)
-          const target = new URL(requested, location.origin)
-          return target.origin === location.origin ? target : new URL('/', location.origin)
+          if (!requested) return appScope
+          const target = new URL(requested, appScope)
+          return target.href.startsWith(appScope.href) ? target : appScope
         }
         const returnUrl = resolveReturnUrl()
-        const appScope = new URL('./', returnUrl)
         const getCandidateWorker = registration => {
           if (new URL(registration.scope).href !== appScope.href) return null
           return [registration.active, registration.waiting, registration.installing].find(worker => {
@@ -213,6 +215,9 @@ export function createDevServiceWorkerCleanupPlugin(): Plugin {
         const verifyMoviePilotWorker = worker =>
           retryIdentityVerification(() => verifyMoviePilotWorkerOnce(worker), identityAttempts)
         const cleanup = async () => {
+          if (sessionStorage.getItem(cleanupAttemptKey) !== 'pending') {
+            throw new Error('Missing Service Worker cleanup context for current application scope')
+          }
           const registrations = 'serviceWorker' in navigator ? await navigator.serviceWorker.getRegistrations() : []
           const managedRegistrations = []
           for (const registration of registrations) {

--- a/scripts/pwa-development.ts
+++ b/scripts/pwa-development.ts
@@ -3,6 +3,8 @@ import type { Plugin } from 'vite'
 const PWA_DEVELOPMENT_SCRIPT = 'dev:pwa'
 export const DEV_SW_CLEANUP_PATH = '/__moviepilot_dev_sw_cleanup__'
 
+const devEntryScriptTag = '<script type="module" src="/src/main.ts"></script>'
+const devEntryScriptUrl = '/src/main.ts'
 const moviePilotWorkerScripts = ['dev-sw.js?dev-sw', 'service-worker.js']
 const moviePilotIdentityMessage = 'GET_UNREAD_COUNT'
 const moviePilotIdentityTimeoutMs = 1500
@@ -76,12 +78,26 @@ export function createDevServiceWorkerCleanupPlugin(): Plugin {
   const identityTimeoutMs = JSON.stringify(moviePilotIdentityTimeoutMs)
   const identityAttempts = JSON.stringify(moviePilotIdentityAttempts)
   const retryIdentityVerification = retryMoviePilotIdentityVerification.toString()
+  const entryScriptUrl = JSON.stringify(devEntryScriptUrl)
   const cleanupPath = JSON.stringify(DEV_SW_CLEANUP_PATH)
   const cleanupAttemptKey = JSON.stringify('moviepilot:dev-sw-cleanup-attempted')
 
   const redirectScript = `
 (() => {
-  if (!('serviceWorker' in navigator)) return
+  const entryScriptUrl = ${entryScriptUrl}
+  let appStarted = false
+  const startApp = () => {
+    if (appStarted) return
+    appStarted = true
+    const entry = document.createElement('script')
+    entry.type = 'module'
+    entry.src = entryScriptUrl
+    document.head.appendChild(entry)
+  }
+  if (!('serviceWorker' in navigator)) {
+    startApp()
+    return
+  }
 
   const workerScripts = ${workerScripts}
   const identityMessage = ${identityMessage}
@@ -126,11 +142,12 @@ export function createDevServiceWorkerCleanupPlugin(): Plugin {
     return false
   }
   const redirectToCleanup = () => {
-    if (cleanupState) return
+    if (cleanupState) return false
     sessionStorage.setItem(cleanupAttemptKey, '1')
     const target = new URL(cleanupPath.slice(1), appScope)
     target.searchParams.set('return', location.href)
     location.replace(target.href)
+    return true
   }
 
   // unregister 不会立即解除当前 document 的 controller；应用模块加载前需再导航一次以脱离旧 Worker。
@@ -141,7 +158,11 @@ export function createDevServiceWorkerCleanupPlugin(): Plugin {
   }
 
   void hasVerifiedRegistration().then(hasRegistration => {
-    if (hasRegistration) redirectToCleanup()
+    if (hasRegistration && redirectToCleanup()) return
+    startApp()
+  }).catch(error => {
+    console.warn('[PWA] Failed to inspect historical Service Worker state', error)
+    startApp()
   })
 })()
 `
@@ -234,8 +255,15 @@ export function createDevServiceWorkerCleanupPlugin(): Plugin {
     },
     transformIndexHtml: {
       order: 'pre',
-      handler() {
-        return [{ tag: 'script', children: redirectScript, injectTo: 'head-prepend' }]
+      handler(html) {
+        if (!html.includes(devEntryScriptTag)) {
+          throw new Error(`Expected development entry tag: ${devEntryScriptTag}`)
+        }
+
+        return {
+          html: html.replace(devEntryScriptTag, ''),
+          tags: [{ tag: 'script', children: redirectScript, injectTo: 'head-prepend' }],
+        }
       },
     },
   }

--- a/scripts/pwa-development.ts
+++ b/scripts/pwa-development.ts
@@ -3,16 +3,10 @@ import type { Plugin } from 'vite'
 const PWA_DEVELOPMENT_SCRIPT = 'dev:pwa'
 export const DEV_SW_CLEANUP_PATH = '/__moviepilot_dev_sw_cleanup__'
 
-const moviePilotWorkerPaths = ['/dev-sw.js', '/service-worker.js']
-const moviePilotCachePrefixes = [
-  'app-shell-',
-  'static-resources-',
-  'image-cache-',
-  'font-cache-',
-  'api-cache-',
-  'tmdb-image-cache-',
-  'workbox-precache-',
-]
+const moviePilotWorkerScripts = ['dev-sw.js?dev-sw', 'service-worker.js']
+const moviePilotIdentityMessage = 'GET_UNREAD_COUNT'
+const moviePilotIdentityTimeoutMs = 1500
+const moviePilotIdentityAttempts = 2
 
 /** 普通 development mode 仅在显式 dev:pwa 脚本中启用开发 Service Worker。 */
 export const isPwaDevelopmentEnabled = (mode: string, lifecycleEvent?: string) =>
@@ -27,15 +21,44 @@ export const shouldEnableDevServiceWorkerCleanup = (
 ) =>
   command === 'serve' && mode === 'development' && isPreview !== true && !isPwaDevelopmentEnabled(mode, lifecycleEvent)
 
-/** 判断脚本 URL 是否属于当前 origin 的 MoviePilot Service Worker。 */
-export function isManagedServiceWorkerUrl(scriptUrl: string, origin: string): boolean {
-  const url = new URL(scriptUrl)
-  return url.origin === origin && moviePilotWorkerPaths.some(path => url.pathname.endsWith(path))
+/** 解析当前页面所属的应用根目录，兼容根路径和子路径部署。 */
+export function resolveDevAppScope(pageUrl: string): URL {
+  return new URL('./', new URL(pageUrl))
 }
 
-/** 判断 Cache Storage 名称是否属于 MoviePilot 管理的缓存。 */
-export const isManagedCacheName = (name: string): boolean =>
-  moviePilotCachePrefixes.some(prefix => name.startsWith(prefix))
+/** Worker 的 scope 和脚本 URL 都必须精确落在当前应用根目录。 */
+export function isManagedServiceWorkerRegistration(
+  scriptUrl: string,
+  registrationScope: string,
+  pageUrl: string,
+): boolean {
+  const appScope = resolveDevAppScope(pageUrl)
+  const scope = new URL(registrationScope)
+  const script = new URL(scriptUrl)
+
+  return (
+    scope.href === appScope.href &&
+    moviePilotWorkerScripts.some(workerScript => script.href === new URL(workerScript, appScope).href)
+  )
+}
+
+/** 复用现有轻量消息协议确认 Worker 确由 MoviePilot 提供。 */
+export function isMoviePilotServiceWorkerIdentityResponse(value: unknown): boolean {
+  if (!value || typeof value !== 'object') return false
+
+  return typeof (value as { count?: unknown }).count === 'number'
+}
+
+/** 身份探测允许有限次重试；持续失败时保持现有注册，避免误清理未知 Worker。 */
+export async function retryMoviePilotIdentityVerification(
+  verifyOnce: () => Promise<boolean>,
+  attempts: number,
+): Promise<boolean> {
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    if (await verifyOnce()) return true
+  }
+  return false
+}
 
 /** 清理完成后只允许返回当前 origin，避免开发中间页形成开放重定向。 */
 export function resolveDevCleanupReturnUrl(requested: string | null, origin: string): URL {
@@ -48,8 +71,11 @@ export function resolveDevCleanupReturnUrl(requested: string | null, origin: str
  * 普通开发服务器不应被历史 Service Worker 控制；受控页面先进入独立清理页，避免旧缓存模块抢先执行。
  */
 export function createDevServiceWorkerCleanupPlugin(): Plugin {
-  const workerPaths = JSON.stringify(moviePilotWorkerPaths)
-  const cachePrefixes = JSON.stringify(moviePilotCachePrefixes)
+  const workerScripts = JSON.stringify(moviePilotWorkerScripts)
+  const identityMessage = JSON.stringify(moviePilotIdentityMessage)
+  const identityTimeoutMs = JSON.stringify(moviePilotIdentityTimeoutMs)
+  const identityAttempts = JSON.stringify(moviePilotIdentityAttempts)
+  const retryIdentityVerification = retryMoviePilotIdentityVerification.toString()
   const cleanupPath = JSON.stringify(DEV_SW_CLEANUP_PATH)
   const cleanupAttemptKey = JSON.stringify('moviepilot:dev-sw-cleanup-attempted')
 
@@ -57,20 +83,52 @@ export function createDevServiceWorkerCleanupPlugin(): Plugin {
 (() => {
   if (!('serviceWorker' in navigator)) return
 
-  const workerPaths = ${workerPaths}
-  const cachePrefixes = ${cachePrefixes}
+  const workerScripts = ${workerScripts}
+  const identityMessage = ${identityMessage}
+  const identityTimeoutMs = ${identityTimeoutMs}
+  const identityAttempts = ${identityAttempts}
+  const retryIdentityVerification = ${retryIdentityVerification}
   const cleanupPath = ${cleanupPath}
   const cleanupAttemptKey = ${cleanupAttemptKey}
   const cleanupState = sessionStorage.getItem(cleanupAttemptKey)
-  const isManagedWorker = worker => {
-    if (!worker) return false
-    const url = new URL(worker.scriptURL)
-    return url.origin === location.origin && workerPaths.some(path => url.pathname.endsWith(path))
+  const appScope = new URL('./', location.href)
+  const getCandidateWorker = registration => {
+    if (new URL(registration.scope).href !== appScope.href) return null
+    return [registration.active, registration.waiting, registration.installing].find(worker => {
+      if (!worker) return false
+      const scriptUrl = new URL(worker.scriptURL).href
+      return workerScripts.some(workerScript => scriptUrl === new URL(workerScript, appScope).href)
+    }) || null
+  }
+  const verifyMoviePilotWorkerOnce = worker => new Promise(resolve => {
+    const channel = new MessageChannel()
+    const finish = result => {
+      window.clearTimeout(timeout)
+      channel.port1.close()
+      resolve(result)
+    }
+    const timeout = window.setTimeout(() => finish(false), identityTimeoutMs)
+    channel.port1.onmessage = event => finish(typeof event.data?.count === 'number')
+    try {
+      worker.postMessage({ type: identityMessage }, [channel.port2])
+    } catch {
+      finish(false)
+    }
+  })
+  const verifyMoviePilotWorker = worker =>
+    retryIdentityVerification(() => verifyMoviePilotWorkerOnce(worker), identityAttempts)
+  const hasVerifiedRegistration = async () => {
+    const registrations = await navigator.serviceWorker.getRegistrations()
+    for (const registration of registrations) {
+      const worker = getCandidateWorker(registration)
+      if (worker && await verifyMoviePilotWorker(worker)) return true
+    }
+    return false
   }
   const redirectToCleanup = () => {
     if (cleanupState) return
     sessionStorage.setItem(cleanupAttemptKey, '1')
-    const target = new URL(cleanupPath, location.origin)
+    const target = new URL(cleanupPath.slice(1), appScope)
     target.searchParams.set('return', location.href)
     location.replace(target.href)
   }
@@ -82,27 +140,8 @@ export function createDevServiceWorkerCleanupPlugin(): Plugin {
     return
   }
 
-  if (isManagedWorker(navigator.serviceWorker.controller)) {
-    redirectToCleanup()
-    return
-  }
-
-  void navigator.serviceWorker.getRegistrations().then(registrations => {
-    const hasManagedRegistration = registrations.some(registration =>
-      [registration.installing, registration.waiting, registration.active].some(isManagedWorker),
-    )
-    if (hasManagedRegistration) {
-      redirectToCleanup()
-      return
-    }
-
-    if ('caches' in window) {
-      void caches.keys().then(cacheNames =>
-        Promise.allSettled(
-          cacheNames.filter(name => cachePrefixes.some(prefix => name.startsWith(prefix))).map(name => caches.delete(name)),
-        ),
-      )
-    }
+  void hasVerifiedRegistration().then(hasRegistration => {
+    if (hasRegistration) redirectToCleanup()
   })
 })()
 `
@@ -113,36 +152,58 @@ export function createDevServiceWorkerCleanupPlugin(): Plugin {
   <body>
     <script>
       (() => {
-        const workerPaths = ${workerPaths}
-        const cachePrefixes = ${cachePrefixes}
+        const workerScripts = ${workerScripts}
+        const identityMessage = ${identityMessage}
+        const identityTimeoutMs = ${identityTimeoutMs}
+        const identityAttempts = ${identityAttempts}
+        const retryIdentityVerification = ${retryIdentityVerification}
         const cleanupAttemptKey = ${cleanupAttemptKey}
-        const isManagedWorker = worker => {
-          if (!worker) return false
-          const url = new URL(worker.scriptURL)
-          return url.origin === location.origin && workerPaths.some(path => url.pathname.endsWith(path))
-        }
         const resolveReturnUrl = () => {
           const requested = new URLSearchParams(location.search).get('return')
           if (!requested) return new URL('/', location.origin)
           const target = new URL(requested, location.origin)
           return target.origin === location.origin ? target : new URL('/', location.origin)
         }
+        const returnUrl = resolveReturnUrl()
+        const appScope = new URL('./', returnUrl)
+        const getCandidateWorker = registration => {
+          if (new URL(registration.scope).href !== appScope.href) return null
+          return [registration.active, registration.waiting, registration.installing].find(worker => {
+            if (!worker) return false
+            const scriptUrl = new URL(worker.scriptURL).href
+            return workerScripts.some(workerScript => scriptUrl === new URL(workerScript, appScope).href)
+          }) || null
+        }
+        const verifyMoviePilotWorkerOnce = worker => new Promise(resolve => {
+          const channel = new MessageChannel()
+          const finish = result => {
+            window.clearTimeout(timeout)
+            channel.port1.close()
+            resolve(result)
+          }
+          const timeout = window.setTimeout(() => finish(false), identityTimeoutMs)
+          channel.port1.onmessage = event => finish(typeof event.data?.count === 'number')
+          try {
+            worker.postMessage({ type: identityMessage }, [channel.port2])
+          } catch {
+            finish(false)
+          }
+        })
+        const verifyMoviePilotWorker = worker =>
+          retryIdentityVerification(() => verifyMoviePilotWorkerOnce(worker), identityAttempts)
         const cleanup = async () => {
           const registrations = 'serviceWorker' in navigator ? await navigator.serviceWorker.getRegistrations() : []
-          const managedRegistrations = registrations.filter(registration =>
-            [registration.installing, registration.waiting, registration.active].some(isManagedWorker),
-          )
-          await Promise.allSettled(managedRegistrations.map(registration => registration.unregister()))
-
-          if ('caches' in window) {
-            const cacheNames = await caches.keys()
-            const managedCacheNames = cacheNames.filter(name => cachePrefixes.some(prefix => name.startsWith(prefix)))
-            await Promise.allSettled(managedCacheNames.map(name => caches.delete(name)))
+          const managedRegistrations = []
+          for (const registration of registrations) {
+            const worker = getCandidateWorker(registration)
+            if (worker && await verifyMoviePilotWorker(worker)) managedRegistrations.push(registration)
           }
+          if (!managedRegistrations.length) throw new Error('MoviePilot Service Worker identity verification failed')
+          await Promise.allSettled(managedRegistrations.map(registration => registration.unregister()))
 
           // 回跳入口后由 head-prepend 脚本完成第二次导航，避免同一 client 继续复用旧模块响应。
           sessionStorage.setItem(cleanupAttemptKey, 'complete')
-          location.replace(resolveReturnUrl().href)
+          location.replace(returnUrl.href)
         }
 
         void cleanup().catch(error => {
@@ -160,7 +221,7 @@ export function createDevServiceWorkerCleanupPlugin(): Plugin {
     configureServer(server) {
       server.middlewares.use((request, response, next) => {
         const pathname = new URL(request.url || '/', 'http://localhost').pathname
-        if (pathname !== DEV_SW_CLEANUP_PATH) {
+        if (!pathname.endsWith(DEV_SW_CLEANUP_PATH)) {
           next()
           return
         }

--- a/scripts/pwa-development.ts
+++ b/scripts/pwa-development.ts
@@ -1,0 +1,181 @@
+import type { Plugin } from 'vite'
+
+const PWA_DEVELOPMENT_SCRIPT = 'dev:pwa'
+export const DEV_SW_CLEANUP_PATH = '/__moviepilot_dev_sw_cleanup__'
+
+const moviePilotWorkerPaths = ['/dev-sw.js', '/service-worker.js']
+const moviePilotCachePrefixes = [
+  'app-shell-',
+  'static-resources-',
+  'image-cache-',
+  'font-cache-',
+  'api-cache-',
+  'tmdb-image-cache-',
+  'workbox-precache-',
+]
+
+/** 普通 development mode 仅在显式 dev:pwa 脚本中启用开发 Service Worker。 */
+export const isPwaDevelopmentEnabled = (mode: string, lifecycleEvent?: string) =>
+  mode === 'development' && lifecycleEvent === PWA_DEVELOPMENT_SCRIPT
+
+/** 普通开发服务器才执行历史 Service Worker 清理，production preview 保持构建产物行为。 */
+export const shouldEnableDevServiceWorkerCleanup = (
+  command: 'build' | 'serve',
+  mode: string,
+  isPreview: boolean | undefined,
+  lifecycleEvent?: string,
+) =>
+  command === 'serve' && mode === 'development' && isPreview !== true && !isPwaDevelopmentEnabled(mode, lifecycleEvent)
+
+/** 判断脚本 URL 是否属于当前 origin 的 MoviePilot Service Worker。 */
+export function isManagedServiceWorkerUrl(scriptUrl: string, origin: string): boolean {
+  const url = new URL(scriptUrl)
+  return url.origin === origin && moviePilotWorkerPaths.some(path => url.pathname.endsWith(path))
+}
+
+/** 判断 Cache Storage 名称是否属于 MoviePilot 管理的缓存。 */
+export const isManagedCacheName = (name: string): boolean =>
+  moviePilotCachePrefixes.some(prefix => name.startsWith(prefix))
+
+/** 清理完成后只允许返回当前 origin，避免开发中间页形成开放重定向。 */
+export function resolveDevCleanupReturnUrl(requested: string | null, origin: string): URL {
+  if (!requested) return new URL('/', origin)
+  const target = new URL(requested, origin)
+  return target.origin === origin ? target : new URL('/', origin)
+}
+
+/**
+ * 普通开发服务器不应被历史 Service Worker 控制；受控页面先进入独立清理页，避免旧缓存模块抢先执行。
+ */
+export function createDevServiceWorkerCleanupPlugin(): Plugin {
+  const workerPaths = JSON.stringify(moviePilotWorkerPaths)
+  const cachePrefixes = JSON.stringify(moviePilotCachePrefixes)
+  const cleanupPath = JSON.stringify(DEV_SW_CLEANUP_PATH)
+  const cleanupAttemptKey = JSON.stringify('moviepilot:dev-sw-cleanup-attempted')
+
+  const redirectScript = `
+(() => {
+  if (!('serviceWorker' in navigator)) return
+
+  const workerPaths = ${workerPaths}
+  const cachePrefixes = ${cachePrefixes}
+  const cleanupPath = ${cleanupPath}
+  const cleanupAttemptKey = ${cleanupAttemptKey}
+  const cleanupState = sessionStorage.getItem(cleanupAttemptKey)
+  const isManagedWorker = worker => {
+    if (!worker) return false
+    const url = new URL(worker.scriptURL)
+    return url.origin === location.origin && workerPaths.some(path => url.pathname.endsWith(path))
+  }
+  const redirectToCleanup = () => {
+    if (cleanupState) return
+    sessionStorage.setItem(cleanupAttemptKey, '1')
+    const target = new URL(cleanupPath, location.origin)
+    target.searchParams.set('return', location.href)
+    location.replace(target.href)
+  }
+
+  // unregister 不会立即解除当前 document 的 controller；应用模块加载前需再导航一次以脱离旧 Worker。
+  if (cleanupState === 'complete') {
+    sessionStorage.removeItem(cleanupAttemptKey)
+    location.reload()
+    return
+  }
+
+  if (isManagedWorker(navigator.serviceWorker.controller)) {
+    redirectToCleanup()
+    return
+  }
+
+  void navigator.serviceWorker.getRegistrations().then(registrations => {
+    const hasManagedRegistration = registrations.some(registration =>
+      [registration.installing, registration.waiting, registration.active].some(isManagedWorker),
+    )
+    if (hasManagedRegistration) {
+      redirectToCleanup()
+      return
+    }
+
+    if ('caches' in window) {
+      void caches.keys().then(cacheNames =>
+        Promise.allSettled(
+          cacheNames.filter(name => cachePrefixes.some(prefix => name.startsWith(prefix))).map(name => caches.delete(name)),
+        ),
+      )
+    }
+  })
+})()
+`
+
+  const cleanupDocument = `<!doctype html>
+<html lang="zh-CN">
+  <head><meta charset="UTF-8"><title>MoviePilot Dev Cleanup</title></head>
+  <body>
+    <script>
+      (() => {
+        const workerPaths = ${workerPaths}
+        const cachePrefixes = ${cachePrefixes}
+        const cleanupAttemptKey = ${cleanupAttemptKey}
+        const isManagedWorker = worker => {
+          if (!worker) return false
+          const url = new URL(worker.scriptURL)
+          return url.origin === location.origin && workerPaths.some(path => url.pathname.endsWith(path))
+        }
+        const resolveReturnUrl = () => {
+          const requested = new URLSearchParams(location.search).get('return')
+          if (!requested) return new URL('/', location.origin)
+          const target = new URL(requested, location.origin)
+          return target.origin === location.origin ? target : new URL('/', location.origin)
+        }
+        const cleanup = async () => {
+          const registrations = 'serviceWorker' in navigator ? await navigator.serviceWorker.getRegistrations() : []
+          const managedRegistrations = registrations.filter(registration =>
+            [registration.installing, registration.waiting, registration.active].some(isManagedWorker),
+          )
+          await Promise.allSettled(managedRegistrations.map(registration => registration.unregister()))
+
+          if ('caches' in window) {
+            const cacheNames = await caches.keys()
+            const managedCacheNames = cacheNames.filter(name => cachePrefixes.some(prefix => name.startsWith(prefix)))
+            await Promise.allSettled(managedCacheNames.map(name => caches.delete(name)))
+          }
+
+          // 回跳入口后由 head-prepend 脚本完成第二次导航，避免同一 client 继续复用旧模块响应。
+          sessionStorage.setItem(cleanupAttemptKey, 'complete')
+          location.replace(resolveReturnUrl().href)
+        }
+
+        void cleanup().catch(error => {
+          console.error('[PWA] Failed to clean stale development Service Worker state', error)
+          document.body.textContent = 'Failed to clean stale development Service Worker state. Reload to retry.'
+        })
+      })()
+    </script>
+  </body>
+</html>`
+
+  return {
+    name: 'moviepilot:dev-service-worker-cleanup',
+    apply: 'serve',
+    configureServer(server) {
+      server.middlewares.use((request, response, next) => {
+        const pathname = new URL(request.url || '/', 'http://localhost').pathname
+        if (pathname !== DEV_SW_CLEANUP_PATH) {
+          next()
+          return
+        }
+
+        response.statusCode = 200
+        response.setHeader('Content-Type', 'text/html; charset=utf-8')
+        response.setHeader('Cache-Control', 'no-store')
+        response.end(cleanupDocument)
+      })
+    },
+    transformIndexHtml: {
+      order: 'pre',
+      handler() {
+        return [{ tag: 'script', children: redirectScript, injectTo: 'head-prepend' }]
+      },
+    },
+  }
+}

--- a/tests/config/pwa-development.spec.ts
+++ b/tests/config/pwa-development.spec.ts
@@ -1,0 +1,100 @@
+import type { IndexHtmlTransformContext, IndexHtmlTransformResult, ViteDevServer } from 'vite'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  createDevServiceWorkerCleanupPlugin,
+  DEV_SW_CLEANUP_PATH,
+  isManagedCacheName,
+  isManagedServiceWorkerUrl,
+  isPwaDevelopmentEnabled,
+  resolveDevCleanupReturnUrl,
+  shouldEnableDevServiceWorkerCleanup,
+} from '../../scripts/pwa-development'
+
+describe('PWA 开发模式', () => {
+  it('仅显式 dev:pwa 脚本启用开发 Service Worker', () => {
+    expect(isPwaDevelopmentEnabled('development', 'dev')).toBe(false)
+    expect(isPwaDevelopmentEnabled('development', 'dev:pwa')).toBe(true)
+    expect(isPwaDevelopmentEnabled('production', 'dev:pwa')).toBe(false)
+  })
+
+  it('仅普通 development server 启用历史 Service Worker 清理', () => {
+    expect(shouldEnableDevServiceWorkerCleanup('serve', 'development', false, 'dev')).toBe(true)
+    expect(shouldEnableDevServiceWorkerCleanup('serve', 'development', false, 'dev:pwa')).toBe(false)
+    expect(shouldEnableDevServiceWorkerCleanup('serve', 'production', true, 'preview')).toBe(false)
+    expect(shouldEnableDevServiceWorkerCleanup('build', 'production', false, 'build')).toBe(false)
+  })
+
+  it('只匹配当前 origin 的 MoviePilot Service Worker 和缓存', () => {
+    const origin = 'http://localhost:5173'
+
+    expect(isManagedServiceWorkerUrl(`${origin}/dev-sw.js?dev-sw`, origin)).toBe(true)
+    expect(isManagedServiceWorkerUrl(`${origin}/service-worker.js`, origin)).toBe(true)
+    expect(isManagedServiceWorkerUrl(`${origin}/unrelated-sw.js`, origin)).toBe(false)
+    expect(isManagedServiceWorkerUrl('http://localhost:5174/dev-sw.js?dev-sw', origin)).toBe(false)
+    expect(isManagedCacheName('static-resources-dev-dev')).toBe(true)
+    expect(isManagedCacheName('workbox-precache-v2-http://localhost:5173/')).toBe(true)
+    expect(isManagedCacheName('unrelated-cache')).toBe(false)
+  })
+
+  it('清理完成后只返回当前 origin', () => {
+    const origin = 'http://localhost:5173'
+
+    expect(resolveDevCleanupReturnUrl('/#/dashboard', origin).href).toBe(`${origin}/#/dashboard`)
+    expect(resolveDevCleanupReturnUrl('https://example.com/path', origin).href).toBe(`${origin}/`)
+    expect(resolveDevCleanupReturnUrl(null, origin).href).toBe(`${origin}/`)
+  })
+
+  it('在应用入口前检查历史 MoviePilot Service Worker', async () => {
+    const plugin = createDevServiceWorkerCleanupPlugin()
+    const transform = plugin.transformIndexHtml
+
+    expect(transform).toBeTypeOf('object')
+    const result = await (
+      transform as {
+        handler: (html: string, context: IndexHtmlTransformContext) => IndexHtmlTransformResult
+      }
+    ).handler('', {} as IndexHtmlTransformContext)
+    if (!Array.isArray(result)) throw new Error('Expected transformIndexHtml to return injected tags')
+    const [script] = result
+
+    expect(script.injectTo).toBe('head-prepend')
+    expect(script.children).toContain('/dev-sw.js')
+    expect(script.children).toContain('/service-worker.js')
+    expect(script.children).toContain(DEV_SW_CLEANUP_PATH)
+    expect(script.children).toContain('static-resources-')
+    expect(script.children).toContain("cleanupState === 'complete'")
+    expect(script.children).toContain('location.reload()')
+  })
+
+  it('提供不缓存的清理页面并只清理 MoviePilot 管理的浏览器状态', () => {
+    const plugin = createDevServiceWorkerCleanupPlugin()
+    let middleware: ((request: { url?: string }, response: ResponseStub, next: () => void) => void) | undefined
+    const use = vi.fn(handler => {
+      middleware = handler
+    })
+    const response: ResponseStub = {
+      statusCode: 0,
+      setHeader: vi.fn(),
+      end: vi.fn(),
+    }
+
+    const configureServer = plugin.configureServer as (server: Pick<ViteDevServer, 'middlewares'>) => void
+    configureServer({ middlewares: { use } } as unknown as Pick<ViteDevServer, 'middlewares'>)
+    middleware?.({ url: DEV_SW_CLEANUP_PATH }, response, vi.fn())
+
+    expect(response.statusCode).toBe(200)
+    expect(response.setHeader).toHaveBeenCalledWith('Cache-Control', 'no-store')
+    expect(response.end).toHaveBeenCalledWith(expect.stringContaining('registration.unregister()'))
+    expect(response.end).toHaveBeenCalledWith(expect.stringContaining('name.startsWith(prefix)'))
+    expect(response.end).toHaveBeenCalledWith(
+      expect.stringContaining("sessionStorage.setItem(cleanupAttemptKey, 'complete')"),
+    )
+    expect(response.end).not.toHaveBeenCalledWith(expect.stringContaining('localStorage.clear'))
+  })
+})
+
+interface ResponseStub {
+  statusCode: number
+  setHeader: (name: string, value: string) => void
+  end: (body: string) => void
+}

--- a/tests/config/pwa-development.spec.ts
+++ b/tests/config/pwa-development.spec.ts
@@ -110,6 +110,8 @@ describe('PWA 开发模式', () => {
     expect(scriptContent).toContain('verifyMoviePilotWorkerOnce')
     expect(scriptContent).toContain('verifyMoviePilotWorker')
     expect(scriptContent).toContain("cleanupState === 'complete'")
+    expect(scriptContent).toContain("sessionStorage.setItem(cleanupAttemptKey, 'pending')")
+    expect(scriptContent).toContain('encodeURIComponent(appScope.pathname)')
     expect(scriptContent).toContain('location.reload()')
     expect(scriptContent).not.toContain('caches.delete')
   })
@@ -148,6 +150,11 @@ describe('PWA 开发模式', () => {
     expect(response.end).toHaveBeenCalledWith(expect.stringContaining('verifyMoviePilotWorker'))
     expect(response.end).toHaveBeenCalledWith(expect.stringContaining('const identityTimeoutMs = 1500'))
     expect(response.end).toHaveBeenCalledWith(expect.stringContaining('const identityAttempts = 2'))
+    expect(response.end).toHaveBeenCalledWith(
+      expect.stringContaining("sessionStorage.getItem(cleanupAttemptKey) !== 'pending'"),
+    )
+    expect(response.end).toHaveBeenCalledWith(expect.stringContaining("const appScope = new URL('./', location.href)"))
+    expect(response.end).not.toHaveBeenCalledWith(expect.stringContaining("new URL('./', returnUrl)"))
     expect(response.end).toHaveBeenCalledWith(
       expect.stringContaining("sessionStorage.setItem(cleanupAttemptKey, 'complete')"),
     )

--- a/tests/config/pwa-development.spec.ts
+++ b/tests/config/pwa-development.spec.ts
@@ -3,9 +3,11 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   createDevServiceWorkerCleanupPlugin,
   DEV_SW_CLEANUP_PATH,
-  isManagedCacheName,
-  isManagedServiceWorkerUrl,
+  isManagedServiceWorkerRegistration,
+  isMoviePilotServiceWorkerIdentityResponse,
   isPwaDevelopmentEnabled,
+  retryMoviePilotIdentityVerification,
+  resolveDevAppScope,
   resolveDevCleanupReturnUrl,
   shouldEnableDevServiceWorkerCleanup,
 } from '../../scripts/pwa-development'
@@ -24,16 +26,45 @@ describe('PWA 开发模式', () => {
     expect(shouldEnableDevServiceWorkerCleanup('build', 'production', false, 'build')).toBe(false)
   })
 
-  it('只匹配当前 origin 的 MoviePilot Service Worker 和缓存', () => {
-    const origin = 'http://localhost:5173'
+  it('只匹配当前应用 scope 下精确的 MoviePilot Worker URL', () => {
+    const pageUrl = 'http://localhost:5173/moviepilot/#/dashboard'
+    const scope = 'http://localhost:5173/moviepilot/'
 
-    expect(isManagedServiceWorkerUrl(`${origin}/dev-sw.js?dev-sw`, origin)).toBe(true)
-    expect(isManagedServiceWorkerUrl(`${origin}/service-worker.js`, origin)).toBe(true)
-    expect(isManagedServiceWorkerUrl(`${origin}/unrelated-sw.js`, origin)).toBe(false)
-    expect(isManagedServiceWorkerUrl('http://localhost:5174/dev-sw.js?dev-sw', origin)).toBe(false)
-    expect(isManagedCacheName('static-resources-dev-dev')).toBe(true)
-    expect(isManagedCacheName('workbox-precache-v2-http://localhost:5173/')).toBe(true)
-    expect(isManagedCacheName('unrelated-cache')).toBe(false)
+    expect(resolveDevAppScope(pageUrl).href).toBe(scope)
+    expect(isManagedServiceWorkerRegistration(`${scope}dev-sw.js?dev-sw`, scope, pageUrl)).toBe(true)
+    expect(isManagedServiceWorkerRegistration(`${scope}service-worker.js`, scope, pageUrl)).toBe(true)
+    expect(isManagedServiceWorkerRegistration(`${scope}unrelated-sw.js`, scope, pageUrl)).toBe(false)
+    expect(
+      isManagedServiceWorkerRegistration(
+        'http://localhost:5173/another-app/service-worker.js',
+        'http://localhost:5173/another-app/',
+        pageUrl,
+      ),
+    ).toBe(false)
+    expect(
+      isManagedServiceWorkerRegistration(
+        'http://localhost:5174/moviepilot/dev-sw.js?dev-sw',
+        'http://localhost:5174/moviepilot/',
+        pageUrl,
+      ),
+    ).toBe(false)
+  })
+
+  it('只有现有 MoviePilot 消息协议响应才能通过身份确认', () => {
+    expect(isMoviePilotServiceWorkerIdentityResponse({ count: 0 })).toBe(true)
+    expect(isMoviePilotServiceWorkerIdentityResponse({ count: 3 })).toBe(true)
+    expect(isMoviePilotServiceWorkerIdentityResponse({ success: true })).toBe(false)
+    expect(isMoviePilotServiceWorkerIdentityResponse(null)).toBe(false)
+  })
+
+  it('身份确认首次失败后重试，持续失败时保持 fail-closed', async () => {
+    const succeedsOnRetry = vi.fn().mockResolvedValueOnce(false).mockResolvedValueOnce(true)
+    const alwaysFails = vi.fn().mockResolvedValue(false)
+
+    await expect(retryMoviePilotIdentityVerification(succeedsOnRetry, 2)).resolves.toBe(true)
+    expect(succeedsOnRetry).toHaveBeenCalledTimes(2)
+    await expect(retryMoviePilotIdentityVerification(alwaysFails, 2)).resolves.toBe(false)
+    expect(alwaysFails).toHaveBeenCalledTimes(2)
   })
 
   it('清理完成后只返回当前 origin', () => {
@@ -58,12 +89,23 @@ describe('PWA 开发模式', () => {
     const [script] = result
 
     expect(script.injectTo).toBe('head-prepend')
-    expect(script.children).toContain('/dev-sw.js')
-    expect(script.children).toContain('/service-worker.js')
-    expect(script.children).toContain(DEV_SW_CLEANUP_PATH)
-    expect(script.children).toContain('static-resources-')
-    expect(script.children).toContain("cleanupState === 'complete'")
-    expect(script.children).toContain('location.reload()')
+    if (typeof script.children !== 'string') throw new TypeError('Expected an inline cleanup script')
+    const scriptContent = script.children
+
+    expect(scriptContent).toContain('cleanupPath.slice(1)')
+    expect(scriptContent).not.toContain("replace(/^//, '')")
+    expect(scriptContent).toContain('dev-sw.js?dev-sw')
+    expect(scriptContent).toContain('service-worker.js')
+    expect(scriptContent).toContain(DEV_SW_CLEANUP_PATH)
+    expect(scriptContent).toContain('GET_UNREAD_COUNT')
+    expect(scriptContent).toContain('const identityTimeoutMs = 1500')
+    expect(scriptContent).toContain('const identityAttempts = 2')
+    expect(scriptContent).toContain('retryMoviePilotIdentityVerification')
+    expect(scriptContent).toContain('verifyMoviePilotWorkerOnce')
+    expect(scriptContent).toContain('verifyMoviePilotWorker')
+    expect(scriptContent).toContain("cleanupState === 'complete'")
+    expect(scriptContent).toContain('location.reload()')
+    expect(scriptContent).not.toContain('caches.delete')
   })
 
   it('提供不缓存的清理页面并只清理 MoviePilot 管理的浏览器状态', () => {
@@ -85,10 +127,13 @@ describe('PWA 开发模式', () => {
     expect(response.statusCode).toBe(200)
     expect(response.setHeader).toHaveBeenCalledWith('Cache-Control', 'no-store')
     expect(response.end).toHaveBeenCalledWith(expect.stringContaining('registration.unregister()'))
-    expect(response.end).toHaveBeenCalledWith(expect.stringContaining('name.startsWith(prefix)'))
+    expect(response.end).toHaveBeenCalledWith(expect.stringContaining('verifyMoviePilotWorker'))
+    expect(response.end).toHaveBeenCalledWith(expect.stringContaining('const identityTimeoutMs = 1500'))
+    expect(response.end).toHaveBeenCalledWith(expect.stringContaining('const identityAttempts = 2'))
     expect(response.end).toHaveBeenCalledWith(
       expect.stringContaining("sessionStorage.setItem(cleanupAttemptKey, 'complete')"),
     )
+    expect(response.end).not.toHaveBeenCalledWith(expect.stringContaining('caches.delete'))
     expect(response.end).not.toHaveBeenCalledWith(expect.stringContaining('localStorage.clear'))
   })
 })

--- a/tests/config/pwa-development.spec.ts
+++ b/tests/config/pwa-development.spec.ts
@@ -80,14 +80,18 @@ describe('PWA 开发模式', () => {
     const transform = plugin.transformIndexHtml
 
     expect(transform).toBeTypeOf('object')
+    const entryTag = '<script type="module" src="/src/main.ts"></script>'
     const result = await (
       transform as {
         handler: (html: string, context: IndexHtmlTransformContext) => IndexHtmlTransformResult
       }
-    ).handler('', {} as IndexHtmlTransformContext)
-    if (!Array.isArray(result)) throw new Error('Expected transformIndexHtml to return injected tags')
-    const [script] = result
+    ).handler(`<main>loading</main>${entryTag}`, {} as IndexHtmlTransformContext)
+    if (!result || Array.isArray(result) || typeof result === 'string') {
+      throw new Error('Expected transformIndexHtml to gate the development entry')
+    }
+    const [script] = result.tags ?? []
 
+    expect(result.html).toBe('<main>loading</main>')
     expect(script.injectTo).toBe('head-prepend')
     if (typeof script.children !== 'string') throw new TypeError('Expected an inline cleanup script')
     const scriptContent = script.children
@@ -101,11 +105,25 @@ describe('PWA 开发模式', () => {
     expect(scriptContent).toContain('const identityTimeoutMs = 1500')
     expect(scriptContent).toContain('const identityAttempts = 2')
     expect(scriptContent).toContain('retryMoviePilotIdentityVerification')
+    expect(scriptContent).toContain('entry.src = entryScriptUrl')
+    expect(scriptContent).toContain('startApp()')
     expect(scriptContent).toContain('verifyMoviePilotWorkerOnce')
     expect(scriptContent).toContain('verifyMoviePilotWorker')
     expect(scriptContent).toContain("cleanupState === 'complete'")
     expect(scriptContent).toContain('location.reload()')
     expect(scriptContent).not.toContain('caches.delete')
+  })
+
+  it('开发入口标签缺失时立即失败，避免普通 dev 静默白屏', () => {
+    const transform = createDevServiceWorkerCleanupPlugin().transformIndexHtml
+
+    expect(() =>
+      (
+        transform as {
+          handler: (html: string, context: IndexHtmlTransformContext) => IndexHtmlTransformResult
+        }
+      ).handler('<main>missing entry</main>', {} as IndexHtmlTransformContext),
+    ).toThrow('Expected development entry tag')
   })
 
   it('提供不缓存的清理页面并只清理 MoviePilot 管理的浏览器状态', () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,6 +14,11 @@ import federation from '@originjs/vite-plugin-federation'
 import topLevelAwait from 'vite-plugin-top-level-await'
 import { readFileSync } from 'node:fs'
 import { responsiveInputCoreComponentNames } from './src/plugins/vuetify/responsiveInputNames'
+import {
+  createDevServiceWorkerCleanupPlugin,
+  isPwaDevelopmentEnabled,
+  shouldEnableDevServiceWorkerCleanup,
+} from './scripts/pwa-development'
 
 // 读取 package.json 获取版本号
 const packageJson = JSON.parse(readFileSync('./package.json', 'utf-8'))
@@ -21,9 +26,11 @@ const buildTime = new Date().getTime().toString()
 const isTestMode = (mode: string) => mode === 'test' || process.env.VITEST === 'true'
 
 // https://vitejs.dev/config/
-export default defineConfig(({ mode }) => ({
+export default defineConfig(({ command, mode, isPreview }) => ({
   base: './',
   plugins: [
+    shouldEnableDevServiceWorkerCleanup(command, mode, isPreview, process.env.npm_lifecycle_event) &&
+      createDevServiceWorkerCleanupPlugin(),
     vue(),
     vueJsx(),
     vuetify({
@@ -74,7 +81,7 @@ export default defineConfig(({ mode }) => ({
           globPatterns: ['**/*.{js,css,html,ico,png,svg,jpg,jpeg,webp,woff,woff2,ttf,otf,eot}'],
         },
         devOptions: {
-          enabled: true,
+          enabled: isPwaDevelopmentEnabled(mode, process.env.npm_lifecycle_event),
           type: 'module',
         },
         manifest: {


### PR DESCRIPTION
## 实际问题

普通 `yarn dev` 过去会自动注册开发 Service Worker。实测其 `StaleWhileRevalidate` 缓存会接管 Vite 源模块：同一脚本从 `v1` 更新为 `v2` 后，连续加载结果出现 `v1 -> v1 -> v2`。这会让刷新后的页面仍运行落后一轮的代码，表现为 HMR/模块状态异常；清理浏览器 Application 状态后才恢复。

仅停止注册新 Worker 不能处理已经留在同一 origin 的历史 registration。初版自动恢复又暴露出两个所有权问题：按 `/service-worker.js` 路径后缀可能匹配同 origin 子路径应用，按 `image-cache-`、`workbox-precache-` 等通用前缀删除 Cache Storage 也可能影响其他应用。

## 根因与方案选择

- Service Worker 和 Cache Storage 跨刷新、跨开发命令持续存在；普通 Vite dev 与 PWA dev 复用 origin 时，旧 Worker 仍可继续控制请求。
- 普通开发不需要离线缓存，因此默认 `yarn dev` 不再注册 Worker；需要调试 PWA 时使用显式 `yarn dev:pwa`。
- 普通 dev 注入仅开发服务器存在的恢复逻辑。registration 必须同时满足当前应用的精确 scope、精确 Worker URL，并通过 MoviePilot 既有 `GET_UNREAD_COUNT` 消息协议确认身份后才允许注销。
- 身份探测使用 1500 ms 超时并最多尝试两次，兼容 Worker 冷启动；持续无响应时 fail-closed，保留未知 Worker。
- 不再自动删除任何 Cache Storage。现有运行时缓存没有 MoviePilot 专属命名空间，无法可靠证明所有权；Worker 注销并完成两阶段导航后，这些缓存不会继续控制普通 dev 请求。
- 清理页回跳后再导航一次，确保当前 document 脱离已经注销但仍暂时存在的 controller，避免继续复用旧模块响应。

## 影响

- 开发者从 `dev:pwa` 或历史 PWA 状态切回普通 `yarn dev` 后，一次刷新会自动注销已确认的 MoviePilot Worker并恢复 Vite 页面，不再需要常规清理 Application。
- `yarn dev:pwa` 继续使用 development mode 和开发环境变量，保留完整 PWA 调试能力。
- production build、preview、线上 PWA 注册与更新策略不变，线上用户无需清缓存或执行迁移。
- Cookie、localStorage、IndexedDB、全部 Cache Storage、其他 scope 的 registration 均不清理；现有异常清理入口继续作为兜底。

## 验证

- `yarn vitest run tests/config/pwa-development.spec.ts`（8 tests passed）
- `yarn typecheck`
- `yarn lint`
- `yarn lint:suppressions:prune`
- `yarn prettier --check package.json vite.config.ts scripts/pwa-development.ts tests/config/pwa-development.spec.ts`
- `yarn build`
- `git diff --check`
- 真实 Chrome 串行验证：PWA dev 仅有一个 MoviePilot 根 scope registration；预置同 origin 子路径 Worker、无关 Cache Storage 和 localStorage 哨兵后切换普通 dev，一次刷新完成两阶段恢复。MoviePilot 根 Worker 被注销且页面脱离 controller，子路径 Worker、全部缓存和 localStorage 哨兵均保留。
- 恢复后的新标签无 console error/warn；production 构建产物不包含 dev cleanup 入口、状态键或身份重试逻辑。

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 843f605f1c016aafee3eee78518fdb3f6fe3feb2

- 隔离普通开发与 PWA Service Worker
- 新增显式 `dev:pwa` 开发命令
- 安全识别并注销历史应用 Worker
- 入口延迟加载并二次导航脱离缓存
- 覆盖 scope、身份验证与清理流程测试
- 风险：身份探测失败时保留旧 Worker

<!-- pr-agent-summary:end -->