### PR TITLE
feat: 调整文件重命名输入框宽度

### DIFF
--- a/src/components/dialog/FileRenameDialog.vue
+++ b/src/components/dialog/FileRenameDialog.vue
@@ -74,6 +74,7 @@ function closeDialog() {
               :label="t('file.newName')"
               :loading="loading"
               prepend-inner-icon="mdi-format-text"
+              mobile-control-width="80%"
             />
           </VCol>
           <VCol v-if="item && item.type == 'dir'" cols="12">


### PR DESCRIPTION
## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at aae96ed275b6a4e86e22495c862caa76c36775da

- 调整文件重命名输入框的移动端宽度
- 为 `VTextField` 设置 `mobile-control-width="80%"`
- 仅影响重命名对话框的移动端布局
<!-- pr-agent-summary:end -->
