### PR TITLE
修复仪表盘首屏布局跳动与响应式错位

### DIFF
--- a/src/pages/__tests__/dashboard.spec.ts
+++ b/src/pages/__tests__/dashboard.spec.ts
@@ -758,4 +758,148 @@ describe('dashboard page initial layout', () => {
       'mediaRecommend',
     ])
   })
+
+  it('rebuilds a legacy responsive profile before its migration save settles', async () => {
+    const mobileProfile = deferred<unknown>()
+    const migrationSave = deferred<unknown>()
+    localStorage.setItem(
+      'MP_DASHBOARD_GRID_LAYOUT',
+      JSON.stringify({
+        enabled: enabledOnlySystemInfo,
+        items: { systemInfo: { x: 8, y: 0, w: 4, h: 6 } },
+        updatedAt: 10,
+      }),
+    )
+    localStorage.setItem('MP_DASHBOARD_ORDER', JSON.stringify([{ id: 'systemInfo', key: '' }]))
+    mocks.apiGet.mockImplementation((url: string) => {
+      if (url === '/user/config/DashboardOrder') {
+        return { data: { value: [{ id: 'systemInfo', key: '' }] } }
+      }
+      if (url === '/user/config/DashboardGridLayout') {
+        return {
+          data: {
+            value: {
+              enabled: enabledOnlySystemInfo,
+              items: { systemInfo: { x: 8, y: 0, w: 4, h: 6 } },
+              updatedAt: 20,
+            },
+          },
+        }
+      }
+      if (url === '/user/config/DashboardGridLayoutMobile') return mobileProfile.promise
+      if (url === '/user/config/Dashboard') return { data: { value: enabledOnlyLibrary } }
+      if (url === '/plugin/dashboard/meta') return []
+      throw new Error('Unexpected GET ' + url)
+    })
+    mocks.apiPost.mockImplementation((url: string) => {
+      if (url === '/user/config/DashboardGridLayoutMobile') return migrationSave.promise
+      throw new Error('Unexpected POST ' + url)
+    })
+
+    await renderDashboard()
+    await waitFor(() => expect(mocks.grid.makeWidget).toHaveBeenCalledTimes(1))
+
+    mocks.displayWidth.value = 390
+    await waitFor(() => expect(mocks.apiGet).toHaveBeenCalledWith('/user/config/DashboardGridLayoutMobile'))
+    await waitFor(() => expect(mocks.grid.removeAll).toHaveBeenCalledTimes(1))
+    mocks.grid.removeAll.mockClear()
+    mocks.grid.load.mockClear()
+
+    mobileProfile.resolve({
+      data: {
+        value: {
+          items: { library: { x: 0, y: 0, w: 1, h: 20 } },
+          updatedAt: 30,
+        },
+      },
+    })
+
+    await waitFor(() =>
+      expect(mocks.apiPost).toHaveBeenCalledWith(
+        '/user/config/DashboardGridLayoutMobile',
+        expect.objectContaining({ enabled: enabledOnlyLibrary }),
+      ),
+    )
+    await waitFor(() => expect(mocks.grid.removeAll).toHaveBeenCalledTimes(1))
+    expect(mocks.grid.load.mock.calls.at(-1)?.[0]).toEqual([
+      expect.objectContaining({ id: 'library', x: 0, y: 0, w: 1, h: 20 }),
+    ])
+
+    migrationSave.resolve({ data: {} })
+  })
+
+  it('keeps a newer remote legacy layout when its merged migration save fails', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    localStorage.setItem(
+      'MP_DASHBOARD_GRID_LAYOUT',
+      JSON.stringify({
+        enabled: enabledOnlySystemInfo,
+        items: { systemInfo: { x: 8, y: 0, w: 4, h: 6 } },
+        updatedAt: 10,
+      }),
+    )
+    localStorage.setItem(
+      'MP_DASHBOARD_GRID_LAYOUT_MOBILE',
+      JSON.stringify({
+        enabled: enabledOnlyLibrary,
+        items: { library: { x: 0, y: 0, w: 1, h: 10 } },
+        updatedAt: 10,
+      }),
+    )
+    localStorage.setItem('MP_DASHBOARD_ORDER', JSON.stringify([{ id: 'systemInfo', key: '' }]))
+    mocks.apiGet.mockImplementation((url: string) => {
+      if (url === '/user/config/DashboardOrder') {
+        return { data: { value: [{ id: 'systemInfo', key: '' }] } }
+      }
+      if (url === '/user/config/DashboardGridLayout') {
+        return {
+          data: {
+            value: {
+              enabled: enabledOnlySystemInfo,
+              items: { systemInfo: { x: 8, y: 0, w: 4, h: 6 } },
+              updatedAt: 20,
+            },
+          },
+        }
+      }
+      if (url === '/user/config/DashboardGridLayoutMobile') {
+        return {
+          data: {
+            value: {
+              items: { library: { x: 0, y: 5, w: 1, h: 20 } },
+              updatedAt: 30,
+            },
+          },
+        }
+      }
+      if (url === '/plugin/dashboard/meta') return []
+      throw new Error('Unexpected GET ' + url)
+    })
+    mocks.apiPost.mockImplementation((url: string) => {
+      if (url === '/user/config/DashboardGridLayoutMobile') {
+        return Promise.reject(new Error('migration save failed'))
+      }
+      throw new Error('Unexpected POST ' + url)
+    })
+
+    await renderDashboard()
+    await waitFor(() => expect(mocks.grid.makeWidget).toHaveBeenCalledTimes(1))
+
+    mocks.displayWidth.value = 390
+    await waitFor(() =>
+      expect(mocks.apiPost).toHaveBeenCalledWith(
+        '/user/config/DashboardGridLayoutMobile',
+        expect.objectContaining({ enabled: enabledOnlyLibrary, updatedAt: 30 }),
+      ),
+    )
+    await waitFor(() => {
+      const loadedWidgets = mocks.grid.load.mock.calls.at(-1)?.[0] as Array<Record<string, unknown>> | undefined
+
+      expect(loadedWidgets?.find(widget => widget.id === 'library')).toEqual(
+        expect.objectContaining({ x: 0, y: 5, w: 1, h: 20 }),
+      )
+    })
+    await waitFor(() => expect(consoleError).toHaveBeenCalledWith(expect.any(Error)))
+    consoleError.mockRestore()
+  })
 })

--- a/src/pages/__tests__/dashboard.spec.ts
+++ b/src/pages/__tests__/dashboard.spec.ts
@@ -336,6 +336,58 @@ describe('dashboard page initial layout', () => {
     })
   })
 
+  it('restores default coordinates when a newer remote profile clears cached layout overrides', async () => {
+    const remoteOrder = deferred<unknown>()
+    const remoteProfile = deferred<unknown>()
+    localStorage.setItem(
+      'MP_DASHBOARD_GRID_LAYOUT',
+      JSON.stringify({
+        enabled: enabledOnlySystemInfo,
+        items: { systemInfo: { x: 0, y: 12, w: 8, h: 6 } },
+        updatedAt: 10,
+      }),
+    )
+    mocks.apiGet.mockImplementation((url: string) => {
+      if (url === '/user/config/DashboardOrder') return remoteOrder.promise
+      if (url === '/user/config/DashboardGridLayout') return remoteProfile.promise
+      if (url === '/plugin/dashboard/meta') return []
+      throw new Error('Unexpected GET ' + url)
+    })
+
+    await renderDashboard()
+    await waitFor(() => expect(mocks.grid.makeWidget).toHaveBeenCalledTimes(1))
+    expect(mocks.grid.makeWidget.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({ id: 'systemInfo', x: 0, y: 12, w: 8 }),
+    )
+    mocks.grid.load.mockClear()
+
+    remoteOrder.resolve({ data: { value: [{ id: 'systemInfo', key: '' }] } })
+    remoteProfile.resolve({
+      data: {
+        value: {
+          enabled: enabledOnlySystemInfo,
+          items: {},
+          updatedAt: 20,
+        },
+      },
+    })
+    await waitFor(() => expect(mocks.grid.load).toHaveBeenCalled())
+
+    let loadedWidgets = mocks.grid.load.mock.calls.at(-1)?.[0] as Array<Record<string, unknown>>
+    expect(loadedWidgets.find(widget => widget.id === 'systemInfo')).toEqual(
+      expect.objectContaining({ x: 8, y: 27, w: 4 }),
+    )
+
+    mocks.grid.load.mockClear()
+    await fireEvent.click(document.querySelector('.compact-fab--primary') as HTMLElement)
+    await waitFor(() => expect(mocks.grid.load).toHaveBeenCalled())
+
+    loadedWidgets = mocks.grid.load.mock.calls.at(-1)?.[0] as Array<Record<string, unknown>>
+    expect(loadedWidgets.find(widget => widget.id === 'systemInfo')).toEqual(
+      expect.objectContaining({ x: 8, y: 27, w: 4 }),
+    )
+  })
+
   it('falls back to the default dashboard after an uncached remote miss', async () => {
     mocks.apiGet.mockImplementation((url: string) => {
       if (url === '/user/config/DashboardOrder' || url === '/user/config/DashboardGridLayout') {
@@ -446,6 +498,37 @@ describe('dashboard page initial layout', () => {
         items: { systemInfo: { x: 8, y: 0, w: 4 } },
         updatedAt: 10,
       }),
+    )
+    localStorage.setItem('MP_DASHBOARD_GRID_AUTO_HEIGHTS', JSON.stringify({ systemInfo: 6 }))
+    mocks.apiGet.mockImplementation((url: string) => {
+      if (url === '/user/config/DashboardOrder') return remoteOrder.promise
+      if (url === '/user/config/DashboardGridLayout') return remoteProfile.promise
+      if (url === '/plugin/dashboard/meta') return []
+      throw new Error('Unexpected GET ' + url)
+    })
+
+    const { container } = await renderDashboard()
+    await waitFor(() => expect(mocks.grid.makeWidget).toHaveBeenCalledTimes(1))
+    const element = container.querySelector<HTMLElement & { gridstackNode?: Record<string, unknown> }>(
+      '.dashboard-grid-item[gs-id="systemInfo"]',
+    )
+    expect(element?.gridstackNode?.h).toBe(6)
+
+    if (element?.gridstackNode) element.gridstackNode.h = 13
+    mocks.grid.load.mockClear()
+    await fireEvent.click(document.querySelector('.compact-fab--primary') as HTMLElement)
+    await waitFor(() => expect(mocks.grid.load).toHaveBeenCalled())
+
+    const loadedWidgets = mocks.grid.load.mock.calls.at(-1)?.[0] as Array<Record<string, unknown>>
+    expect(loadedWidgets.find(widget => widget.id === 'systemInfo')).toEqual(expect.objectContaining({ h: 13 }))
+  })
+
+  it('keeps a live automatic height for the default layout when entering editing', async () => {
+    const remoteOrder = deferred<unknown>()
+    const remoteProfile = deferred<unknown>()
+    localStorage.setItem(
+      'MP_DASHBOARD_GRID_LAYOUT',
+      JSON.stringify({ enabled: enabledOnlySystemInfo, items: {}, updatedAt: 10 }),
     )
     localStorage.setItem('MP_DASHBOARD_GRID_AUTO_HEIGHTS', JSON.stringify({ systemInfo: 6 }))
     mocks.apiGet.mockImplementation((url: string) => {

--- a/src/pages/__tests__/dashboard.spec.ts
+++ b/src/pages/__tests__/dashboard.spec.ts
@@ -1,7 +1,7 @@
 import DashboardPage from '@/pages/dashboard.vue'
 import { DEFAULT_PERMISSIONS } from '@/utils/permission'
 import { renderWithProviders } from '@tests/support/render'
-import { screen, waitFor } from '@testing-library/vue'
+import { fireEvent, screen, waitFor } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => {
@@ -434,6 +434,41 @@ describe('dashboard page initial layout', () => {
       expect(widgets.speed.h).toBe(19)
       expect(widgets.scheduler.h).toBe(23)
     })
+  })
+
+  it('keeps a live automatic height when entering layout editing', async () => {
+    const remoteOrder = deferred<unknown>()
+    const remoteProfile = deferred<unknown>()
+    localStorage.setItem(
+      'MP_DASHBOARD_GRID_LAYOUT',
+      JSON.stringify({
+        enabled: enabledOnlySystemInfo,
+        items: { systemInfo: { x: 8, y: 0, w: 4 } },
+        updatedAt: 10,
+      }),
+    )
+    localStorage.setItem('MP_DASHBOARD_GRID_AUTO_HEIGHTS', JSON.stringify({ systemInfo: 6 }))
+    mocks.apiGet.mockImplementation((url: string) => {
+      if (url === '/user/config/DashboardOrder') return remoteOrder.promise
+      if (url === '/user/config/DashboardGridLayout') return remoteProfile.promise
+      if (url === '/plugin/dashboard/meta') return []
+      throw new Error('Unexpected GET ' + url)
+    })
+
+    const { container } = await renderDashboard()
+    await waitFor(() => expect(mocks.grid.makeWidget).toHaveBeenCalledTimes(1))
+    const element = container.querySelector<HTMLElement & { gridstackNode?: Record<string, unknown> }>(
+      '.dashboard-grid-item[gs-id="systemInfo"]',
+    )
+    expect(element?.gridstackNode?.h).toBe(6)
+
+    if (element?.gridstackNode) element.gridstackNode.h = 13
+    mocks.grid.load.mockClear()
+    await fireEvent.click(document.querySelector('.compact-fab--primary') as HTMLElement)
+    await waitFor(() => expect(mocks.grid.load).toHaveBeenCalled())
+
+    const loadedWidgets = mocks.grid.load.mock.calls.at(-1)?.[0] as Array<Record<string, unknown>>
+    expect(loadedWidgets.find(widget => widget.id === 'systemInfo')).toEqual(expect.objectContaining({ h: 13 }))
   })
 
   it('registers an arbitrary saved layout by position instead of settings order', async () => {

--- a/src/pages/__tests__/dashboard.spec.ts
+++ b/src/pages/__tests__/dashboard.spec.ts
@@ -1,0 +1,643 @@
+import DashboardPage from '@/pages/dashboard.vue'
+import { DEFAULT_PERMISSIONS } from '@/utils/permission'
+import { renderWithProviders } from '@tests/support/render'
+import { screen, waitFor } from '@testing-library/vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => {
+  const grid = {
+    batchUpdate: vi.fn(),
+    column: vi.fn(),
+    destroy: vi.fn(),
+    enableMove: vi.fn(),
+    enableResize: vi.fn(),
+    engine: { nodes: [] as Array<Record<string, unknown>> },
+    getColumn: vi.fn(() => 12),
+    load: vi.fn(),
+    makeWidget: vi.fn((element: HTMLElement, widget: Record<string, unknown>) => {
+      const node = { ...widget, el: element, id: widget.id }
+      Object.assign(element, { gridstackNode: node })
+      grid.engine.nodes.push(node)
+    }),
+    on: vi.fn(),
+    removeAll: vi.fn(() => {
+      grid.engine.nodes.forEach(node => {
+        const element = node.el as HTMLElement | undefined
+        if (element) delete (element as HTMLElement & { gridstackNode?: unknown }).gridstackNode
+      })
+      grid.engine.nodes.length = 0
+    }),
+    removeWidget: vi.fn(),
+    resizeToContent: vi.fn(),
+    save: vi.fn(() => []),
+    setAnimation: vi.fn(),
+    setStatic: vi.fn(),
+    update: vi.fn((element: HTMLElement, widget: Record<string, unknown>) => {
+      Object.assign((element as HTMLElement & { gridstackNode?: Record<string, unknown> }).gridstackNode ?? {}, widget)
+    }),
+  }
+
+  return {
+    apiGet: vi.fn(),
+    apiPost: vi.fn(),
+    displayWidth: undefined as unknown as { value: number },
+    grid,
+    gridInit: vi.fn<(options: unknown, element: unknown) => unknown>(() => grid),
+    openSharedDialog: vi.fn(),
+    useDynamicButton: vi.fn(),
+  }
+})
+
+class ResizeObserverMock implements ResizeObserver {
+  private readonly callback: ResizeObserverCallback
+
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback
+  }
+
+  disconnect() {}
+
+  observe(target: Element) {
+    requestAnimationFrame(() => {
+      this.callback([{ contentRect: { height: 240 }, target } as ResizeObserverEntry], this)
+    })
+  }
+
+  unobserve() {}
+}
+
+vi.mock('@/api', () => ({
+  default: {
+    get: (...args: unknown[]) => mocks.apiGet(...args),
+    post: (...args: unknown[]) => mocks.apiPost(...args),
+  },
+}))
+
+vi.mock('vuetify', async importOriginal => {
+  const { ref } = await import('vue')
+  mocks.displayWidth = ref(1512)
+
+  return {
+    ...(await importOriginal<typeof import('vuetify')>()),
+    useDisplay: () => ({ width: mocks.displayWidth }),
+  }
+})
+
+vi.mock('gridstack', () => ({
+  GridStack: {
+    init: (options: unknown, element: unknown) => mocks.gridInit(options, element),
+  },
+}))
+
+vi.mock('@/composables/useDynamicButton', () => ({
+  useDynamicButton: (options: unknown) => mocks.useDynamicButton(options),
+}))
+
+vi.mock('@/composables/usePWA', async () => {
+  const { ref } = await import('vue')
+  return {
+    usePWA: () => ({ appMode: ref(false) }),
+  }
+})
+
+vi.mock('@/composables/useSharedDialog', () => ({
+  openSharedDialog: (...args: unknown[]) => mocks.openSharedDialog(...args),
+}))
+
+vi.mock('@/components/misc/DashboardElement.vue', async () => {
+  const { defineComponent, h, onMounted } = await import('vue')
+
+  return {
+    default: defineComponent({
+      name: 'DashboardElement',
+      props: {
+        config: { type: Object, required: true },
+      },
+      emits: ['loaded'],
+      setup(props, { emit }) {
+        onMounted(() => emit('loaded'))
+
+        return () =>
+          h(
+            'section',
+            {
+              'data-dashboard-id': (props.config as { id: string }).id,
+              'data-testid': 'dashboard-item',
+            },
+            (props.config as { name: string }).name,
+          )
+      },
+    }),
+  }
+})
+
+const enabledOnlySystemInfo = {
+  cpu: false,
+  latest: false,
+  library: false,
+  mediaRecommend: false,
+  mediaStatistic: false,
+  memory: false,
+  network: false,
+  playing: false,
+  quickActions: false,
+  recentImports: false,
+  scheduler: false,
+  speed: false,
+  storage: false,
+  systemInfo: true,
+  weeklyOverview: false,
+}
+
+const enabledOnlyLibrary = {
+  ...enabledOnlySystemInfo,
+  library: true,
+  systemInfo: false,
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>(promiseResolve => {
+    resolve = promiseResolve
+  })
+
+  return { promise, resolve }
+}
+
+async function renderDashboard() {
+  return renderWithProviders(DashboardPage, {
+    initialRoute: '/dashboard',
+    initialState: {
+      user: {
+        permissions: { ...DEFAULT_PERMISSIONS, discovery: true },
+        superUser: true,
+      },
+    },
+  })
+}
+
+describe('dashboard page initial layout', () => {
+  beforeEach(() => {
+    mocks.grid.engine.nodes.length = 0
+    mocks.gridInit.mockClear()
+    mocks.grid.setAnimation.mockClear()
+    mocks.apiGet.mockReset()
+    mocks.apiPost.mockReset()
+    mocks.displayWidth.value = 1512
+    vi.stubGlobal('ResizeObserver', ResizeObserverMock)
+  })
+
+  it('renders the cached profile on the first frame without waiting for remote validation', async () => {
+    const remoteOrder = deferred<unknown>()
+    const remoteProfile = deferred<unknown>()
+    localStorage.setItem(
+      'MP_DASHBOARD_GRID_LAYOUT',
+      JSON.stringify({
+        enabled: enabledOnlySystemInfo,
+        items: { systemInfo: { x: 8, y: 0, w: 4, h: 6 } },
+        updatedAt: 10,
+      }),
+    )
+    localStorage.setItem('MP_DASHBOARD_ORDER', JSON.stringify([{ id: 'systemInfo', key: '' }]))
+    mocks.apiGet.mockImplementation((url: string) => {
+      if (url === '/user/config/DashboardOrder') return remoteOrder.promise
+      if (url === '/user/config/DashboardGridLayout') return remoteProfile.promise
+      if (url === '/plugin/dashboard/meta') return []
+      throw new Error('Unexpected GET ' + url)
+    })
+
+    const { container } = await renderDashboard()
+
+    expect(screen.getAllByTestId('dashboard-item')).toHaveLength(1)
+    expect(screen.getByTestId('dashboard-item')).toHaveAttribute('data-dashboard-id', 'systemInfo')
+    expect(mocks.gridInit).toHaveBeenCalledWith(expect.objectContaining({ animate: false }), expect.any(HTMLElement))
+    await waitFor(() => expect(mocks.grid.setAnimation).toHaveBeenCalledWith(true))
+    await waitFor(() => expect(container.querySelector('.dashboard-grid')).toHaveClass('is-revealed'))
+
+    remoteOrder.resolve({ data: { value: [{ id: 'systemInfo', key: '' }] } })
+    remoteProfile.resolve({
+      data: {
+        value: {
+          enabled: enabledOnlySystemInfo,
+          items: { systemInfo: { x: 8, y: 0, w: 4, h: 6 } },
+          updatedAt: 10,
+        },
+      },
+    })
+
+    await waitFor(() => expect(mocks.grid.load).toHaveBeenCalled())
+  })
+
+  it('keeps the upstream progressive default while an uncached remote profile is loading', async () => {
+    const remoteOrder = deferred<unknown>()
+    const remoteProfile = deferred<unknown>()
+    mocks.apiGet.mockImplementation((url: string) => {
+      if (url === '/user/config/DashboardOrder') return remoteOrder.promise
+      if (url === '/user/config/DashboardGridLayout') return remoteProfile.promise
+      if (url === '/plugin/dashboard/meta') return []
+      throw new Error('Unexpected GET ' + url)
+    })
+
+    await renderDashboard()
+
+    expect(screen.getAllByTestId('dashboard-item')).toHaveLength(10)
+    expect(mocks.gridInit).toHaveBeenCalledWith(expect.objectContaining({ animate: false }), expect.any(HTMLElement))
+
+    remoteOrder.resolve({ data: { value: [{ id: 'systemInfo', key: '' }] } })
+    remoteProfile.resolve({
+      data: {
+        value: {
+          enabled: enabledOnlySystemInfo,
+          items: { systemInfo: { x: 8, y: 0, w: 4, h: 6 } },
+          updatedAt: 20,
+        },
+      },
+    })
+
+    expect(await screen.findByTestId('dashboard-item')).toHaveAttribute('data-dashboard-id', 'systemInfo')
+  })
+
+  it('prepares an automatic card with its last measured profile height without making it manual', async () => {
+    const remoteOrder = deferred<unknown>()
+    const remoteProfile = deferred<unknown>()
+    localStorage.setItem(
+      'MP_DASHBOARD_GRID_LAYOUT',
+      JSON.stringify({
+        enabled: enabledOnlyLibrary,
+        items: { library: { x: 0, y: 0, w: 12 } },
+        updatedAt: 10,
+      }),
+    )
+    localStorage.setItem('MP_DASHBOARD_GRID_AUTO_HEIGHTS', JSON.stringify({ library: 27 }))
+    mocks.apiGet.mockImplementation((url: string) => {
+      if (url === '/user/config/DashboardOrder') return remoteOrder.promise
+      if (url === '/user/config/DashboardGridLayout') return remoteProfile.promise
+      if (url === '/plugin/dashboard/meta') return []
+      throw new Error('Unexpected GET ' + url)
+    })
+
+    const { container } = await renderDashboard()
+    const libraryItem = container.querySelector('.dashboard-grid-item[gs-id="library"]')
+
+    expect(libraryItem).toHaveAttribute('gs-h', '27')
+    expect(libraryItem).not.toHaveClass('is-manual-height')
+
+    remoteOrder.resolve({ data: { value: [{ id: 'library', key: '' }] } })
+    remoteProfile.resolve({
+      data: {
+        value: {
+          enabled: enabledOnlyLibrary,
+          items: { library: { x: 0, y: 0, w: 12 } },
+          updatedAt: 10,
+        },
+      },
+    })
+    await waitFor(() => expect(mocks.grid.load).toHaveBeenCalled())
+  })
+
+  it('applies a newer remote profile and refreshes the local first-frame cache', async () => {
+    localStorage.setItem(
+      'MP_DASHBOARD_GRID_LAYOUT',
+      JSON.stringify({
+        enabled: enabledOnlySystemInfo,
+        items: { systemInfo: { x: 8, y: 0, w: 4, h: 6 } },
+        updatedAt: 10,
+      }),
+    )
+    mocks.apiGet.mockImplementation((url: string) => {
+      if (url === '/user/config/DashboardOrder') {
+        return { data: { value: [{ id: 'quickActions', key: '' }] } }
+      }
+      if (url === '/user/config/DashboardGridLayout') {
+        return {
+          data: {
+            value: {
+              enabled: { ...enabledOnlySystemInfo, quickActions: true, systemInfo: false },
+              items: { quickActions: { x: 8, y: 0, w: 4, h: 5 } },
+              updatedAt: 20,
+            },
+          },
+        }
+      }
+      if (url === '/plugin/dashboard/meta') return []
+      throw new Error('Unexpected GET ' + url)
+    })
+
+    await renderDashboard()
+
+    expect(screen.getByTestId('dashboard-item')).toHaveAttribute('data-dashboard-id', 'systemInfo')
+    await waitFor(() =>
+      expect(screen.getByTestId('dashboard-item')).toHaveAttribute('data-dashboard-id', 'quickActions'),
+    )
+    expect(JSON.parse(localStorage.getItem('MP_DASHBOARD_GRID_LAYOUT') || '{}')).toEqual({
+      enabled: { ...enabledOnlySystemInfo, quickActions: true, systemInfo: false },
+      items: { quickActions: { x: 8, y: 0, w: 4, h: 5 } },
+      updatedAt: 20,
+    })
+  })
+
+  it('falls back to the default dashboard after an uncached remote miss', async () => {
+    mocks.apiGet.mockImplementation((url: string) => {
+      if (url === '/user/config/DashboardOrder' || url === '/user/config/DashboardGridLayout') {
+        return { data: {} }
+      }
+      if (url === '/user/config/Dashboard') return { data: {} }
+      if (url === '/plugin/dashboard/meta') return []
+      throw new Error('Unexpected GET ' + url)
+    })
+
+    await renderDashboard()
+
+    await waitFor(() => expect(screen.getAllByTestId('dashboard-item')).toHaveLength(10))
+  })
+
+  it('registers the default desktop widgets in target position order', async () => {
+    mocks.apiGet.mockImplementation((url: string) => {
+      if (url === '/user/config/DashboardOrder' || url === '/user/config/DashboardGridLayout') {
+        return { data: {} }
+      }
+      if (url === '/user/config/Dashboard') return { data: {} }
+      if (url === '/plugin/dashboard/meta') return []
+      throw new Error('Unexpected GET ' + url)
+    })
+
+    await renderDashboard()
+    await waitFor(() => expect(mocks.grid.makeWidget).toHaveBeenCalledTimes(10))
+
+    expect(mocks.grid.makeWidget.mock.calls.map(([, widget]) => widget.id)).toEqual([
+      'storage',
+      'mediaStatistic',
+      'speed',
+      'recentImports',
+      'scheduler',
+      'memory',
+      'cpu',
+      'quickActions',
+      'systemInfo',
+      'mediaRecommend',
+    ])
+    const desktopReturnWidgets = mocks.grid.load.mock.calls.at(-1)?.[0] as Array<Record<string, unknown>>
+    expect(desktopReturnWidgets).toHaveLength(10)
+    expect(desktopReturnWidgets.find(widget => widget.id === 'mediaRecommend')).toEqual(
+      expect.objectContaining({ x: 0, y: 33, w: 8 }),
+    )
+  })
+
+  it('registers cached automatic heights without forcing independent columns to share a baseline', async () => {
+    localStorage.setItem(
+      'MP_DASHBOARD_GRID_AUTO_HEIGHTS',
+      JSON.stringify({
+        cpu: 18,
+        mediaRecommend: 27,
+        mediaStatistic: 11,
+        memory: 18,
+        quickActions: 9,
+        recentImports: 27,
+        scheduler: 23,
+        speed: 19,
+        storage: 11,
+        systemInfo: 10,
+      }),
+    )
+    mocks.apiGet.mockImplementation((url: string) => {
+      if (url === '/user/config/DashboardOrder' || url === '/user/config/DashboardGridLayout') {
+        return { data: {} }
+      }
+      if (url === '/user/config/Dashboard') return { data: {} }
+      if (url === '/plugin/dashboard/meta') return []
+      throw new Error('Unexpected GET ' + url)
+    })
+
+    await renderDashboard()
+    await waitFor(() => expect(mocks.grid.makeWidget).toHaveBeenCalledTimes(10))
+    await waitFor(() => expect(mocks.grid.load).toHaveBeenCalled())
+
+    const loadedWidgets = mocks.grid.load.mock.calls.at(-1)?.[0] as Array<Record<string, unknown>>
+    const widgets = Object.fromEntries(loadedWidgets.map(widget => [widget.id, widget])) as Record<
+      string,
+      Record<string, unknown>
+    >
+    expect(widgets.storage).toEqual(expect.objectContaining({ x: 0, y: 0, w: 4, h: 11 }))
+    expect(widgets.mediaStatistic).toEqual(expect.objectContaining({ x: 4, y: 0, w: 8, h: 11 }))
+    expect(widgets.speed).toEqual(expect.objectContaining({ x: 0, y: 7, w: 4, h: 19 }))
+    expect(widgets.recentImports).toEqual(expect.objectContaining({ x: 4, y: 7, w: 4, h: 27 }))
+    expect(widgets.scheduler).toEqual(expect.objectContaining({ x: 8, y: 7, w: 4, h: 23 }))
+    expect(widgets.memory).toEqual(expect.objectContaining({ x: 0, y: 22, w: 4, h: 18 }))
+    expect(widgets.cpu).toEqual(expect.objectContaining({ x: 4, y: 22, w: 4, h: 18 }))
+    expect(widgets.quickActions).toEqual(expect.objectContaining({ x: 8, y: 22, w: 4, h: 9 }))
+    expect(widgets.systemInfo).toEqual(expect.objectContaining({ x: 8, y: 27, w: 4, h: 10 }))
+    expect(widgets.mediaRecommend).toEqual(expect.objectContaining({ x: 0, y: 33, w: 8, h: 27 }))
+    await waitFor(() => {
+      const autoHeights = JSON.parse(localStorage.getItem('MP_DASHBOARD_GRID_AUTO_HEIGHTS') || '{}')
+      expect(autoHeights.speed).toBe(19)
+      expect(autoHeights.scheduler).toBe(23)
+      expect(widgets.speed.h).toBe(19)
+      expect(widgets.scheduler.h).toBe(23)
+    })
+  })
+
+  it('registers an arbitrary saved layout by position instead of settings order', async () => {
+    const enabled = {
+      ...enabledOnlySystemInfo,
+      quickActions: true,
+      recentImports: true,
+    }
+    localStorage.setItem(
+      'MP_DASHBOARD_GRID_LAYOUT',
+      JSON.stringify({
+        enabled,
+        items: {
+          quickActions: { x: 7, y: 0, w: 5, h: 8 },
+          recentImports: { x: 1, y: 12, w: 8, h: 19 },
+          systemInfo: { x: 3, y: 40, w: 6, h: 9 },
+        },
+        updatedAt: 10,
+      }),
+    )
+    localStorage.setItem(
+      'MP_DASHBOARD_ORDER',
+      JSON.stringify([
+        { id: 'systemInfo', key: '' },
+        { id: 'recentImports', key: '' },
+        { id: 'quickActions', key: '' },
+      ]),
+    )
+    mocks.apiGet.mockImplementation((url: string) => {
+      if (url === '/user/config/DashboardOrder') {
+        return { data: { value: JSON.parse(localStorage.getItem('MP_DASHBOARD_ORDER') || '[]') } }
+      }
+      if (url === '/user/config/DashboardGridLayout') {
+        return { data: { value: JSON.parse(localStorage.getItem('MP_DASHBOARD_GRID_LAYOUT') || '{}') } }
+      }
+      if (url === '/plugin/dashboard/meta') return []
+      throw new Error('Unexpected GET ' + url)
+    })
+
+    await renderDashboard()
+    await waitFor(() => expect(mocks.grid.makeWidget).toHaveBeenCalledTimes(3))
+
+    expect(mocks.grid.makeWidget.mock.calls.map(([, widget]) => widget.id)).toEqual([
+      'quickActions',
+      'recentImports',
+      'systemInfo',
+    ])
+    const widgets = Object.fromEntries(
+      mocks.grid.makeWidget.mock.calls.map(([, widget]) => [widget.id, widget]),
+    ) as Record<string, Record<string, unknown>>
+    expect(widgets.quickActions).toEqual(expect.objectContaining({ x: 7, y: 0, w: 5, h: 8 }))
+    expect(widgets.recentImports).toEqual(expect.objectContaining({ x: 1, y: 12, w: 8, h: 19 }))
+    expect(widgets.systemInfo).toEqual(expect.objectContaining({ x: 3, y: 40, w: 6, h: 9 }))
+  })
+
+  it('ignores an initial profile response after the viewport switches to another profile', async () => {
+    const initialOrder = deferred<unknown>()
+    const initialDesktopProfile = deferred<unknown>()
+    localStorage.setItem(
+      'MP_DASHBOARD_GRID_LAYOUT_MOBILE',
+      JSON.stringify({
+        enabled: enabledOnlyLibrary,
+        items: { library: { x: 0, y: 0, w: 1, h: 20 } },
+        updatedAt: 20,
+      }),
+    )
+    mocks.apiGet.mockImplementation((url: string) => {
+      if (url === '/user/config/DashboardOrder') return initialOrder.promise
+      if (url === '/user/config/DashboardGridLayout') return initialDesktopProfile.promise
+      if (url === '/user/config/DashboardGridLayoutMobile') {
+        return {
+          data: {
+            value: {
+              enabled: enabledOnlyLibrary,
+              items: { library: { x: 0, y: 0, w: 1, h: 20 } },
+              updatedAt: 20,
+            },
+          },
+        }
+      }
+      if (url === '/plugin/dashboard/meta') return []
+      throw new Error('Unexpected GET ' + url)
+    })
+
+    await renderDashboard()
+    mocks.displayWidth.value = 390
+    expect(await screen.findByTestId('dashboard-item')).toHaveAttribute('data-dashboard-id', 'library')
+
+    initialOrder.resolve({ data: { value: [{ id: 'systemInfo', key: '' }] } })
+    initialDesktopProfile.resolve({
+      data: {
+        value: {
+          enabled: enabledOnlySystemInfo,
+          items: { systemInfo: { x: 8, y: 0, w: 4, h: 6 } },
+          updatedAt: 30,
+        },
+      },
+    })
+
+    await waitFor(() => expect(mocks.apiGet).toHaveBeenCalledWith('/plugin/dashboard/meta'))
+    expect(screen.getByTestId('dashboard-item')).toHaveAttribute('data-dashboard-id', 'library')
+    expect(mocks.apiPost).not.toHaveBeenCalledWith(
+      '/user/config/DashboardGridLayoutMobile',
+      expect.objectContaining({ items: { systemInfo: expect.anything() } }),
+    )
+  })
+
+  it('rebuilds each responsive profile immediately before remote validation', async () => {
+    const mobileProfile = deferred<unknown>()
+    const desktopReturnProfile = deferred<unknown>()
+    let desktopProfileReads = 0
+    mocks.apiGet.mockImplementation((url: string) => {
+      if (url === '/user/config/DashboardOrder' || url === '/user/config/Dashboard') {
+        return { data: {} }
+      }
+      if (url === '/user/config/DashboardGridLayout') {
+        desktopProfileReads += 1
+
+        return desktopProfileReads === 1 ? { data: {} } : desktopReturnProfile.promise
+      }
+      if (url === '/user/config/DashboardGridLayoutMobile') return mobileProfile.promise
+      if (url === '/plugin/dashboard/meta') return []
+      throw new Error('Unexpected GET ' + url)
+    })
+
+    await renderDashboard()
+    await waitFor(() => expect(mocks.grid.makeWidget).toHaveBeenCalledTimes(10))
+    mocks.grid.column.mockClear()
+    mocks.grid.makeWidget.mockClear()
+    mocks.grid.removeAll.mockClear()
+    mocks.grid.update.mockClear()
+
+    mocks.displayWidth.value = 390
+    await waitFor(() => expect(mocks.apiGet).toHaveBeenCalledWith('/user/config/DashboardGridLayoutMobile'))
+    await waitFor(() => expect(mocks.grid.column).toHaveBeenCalledWith(1, 'list'))
+    await waitFor(() => expect(mocks.grid.removeAll).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(mocks.grid.makeWidget).toHaveBeenCalledTimes(10))
+    expect(mocks.grid.setAnimation).toHaveBeenCalledWith(false)
+    expect(mocks.grid.makeWidget.mock.calls.map(([, widget]) => widget.id)).toEqual([
+      'storage',
+      'mediaStatistic',
+      'mediaRecommend',
+      'speed',
+      'scheduler',
+      'cpu',
+      'memory',
+      'recentImports',
+      'quickActions',
+      'systemInfo',
+    ])
+    mocks.grid.makeWidget.mockClear()
+
+    mobileProfile.resolve({ data: {} })
+    await waitFor(() => expect(mocks.grid.removeAll).toHaveBeenCalledTimes(2))
+    expect(mocks.grid.makeWidget.mock.calls.map(([, widget]) => widget.id)).toEqual([
+      'storage',
+      'mediaStatistic',
+      'mediaRecommend',
+      'speed',
+      'scheduler',
+      'cpu',
+      'memory',
+      'recentImports',
+      'quickActions',
+      'systemInfo',
+    ])
+
+    mocks.grid.column.mockClear()
+    mocks.grid.makeWidget.mockClear()
+    mocks.grid.removeAll.mockClear()
+    mocks.grid.update.mockClear()
+
+    mocks.displayWidth.value = 1512
+    await waitFor(() => expect(desktopProfileReads).toBe(2))
+    await waitFor(() => expect(mocks.grid.column).toHaveBeenCalledWith(12, 'moveScale'))
+    await waitFor(() => expect(mocks.grid.removeAll).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(mocks.grid.makeWidget).toHaveBeenCalledTimes(10))
+    expect(mocks.grid.makeWidget.mock.calls.map(([, widget]) => widget.id)).toEqual([
+      'storage',
+      'mediaStatistic',
+      'speed',
+      'recentImports',
+      'scheduler',
+      'memory',
+      'cpu',
+      'quickActions',
+      'systemInfo',
+      'mediaRecommend',
+    ])
+    mocks.grid.makeWidget.mockClear()
+
+    desktopReturnProfile.resolve({ data: {} })
+    await waitFor(() => expect(mocks.grid.removeAll).toHaveBeenCalledTimes(2))
+    expect(mocks.grid.makeWidget.mock.calls.map(([, widget]) => widget.id)).toEqual([
+      'storage',
+      'mediaStatistic',
+      'speed',
+      'recentImports',
+      'scheduler',
+      'memory',
+      'cpu',
+      'quickActions',
+      'systemInfo',
+      'mediaRecommend',
+    ])
+  })
+})

--- a/src/pages/__tests__/dashboard.spec.ts
+++ b/src/pages/__tests__/dashboard.spec.ts
@@ -257,6 +257,63 @@ describe('dashboard page initial layout', () => {
     expect(await screen.findByTestId('dashboard-item')).toHaveAttribute('data-dashboard-id', 'systemInfo')
   })
 
+  it('applies the shared remote order before profile validation settles', async () => {
+    const remoteOrder = deferred<unknown>()
+    const remoteProfile = deferred<unknown>()
+    const enabled = {
+      ...enabledOnlySystemInfo,
+      quickActions: true,
+      recentImports: true,
+    }
+    localStorage.setItem(
+      'MP_DASHBOARD_GRID_LAYOUT',
+      JSON.stringify({
+        enabled,
+        items: {},
+        updatedAt: 10,
+      }),
+    )
+    localStorage.setItem(
+      'MP_DASHBOARD_ORDER',
+      JSON.stringify([
+        { id: 'systemInfo', key: '' },
+        { id: 'recentImports', key: '' },
+        { id: 'quickActions', key: '' },
+      ]),
+    )
+    mocks.apiGet.mockImplementation((url: string) => {
+      if (url === '/user/config/DashboardOrder') return remoteOrder.promise
+      if (url === '/user/config/DashboardGridLayout') return remoteProfile.promise
+      if (url === '/plugin/dashboard/meta') return []
+      throw new Error('Unexpected GET ' + url)
+    })
+
+    await renderDashboard()
+    expect(screen.getAllByTestId('dashboard-item').map(item => item.getAttribute('data-dashboard-id'))).toEqual([
+      'systemInfo',
+      'recentImports',
+      'quickActions',
+    ])
+
+    remoteOrder.resolve({
+      data: {
+        value: [
+          { id: 'quickActions', key: '' },
+          { id: 'recentImports', key: '' },
+          { id: 'systemInfo', key: '' },
+        ],
+      },
+    })
+
+    await waitFor(() =>
+      expect(screen.getAllByTestId('dashboard-item').map(item => item.getAttribute('data-dashboard-id'))).toEqual([
+        'quickActions',
+        'recentImports',
+        'systemInfo',
+      ]),
+    )
+  })
+
   it('prepares an automatic card with its last measured profile height without making it manual', async () => {
     const remoteOrder = deferred<unknown>()
     const remoteProfile = deferred<unknown>()
@@ -296,6 +353,7 @@ describe('dashboard page initial layout', () => {
   })
 
   it('applies a newer remote profile and refreshes the local first-frame cache', async () => {
+    const remoteProfile = deferred<unknown>()
     localStorage.setItem(
       'MP_DASHBOARD_GRID_LAYOUT',
       JSON.stringify({
@@ -308,17 +366,7 @@ describe('dashboard page initial layout', () => {
       if (url === '/user/config/DashboardOrder') {
         return { data: { value: [{ id: 'quickActions', key: '' }] } }
       }
-      if (url === '/user/config/DashboardGridLayout') {
-        return {
-          data: {
-            value: {
-              enabled: { ...enabledOnlySystemInfo, quickActions: true, systemInfo: false },
-              items: { quickActions: { x: 8, y: 0, w: 4, h: 5 } },
-              updatedAt: 20,
-            },
-          },
-        }
-      }
+      if (url === '/user/config/DashboardGridLayout') return remoteProfile.promise
       if (url === '/plugin/dashboard/meta') return []
       throw new Error('Unexpected GET ' + url)
     })
@@ -326,6 +374,15 @@ describe('dashboard page initial layout', () => {
     await renderDashboard()
 
     expect(screen.getByTestId('dashboard-item')).toHaveAttribute('data-dashboard-id', 'systemInfo')
+    remoteProfile.resolve({
+      data: {
+        value: {
+          enabled: { ...enabledOnlySystemInfo, quickActions: true, systemInfo: false },
+          items: { quickActions: { x: 8, y: 0, w: 4, h: 5 } },
+          updatedAt: 20,
+        },
+      },
+    })
     await waitFor(() =>
       expect(screen.getByTestId('dashboard-item')).toHaveAttribute('data-dashboard-id', 'quickActions'),
     )

--- a/src/pages/dashboard.vue
+++ b/src/pages/dashboard.vue
@@ -25,9 +25,7 @@ const { t } = useI18n()
 const { appMode } = usePWA()
 const display = useDisplay()
 const userStore = useUserStore()
-const userPermissionContext = computed(() =>
-  buildUserPermissionContext(userStore.superUser, userStore.permissions),
-)
+const userPermissionContext = computed(() => buildUserPermissionContext(userStore.superUser, userStore.permissions))
 const canAdmin = computed(() => hasPermission(userPermissionContext.value, 'admin'))
 const canDiscovery = computed(() => hasPermission(userPermissionContext.value, 'discovery'))
 
@@ -45,6 +43,7 @@ const DASHBOARD_GRID_CONTENT_RESIZE_THRESHOLD = 4
 const DASHBOARD_ENABLE_STORAGE_KEY = 'MP_DASHBOARD'
 const DASHBOARD_ORDER_STORAGE_KEY = 'MP_DASHBOARD_ORDER'
 const DASHBOARD_GRID_LAYOUT_STORAGE_KEY_PREFIX = 'MP_DASHBOARD_GRID_LAYOUT'
+const DASHBOARD_GRID_AUTO_HEIGHT_STORAGE_KEY_PREFIX = 'MP_DASHBOARD_GRID_AUTO_HEIGHTS'
 const DASHBOARD_ENABLE_CONFIG_KEY = 'Dashboard'
 const DASHBOARD_ORDER_CONFIG_KEY = 'DashboardOrder'
 const DASHBOARD_GRID_LAYOUT_CONFIG_KEY = 'DashboardGridLayout'
@@ -53,6 +52,7 @@ const DASHBOARD_GRID_LAYOUT_CONFIG_KEY_PREFIX = 'DashboardGridLayout'
 type DashboardEnableConfig = Record<string, boolean>
 type DashboardOrderConfig = { id: string; key: string }[]
 type DashboardGridLayoutConfig = Record<string, DashboardGridLayoutItem>
+type DashboardGridAutoHeightConfig = Record<string, number>
 type DashboardConfigNormalizer<T> = (value: unknown) => T | undefined
 type DashboardConfigRemoteValueBuilder<T> = (value: T) => unknown
 type DashboardLayoutProfile = 'desktop' | 'tablet' | 'mobile'
@@ -97,6 +97,9 @@ interface DashboardGridItem {
 // 是否处于仪表板布局编辑模式
 const isLayoutEditing = ref(false)
 
+// 首次布局完成后触发轻量整体入场，不延迟或隐藏渐进渲染内容。
+const isDashboardGridRevealed = ref(false)
+
 // 是否发送请求的总开关
 const isRequest = ref(true)
 
@@ -121,6 +124,9 @@ const isPersistingDashboardGridLayoutFromGrid = ref(false)
 // 仪表板本地布局覆盖配置
 const dashboardGridLayout = ref<DashboardGridLayoutConfig>({})
 
+// 当前设备档位最近一次测得的自动行高，仅作为下次首屏预排提示，不改变手动高度语义。
+const dashboardGridAutoHeights = shallowRef<DashboardGridAutoHeightConfig>({})
+
 // 最近一次已确认持久化的仪表板布局，用于编辑模式下避开临时布局草稿。
 let persistedDashboardGridLayout: DashboardGridLayoutConfig = {}
 
@@ -141,9 +147,13 @@ const dashboardGridObservedContentHeights = new Map<string, number>()
 let dashboardGridContentObserver: ResizeObserver | null = null
 let dashboardGridContentResizeFrame: number | null = null
 let dashboardGridResizeRefreshFrame: number | null = null
+let dashboardGridAnimationFrame: number | null = null
+let dashboardGridEntranceFrame: number | null = null
 let dashboardRevealFrame: number | null = null
 let isDashboardRevealPending = false
 let dashboardProfileSaveQueue = Promise.resolve()
+// 档位切换必须等目标配置就绪后一次性重建，避免响应式列变化与 Vue 深度监听交叉改写节点。
+let isSwitchingDashboardLayoutProfile = false
 // 标记最近一次响应式档位切换，避免快速缩放时较早的异步配置覆盖最新档位。
 let dashboardLayoutProfileSwitchId = 0
 
@@ -368,14 +378,43 @@ function scheduleDashboardReveal() {
     syncDashboardFillContentState()
     resizeAutoDashboardItemsToContent()
 
-    if (typeof window === 'undefined') {
-      return
-    }
+    if (typeof window === 'undefined') return
 
     dashboardRevealFrame = window.requestAnimationFrame(() => {
       dashboardRevealFrame = null
       notifyDashboardContentResize()
     })
+  })
+}
+
+// 首次 GridStack 坐标提交后的下一帧立即入场，不等待卡片内部异步数据。
+function scheduleDashboardGridEntrance() {
+  if (isDashboardGridRevealed.value || dashboardGridEntranceFrame !== null || typeof window === 'undefined') return
+
+  dashboardGridEntranceFrame = requestAnimationFrame(() => {
+    dashboardGridEntranceFrame = null
+    isDashboardGridRevealed.value = true
+  })
+}
+
+// 程序化批量布局不播放中间态；稳定后恢复用户拖拽、缩放和让位动画。
+function pauseDashboardGridAnimation() {
+  if (dashboardGridAnimationFrame !== null) {
+    cancelAnimationFrame(dashboardGridAnimationFrame)
+    dashboardGridAnimationFrame = null
+  }
+  dashboardGrid.value?.setAnimation(false)
+}
+
+// 动画恢复延后一帧，确保 GridStack 已提交最终坐标后才重新响应交互。
+function scheduleDashboardGridAnimationResume() {
+  if (typeof window === 'undefined') return
+  if (dashboardGridAnimationFrame !== null) cancelAnimationFrame(dashboardGridAnimationFrame)
+
+  dashboardGridAnimationFrame = requestAnimationFrame(() => {
+    dashboardGridAnimationFrame = null
+    const reduceMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false
+    dashboardGrid.value?.setAnimation(!reduceMotion)
   })
 }
 
@@ -487,6 +526,19 @@ function normalizeDashboardGridLayout(value: unknown): DashboardGridLayoutConfig
   })
 
   return normalizedLayout
+}
+
+// 校验本地自动行高提示，异常或过期字段不得进入 GridStack 首屏配置。
+function normalizeDashboardGridAutoHeightConfig(value: unknown): DashboardGridAutoHeightConfig | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined
+
+  return Object.entries(value).reduce<DashboardGridAutoHeightConfig>((config, [id, height]) => {
+    if (!id || !Number.isFinite(Number(height))) return config
+
+    config[id] = clampGridNumber(height, 1, 96, DASHBOARD_GRID_FALLBACK_ROWS)
+
+    return config
+  }, {})
 }
 
 // 校验并归一化单个设备档位的仪表盘配置，兼容旧版只保存 Grid 布局的数据。
@@ -601,6 +653,13 @@ function getDashboardGridLayoutStorageKey(profile: DashboardLayoutProfile) {
   return `${DASHBOARD_GRID_LAYOUT_STORAGE_KEY_PREFIX}_${profile.toUpperCase()}`
 }
 
+// 自动行高提示按设备档位隔离，避免桌面内容密度覆盖手机和平板的首屏尺寸。
+function getDashboardGridAutoHeightStorageKey(profile: DashboardLayoutProfile) {
+  if (profile === 'desktop') return DASHBOARD_GRID_AUTO_HEIGHT_STORAGE_KEY_PREFIX
+
+  return `${DASHBOARD_GRID_AUTO_HEIGHT_STORAGE_KEY_PREFIX}_${profile.toUpperCase()}`
+}
+
 // 获取布局档位对应的用户配置键，桌面沿用旧键以兼容已同步配置。
 function getDashboardGridLayoutConfigKey(profile: DashboardLayoutProfile) {
   if (profile === 'desktop') return DASHBOARD_GRID_LAYOUT_CONFIG_KEY
@@ -668,6 +727,46 @@ function readLocalDashboardConfig<T>(storageKey: string, normalize: DashboardCon
 // 将仪表板配置写入本地存储，保留离线和接口失败时的兜底能力。
 function saveLocalDashboardConfig(storageKey: string, value: unknown) {
   localStorage.setItem(storageKey, JSON.stringify(value))
+}
+
+// 将同一份配置状态应用到首屏预水合和远端校验结果，保证两条路径的排序与迁移语义一致。
+function applyDashboardConfig(
+  profileConfig: DashboardProfileConfig | undefined,
+  legacyEnable: DashboardEnableConfig | undefined,
+  order: DashboardOrderConfig | undefined,
+) {
+  if (order !== undefined) {
+    orderConfig.value = order
+  }
+
+  const loadedLayout = profileConfig?.items ?? {}
+  dashboardGridLayout.value = loadedLayout
+  persistedDashboardGridLayout = cloneDashboardGridLayout(loadedLayout)
+  isDashboardGridLayoutResetDraft.value = false
+  enableConfig.value = mergeDashboardEnableConfig(profileConfig?.enabled ?? legacyEnable)
+  sortDashboardConfigs()
+}
+
+// setup 阶段同步恢复当前设备档位，缓存命中时第一帧直接使用用户实际布局和显示项。
+function hydrateDashboardConfigFromLocal() {
+  dashboardLayoutProfile.value = resolveDashboardLayoutProfile()
+  const profileConfig = readLocalDashboardConfig(
+    getDashboardGridLayoutStorageKey(dashboardLayoutProfile.value),
+    normalizeDashboardProfileConfig,
+  )
+  const legacyEnable =
+    profileConfig?.enabled === undefined
+      ? readLocalDashboardConfig(DASHBOARD_ENABLE_STORAGE_KEY, normalizeDashboardEnableConfig)
+      : undefined
+  const order = readLocalDashboardConfig(DASHBOARD_ORDER_STORAGE_KEY, normalizeDashboardOrderConfig)
+  dashboardGridAutoHeights.value =
+    readLocalDashboardConfig(
+      getDashboardGridAutoHeightStorageKey(dashboardLayoutProfile.value),
+      normalizeDashboardGridAutoHeightConfig,
+    ) ?? {}
+  applyDashboardConfig(profileConfig, legacyEnable, order)
+
+  return profileConfig !== undefined
 }
 
 // 将仪表板配置写入用户配置，用于跨浏览器共享。
@@ -757,7 +856,7 @@ function getDefaultDashboardGridWidth(item: DashboardItem) {
   if (profile === 'mobile') return 1
 
   const columns = getDashboardGridColumnsForProfile(profile)
-  const requestedWidth = profile === 'tablet' ? item.cols?.sm ?? item.cols?.md : item.cols?.md ?? item.cols?.cols
+  const requestedWidth = profile === 'tablet' ? (item.cols?.sm ?? item.cols?.md) : (item.cols?.md ?? item.cols?.cols)
 
   return clampGridNumber(requestedWidth, 1, columns, columns)
 }
@@ -773,7 +872,8 @@ function buildDashboardGridWidget(item: DashboardItem, id: string): GridStackWid
   const defaultLayout = dashboardLayoutProfile.value === 'desktop' ? DASHBOARD_DESKTOP_DEFAULT_LAYOUT[id] : undefined
   const gridColumns = getDashboardGridColumnsForProfile(dashboardLayoutProfile.value)
   const width = savedLayout?.w ?? defaultLayout?.w ?? getDefaultDashboardGridWidth(item)
-  const height = savedLayout?.h ?? defaultLayout?.h ?? getDefaultDashboardGridRows(item)
+  const height =
+    savedLayout?.h ?? dashboardGridAutoHeights.value[id] ?? defaultLayout?.h ?? getDefaultDashboardGridRows(item)
   const normalizedWidth = clampGridNumber(width, 1, gridColumns, gridColumns)
   const widget: GridStackWidget = {
     id,
@@ -922,30 +1022,28 @@ function toggleDashboardLayoutEditing() {
 
 // 加载用户监控面板配置，优先使用服务端用户配置以支持跨浏览器同步。
 async function loadDashboardConfig() {
-  dashboardLayoutProfile.value = resolveDashboardLayoutProfile()
-  // 顺序配置
-  const order = await loadSharedDashboardConfig(
-    DASHBOARD_ORDER_CONFIG_KEY,
-    DASHBOARD_ORDER_STORAGE_KEY,
-    normalizeDashboardOrderConfig,
-  )
-  if (order !== undefined) {
-    orderConfig.value = order
+  const profile = resolveDashboardLayoutProfile()
+  const profileSwitchId = dashboardLayoutProfileSwitchId
+  dashboardLayoutProfile.value = profile
+  // 顺序和当前设备档位互不依赖，并行校验可缩短无本地缓存时的首屏等待时间。
+  const [order, profileConfig] = await Promise.all([
+    loadSharedDashboardConfig(DASHBOARD_ORDER_CONFIG_KEY, DASHBOARD_ORDER_STORAGE_KEY, normalizeDashboardOrderConfig),
+    loadDashboardProfileConfig(profile),
+  ])
+  if (profileSwitchId !== dashboardLayoutProfileSwitchId || dashboardLayoutProfile.value !== profile) {
+    if (order !== undefined) {
+      orderConfig.value = order
+      sortDashboardConfigs()
+    }
+    return
   }
-  // 设备档位配置同时承载 Grid 布局和显示项，显示项缺失时从旧版全局配置迁移。
-  const profileConfig = await loadDashboardProfileConfig(dashboardLayoutProfile.value)
+
   const legacyEnable = profileConfig?.enabled === undefined ? await loadLegacyDashboardEnableConfig() : undefined
-  const loadedLayout = profileConfig?.items ?? {}
-  dashboardGridLayout.value = loadedLayout
-  persistedDashboardGridLayout = cloneDashboardGridLayout(loadedLayout)
-  isDashboardGridLayoutResetDraft.value = false
-  enableConfig.value = mergeDashboardEnableConfig(profileConfig?.enabled ?? legacyEnable)
+  if (profileSwitchId !== dashboardLayoutProfileSwitchId || dashboardLayoutProfile.value !== profile) return
+
+  applyDashboardConfig(profileConfig, legacyEnable, order)
   if (profileConfig?.enabled === undefined && legacyEnable !== undefined) {
     await saveDashboardProfileConfig()
-  }
-  // 排序
-  if (orderConfig.value) {
-    sortDashboardConfigs()
   }
 }
 
@@ -1084,18 +1182,9 @@ function initializeDashboardGrid() {
 
   dashboardGrid.value = GridStack.init(
     {
-      animate: true,
+      animate: false,
       cellHeight: DASHBOARD_GRID_CELL_HEIGHT,
-      column: DASHBOARD_GRID_COLUMNS,
-      columnOpts: {
-        breakpointForWindow: true,
-        breakpoints: [
-          { w: DASHBOARD_GRID_MOBILE_BREAKPOINT, c: 1, layout: 'list' },
-          { w: DASHBOARD_GRID_TABLET_BREAKPOINT, c: 6, layout: 'moveScale' },
-          { w: DASHBOARD_GRID_DESKTOP_BREAKPOINT, c: DASHBOARD_GRID_COLUMNS, layout: 'moveScale' },
-        ],
-        layout: 'moveScale',
-      },
+      column: getDashboardGridColumnsForProfile(dashboardLayoutProfile.value),
       draggable: {
         cancel: 'input,textarea,button,select,option,a,.dashboard-grid-no-drag',
         handle: '.dashboard-grid-drag-handle',
@@ -1130,18 +1219,29 @@ function updateDashboardGridEditableState(editable: boolean) {
 }
 
 // 将 Vue 渲染出的仪表板节点同步注册到 GridStack。
-async function syncDashboardGrid() {
+async function syncDashboardGrid(resumeAnimation = true) {
   const grid = dashboardGrid.value
   const gridElement = dashboardGridRef.value
   if (!grid || !gridElement) return
 
+  pauseDashboardGridAnimation()
   isSyncingDashboardGrid.value = true
   await nextTick()
   syncDashboardFillContentState()
 
   const items = dashboardGridItems.value
   const itemMap = new Map(items.map(item => [item.id, item]))
-  const elements = Array.from(gridElement.querySelectorAll<GridItemHTMLElement>('.dashboard-grid-item'))
+  const elements = Array.from(gridElement.querySelectorAll<GridItemHTMLElement>('.dashboard-grid-item')).sort(
+    (a, b) => {
+      const aWidget = itemMap.get(a.getAttribute('gs-id') ?? '')?.widget
+      const bWidget = itemMap.get(b.getAttribute('gs-id') ?? '')?.widget
+
+      return (
+        (aWidget?.y ?? Number.MAX_SAFE_INTEGER) - (bWidget?.y ?? Number.MAX_SAFE_INTEGER) ||
+        (aWidget?.x ?? Number.MAX_SAFE_INTEGER) - (bWidget?.x ?? Number.MAX_SAFE_INTEGER)
+      )
+    },
+  )
 
   try {
     grid.batchUpdate()
@@ -1167,7 +1267,11 @@ async function syncDashboardGrid() {
         delete widget.x
         delete widget.y
       }
-      if (element.gridstackNode && !hasManualDashboardGridHeight(id)) {
+      if (
+        element.gridstackNode &&
+        !hasManualDashboardGridHeight(id) &&
+        Object.keys(dashboardGridLayout.value).length > 0
+      ) {
         widget.h = element.gridstackNode.h
       }
 
@@ -1179,6 +1283,11 @@ async function syncDashboardGrid() {
     })
 
     grid.batchUpdate(false)
+    // 完整 profile 由 GridStack 按坐标统一恢复，避免逐个注册时的 DOM 顺序污染跨列和响应式布局。
+    grid.load(
+      items.map(item => ({ ...item.widget })),
+      false,
+    )
     updateDashboardGridEditableState(isLayoutEditing.value)
     syncDashboardFillContentState()
     observeDashboardGridContent()
@@ -1187,8 +1296,10 @@ async function syncDashboardGrid() {
       resizeAutoDashboardItemsToContent()
       scheduleDashboardReveal()
     })
+    scheduleDashboardGridEntrance()
   } finally {
     isSyncingDashboardGrid.value = false
+    if (resumeAnimation) scheduleDashboardGridAnimationResume()
   }
 }
 
@@ -1261,7 +1372,15 @@ function scheduleDashboardItemContentResize(element: GridItemHTMLElement) {
 function resizeDashboardItemToContent(element: GridItemHTMLElement) {
   const grid = dashboardGrid.value
   const id = element.getAttribute('gs-id') ?? ''
-  if (!grid || !id || isLayoutEditing.value || isDashboardGridResizing.value || hasManualDashboardGridHeight(id)) return
+  if (
+    !grid ||
+    !id ||
+    isSwitchingDashboardLayoutProfile ||
+    isLayoutEditing.value ||
+    isDashboardGridResizing.value ||
+    hasManualDashboardGridHeight(id)
+  )
+    return
 
   syncDashboardFillContentState(element)
   const shouldMeasureFillContent = element.classList.contains('has-fill-content')
@@ -1271,6 +1390,18 @@ function resizeDashboardItemToContent(element: GridItemHTMLElement) {
 
   try {
     grid.resizeToContent(element)
+    const measuredHeight = element.gridstackNode?.h
+    if (
+      measuredHeight !== undefined &&
+      measuredHeight !== dashboardGridAutoHeights.value[id] &&
+      Number.isFinite(measuredHeight)
+    ) {
+      dashboardGridAutoHeights.value[id] = clampGridNumber(measuredHeight, 1, 96, getDefaultDashboardGridRows())
+      saveLocalDashboardConfig(
+        getDashboardGridAutoHeightStorageKey(dashboardLayoutProfile.value),
+        dashboardGridAutoHeights.value,
+      )
+    }
   } finally {
     if (shouldMeasureFillContent) {
       element.classList.remove('is-measuring-content')
@@ -1410,7 +1541,7 @@ watch(
   dashboardGridItems,
   () => {
     syncDashboardLoadedItemIds()
-    if (!isPersistingDashboardGridLayoutFromGrid.value) {
+    if (!isSwitchingDashboardLayoutProfile && !isPersistingDashboardGridLayoutFromGrid.value) {
       syncDashboardGrid()
     }
     scheduleDashboardReveal()
@@ -1426,31 +1557,63 @@ watch(
 
     // GridStack 可能已先完成列数压缩；档位切换只读取目标配置，不能保存当前自动重排结果。
     const profileSwitchId = ++dashboardLayoutProfileSwitchId
+    isSwitchingDashboardLayoutProfile = true
     dashboardLayoutProfile.value = nextProfile
-    const profileConfig = await loadDashboardProfileConfig(nextProfile)
-    if (profileSwitchId !== dashboardLayoutProfileSwitchId || dashboardLayoutProfile.value !== nextProfile) return
+    try {
+      const localProfileConfig = readLocalDashboardConfig(
+        getDashboardGridLayoutStorageKey(nextProfile),
+        normalizeDashboardProfileConfig,
+      )
+      const localLegacyEnable =
+        localProfileConfig?.enabled === undefined
+          ? readLocalDashboardConfig(DASHBOARD_ENABLE_STORAGE_KEY, normalizeDashboardEnableConfig)
+          : undefined
+      const nextAutoHeights =
+        readLocalDashboardConfig(
+          getDashboardGridAutoHeightStorageKey(nextProfile),
+          normalizeDashboardGridAutoHeightConfig,
+        ) ?? {}
+      dashboardGridAutoHeights.value = nextAutoHeights
+      applyDashboardConfig(localProfileConfig, localLegacyEnable, undefined)
+      updateDashboardSettingsDialog()
+      pauseDashboardGridAnimation()
+      dashboardGrid.value?.column(
+        getDashboardGridColumnsForProfile(nextProfile),
+        getDashboardGridColumnLayout(nextProfile),
+      )
+      dashboardGrid.value?.removeAll(false, false)
+      await syncDashboardGrid(false)
+      scheduleDashboardGridAnimationResume()
+      if (profileSwitchId === dashboardLayoutProfileSwitchId) {
+        isSwitchingDashboardLayoutProfile = false
+      }
 
-    const legacyEnable = profileConfig?.enabled === undefined ? await loadLegacyDashboardEnableConfig() : undefined
-    if (profileSwitchId !== dashboardLayoutProfileSwitchId || dashboardLayoutProfile.value !== nextProfile) return
+      const profileConfig = await loadDashboardProfileConfig(nextProfile)
+      if (profileSwitchId !== dashboardLayoutProfileSwitchId || dashboardLayoutProfile.value !== nextProfile) return
 
-    const loadedLayout = profileConfig?.items ?? {}
-    dashboardGridLayout.value = loadedLayout
-    persistedDashboardGridLayout = cloneDashboardGridLayout(loadedLayout)
-    isDashboardGridLayoutResetDraft.value = false
-    enableConfig.value = mergeDashboardEnableConfig(profileConfig?.enabled ?? legacyEnable)
-    if (profileConfig?.enabled === undefined && legacyEnable !== undefined) {
-      await saveDashboardProfileConfig()
+      const legacyEnable = profileConfig?.enabled === undefined ? await loadLegacyDashboardEnableConfig() : undefined
+      if (profileSwitchId !== dashboardLayoutProfileSwitchId || dashboardLayoutProfile.value !== nextProfile) return
+
+      isSwitchingDashboardLayoutProfile = true
+      applyDashboardConfig(profileConfig, legacyEnable, undefined)
+      if (profileConfig?.enabled === undefined && legacyEnable !== undefined) {
+        await saveDashboardProfileConfig()
+      }
+      updateDashboardSettingsDialog()
+      pauseDashboardGridAnimation()
+      dashboardGrid.value?.removeAll(false, false)
+      await syncDashboardGrid(false)
+      scheduleDashboardGridAnimationResume()
+      notifyDashboardContentResize()
+    } finally {
+      if (profileSwitchId === dashboardLayoutProfileSwitchId) {
+        isSwitchingDashboardLayoutProfile = false
+      }
     }
-    updateDashboardSettingsDialog()
-    dashboardGrid.value?.column(
-      getDashboardGridColumnsForProfile(nextProfile),
-      getDashboardGridColumnLayout(nextProfile),
-    )
-    dashboardGrid.value?.removeAll(false, false)
-    await syncDashboardGrid()
-    notifyDashboardContentResize()
   },
 )
+
+hydrateDashboardConfigFromLocal()
 
 onBeforeMount(async () => {
   await loadDashboardConfig()
@@ -1486,6 +1649,14 @@ onBeforeUnmount(() => {
     cancelAnimationFrame(dashboardGridResizeRefreshFrame)
     dashboardGridResizeRefreshFrame = null
   }
+  if (dashboardGridAnimationFrame !== null) {
+    cancelAnimationFrame(dashboardGridAnimationFrame)
+    dashboardGridAnimationFrame = null
+  }
+  if (dashboardGridEntranceFrame !== null) {
+    cancelAnimationFrame(dashboardGridEntranceFrame)
+    dashboardGridEntranceFrame = null
+  }
   if (dashboardRevealFrame !== null) {
     cancelAnimationFrame(dashboardRevealFrame)
     dashboardRevealFrame = null
@@ -1500,7 +1671,11 @@ onBeforeUnmount(() => {
 
 <template>
   <!-- 仪表板 -->
-  <div ref="dashboardGridRef" class="grid-stack dashboard-grid" :class="{ 'is-editing': isLayoutEditing }">
+  <div
+    ref="dashboardGridRef"
+    class="grid-stack dashboard-grid"
+    :class="{ 'is-editing': isLayoutEditing, 'is-revealed': isDashboardGridRevealed }"
+  >
     <div
       v-for="gridItem in dashboardGridItems"
       :key="gridItem.id"
@@ -1567,11 +1742,17 @@ onBeforeUnmount(() => {
 /* stylelint-disable selector-pseudo-class-no-unknown */
 
 .dashboard-grid {
+  opacity: 0.92;
   pointer-events: auto;
+  transform: translateY(4px);
   transition:
-    opacity 0.45s cubic-bezier(0.25, 1, 0.5, 1),
-    transform 0.45s cubic-bezier(0.25, 1, 0.5, 1);
-  will-change: opacity, transform;
+    opacity 0.18s ease-out,
+    transform 0.18s ease-out;
+}
+
+.dashboard-grid.is-revealed {
+  opacity: 1;
+  transform: none;
 }
 
 .dashboard-grid :deep(.v-card) {
@@ -1652,6 +1833,11 @@ onBeforeUnmount(() => {
 
 .dashboard-grid.is-editing :deep(.v-card) {
   block-size: 100%;
+  min-block-size: 0;
+}
+
+.dashboard-grid-item.is-manual-height :deep(.v-card) {
+  min-block-size: 0;
 }
 
 .dashboard-grid.is-editing :deep(.v-card-text),
@@ -1698,6 +1884,7 @@ onBeforeUnmount(() => {
 
 @media (prefers-reduced-motion: reduce) {
   .dashboard-grid {
+    opacity: 1;
     transform: none;
     transition: none;
   }

--- a/src/pages/dashboard.vue
+++ b/src/pages/dashboard.vue
@@ -154,6 +154,8 @@ let isDashboardRevealPending = false
 let dashboardProfileSaveQueue = Promise.resolve()
 // 档位切换必须等目标配置就绪后一次性重建，避免响应式列变化与 Vue 深度监听交叉改写节点。
 let isSwitchingDashboardLayoutProfile = false
+// 应用档位配置后的首次同步必须恢复缺失覆盖项的默认位置，不能沿用上一份配置的节点坐标。
+let shouldRestoreDashboardGridProfileDefaults = false
 // 标记最近一次响应式档位切换，避免快速缩放时较早的异步配置覆盖最新档位。
 let dashboardLayoutProfileSwitchId = 0
 
@@ -735,6 +737,7 @@ function applyDashboardConfig(
   legacyEnable: DashboardEnableConfig | undefined,
   order: DashboardOrderConfig | undefined,
 ) {
+  shouldRestoreDashboardGridProfileDefaults = true
   if (order !== undefined) {
     orderConfig.value = order
   }
@@ -1224,6 +1227,8 @@ async function syncDashboardGrid(resumeAnimation = true) {
   const gridElement = dashboardGridRef.value
   if (!grid || !gridElement) return
 
+  const restoreProfileDefaults = shouldRestoreDashboardGridProfileDefaults
+  shouldRestoreDashboardGridProfileDefaults = false
   pauseDashboardGridAnimation()
   isSyncingDashboardGrid.value = true
   await nextTick()
@@ -1263,16 +1268,12 @@ async function syncDashboardGrid(resumeAnimation = true) {
       if (!item) return
 
       const widget = { ...item.widget }
-      if (element.gridstackNode && !dashboardGridLayout.value[id]) {
+      if (element.gridstackNode && !dashboardGridLayout.value[id] && !restoreProfileDefaults) {
         delete widget.autoPosition
-        delete widget.x
-        delete widget.y
+        widget.x = element.gridstackNode.x
+        widget.y = element.gridstackNode.y
       }
-      if (
-        element.gridstackNode &&
-        !hasManualDashboardGridHeight(id) &&
-        Object.keys(dashboardGridLayout.value).length > 0
-      ) {
+      if (element.gridstackNode && !hasManualDashboardGridHeight(id)) {
         widget.h = element.gridstackNode.h
       }
       synchronizedWidgets.set(id, widget)

--- a/src/pages/dashboard.vue
+++ b/src/pages/dashboard.vue
@@ -1030,22 +1030,28 @@ async function loadDashboardConfig() {
   const profileSwitchId = dashboardLayoutProfileSwitchId
   dashboardLayoutProfile.value = profile
   // 顺序和当前设备档位互不依赖，并行校验可缩短无本地缓存时的首屏等待时间。
-  const [order, profileConfig] = await Promise.all([
-    loadSharedDashboardConfig(DASHBOARD_ORDER_CONFIG_KEY, DASHBOARD_ORDER_STORAGE_KEY, normalizeDashboardOrderConfig),
-    loadDashboardProfileConfig(profile),
-  ])
+  const orderPromise = loadSharedDashboardConfig(
+    DASHBOARD_ORDER_CONFIG_KEY,
+    DASHBOARD_ORDER_STORAGE_KEY,
+    normalizeDashboardOrderConfig,
+  )
+  const profileConfigPromise = loadDashboardProfileConfig(profile)
+  // 共享顺序不得等待单个档位请求，否则设置保存可能把尚未应用的旧顺序写回服务端。
+  void orderPromise.then(order => {
+    if (order === undefined) return
+
+    orderConfig.value = order
+    sortDashboardConfigs()
+  })
+  const profileConfig = await profileConfigPromise
   if (profileSwitchId !== dashboardLayoutProfileSwitchId || dashboardLayoutProfile.value !== profile) {
-    if (order !== undefined) {
-      orderConfig.value = order
-      sortDashboardConfigs()
-    }
     return
   }
 
   const legacyEnable = profileConfig?.enabled === undefined ? await loadLegacyDashboardEnableConfig() : undefined
   if (profileSwitchId !== dashboardLayoutProfileSwitchId || dashboardLayoutProfile.value !== profile) return
 
-  applyDashboardConfig(profileConfig, legacyEnable, order)
+  applyDashboardConfig(profileConfig, legacyEnable, undefined)
   if (profileConfig?.enabled === undefined && legacyEnable !== undefined) {
     await saveDashboardProfileConfig()
   }

--- a/src/pages/dashboard.vue
+++ b/src/pages/dashboard.vue
@@ -696,7 +696,8 @@ async function loadDashboardProfileConfig(profile: DashboardLayoutProfile) {
       saveLocalDashboardConfig(storageKey, profileConfig)
 
       if (remoteConfig.enabled === undefined && localConfig?.enabled !== undefined) {
-        await queueDashboardProfileRemoteSave(configKey, profileConfig)
+        // 远端布局已是当前权威结果；兼容字段回填失败不能让本次加载退回旧的本地布局。
+        void queueDashboardProfileRemoteSave(configKey, profileConfig).catch(error => console.error(error))
       }
 
       return profileConfig
@@ -1600,7 +1601,8 @@ watch(
       isSwitchingDashboardLayoutProfile = true
       applyDashboardConfig(profileConfig, legacyEnable, undefined)
       if (profileConfig?.enabled === undefined && legacyEnable !== undefined) {
-        await saveDashboardProfileConfig()
+        // 兼容配置的远端回填不得阻塞当前档位重建，否则慢请求会让 Vue 状态和 GridStack 节点暂时分离。
+        void saveDashboardProfileConfig()
       }
       updateDashboardSettingsDialog()
       pauseDashboardGridAnimation()

--- a/src/pages/dashboard.vue
+++ b/src/pages/dashboard.vue
@@ -1231,6 +1231,7 @@ async function syncDashboardGrid(resumeAnimation = true) {
 
   const items = dashboardGridItems.value
   const itemMap = new Map(items.map(item => [item.id, item]))
+  const synchronizedWidgets = new Map<string, GridStackWidget>()
   const elements = Array.from(gridElement.querySelectorAll<GridItemHTMLElement>('.dashboard-grid-item')).sort(
     (a, b) => {
       const aWidget = itemMap.get(a.getAttribute('gs-id') ?? '')?.widget
@@ -1274,6 +1275,7 @@ async function syncDashboardGrid(resumeAnimation = true) {
       ) {
         widget.h = element.gridstackNode.h
       }
+      synchronizedWidgets.set(id, widget)
 
       if (element.gridstackNode) {
         grid.update(element, widget)
@@ -1283,9 +1285,9 @@ async function syncDashboardGrid(resumeAnimation = true) {
     })
 
     grid.batchUpdate(false)
-    // 完整 profile 由 GridStack 按坐标统一恢复，避免逐个注册时的 DOM 顺序污染跨列和响应式布局。
+    // 完整档位布局由 GridStack 按坐标统一恢复，避免逐个注册时的页面节点顺序污染跨列和响应式布局。
     grid.load(
-      items.map(item => ({ ...item.widget })),
+      items.map(item => ({ ...(synchronizedWidgets.get(item.id) ?? item.widget) })),
       false,
     )
     updateDashboardGridEditableState(isLayoutEditing.value)


### PR DESCRIPTION
## 问题与背景

仪表盘冷启动时会先显示默认卡片布局，再切换到用户保存的布局和实际内容高度，导致卡片明显跳动。生产采样中，桌面冷载 CLS（累积布局偏移）曾达到 `0.2792`，移动端达到 `0.8362`。

响应式切换还可能出现“推荐媒体”移动到第一项、返回宽屏后排列与初始状态不一致的问题。编辑模式缩小卡片时，卡片自身的最小高度也可能越过 GridStack 外框，造成内容错位。

## 原因分析

- 用户布局和显示项需要等待异步配置请求，首帧只能按默认配置渲染。
- GridStack（仪表盘网格布局组件）逐项注册节点时会根据页面节点顺序自动占位，完整坐标稍后到达后再次重排。
- GridStack 自动断点和 Vue 的桌面、平板、移动档位切换同时管理响应式布局，切换过程中会短暂提交不同档位的中间状态。
- 自动高度没有作为下一次首屏预排提示保存，异步内容完成后需要再次调整网格高度。
- 编辑和手动高度卡片继承了内容组件的最小高度，用户缩小外框后内容仍可能撑开卡片。
- 旧格式档位配置迁移会等待远端保存完成后才重建网格，慢请求期间 Vue 卡片状态与 GridStack 节点可能暂时不一致。
- 共享的卡片顺序和当前设备档位配置虽然并行请求，但原实现等待两者全部完成后才应用；当顺序已返回而档位请求持续缓慢时，页面仍保留旧顺序，期间保存设置还可能把旧顺序写回服务端。

## 解决方案

- 在页面初始化阶段同步恢复当前设备档位的本地布局、显示项、顺序和自动高度提示，让缓存命中时首帧直接使用用户布局。
- 对远端配置继续进行异步校验，并通过异步请求代次保护忽略已经过期的档位响应，避免桌面冷载响应覆盖切换后的移动布局。
- 保持共享顺序与档位配置并行加载，但让共享顺序在返回后立即独立应用；档位代次校验只约束对应档位配置，慢档位请求不再阻塞顺序同步。
- 按目标坐标顺序注册节点，再通过 `grid.load()` 一次性提交完整布局，避免页面节点顺序影响最终坐标。
- 批量提交布局时沿用当前节点已经测得的自动高度，进入编辑模式不会回退到陈旧的首屏高度提示。
- 服务端清空布局覆盖时恢复目标档位的默认坐标；后续普通同步显式保留当前节点坐标，避免 GridStack 对缺少坐标的节点再次自动排位。
- 由 Vue 统一管理桌面、平板、移动档位；程序化重建期间暂停 GridStack 动画，最终坐标提交后恢复拖拽、缩放和卡片让位动画。
- 旧格式配置迁移先同步写入本地缓存，再在后台回填服务端，不让网络保存阻塞当前档位的必要重建。
- 首屏保留 `180 ms` 的轻量整体入场，并遵守系统的“减少动态效果”偏好；不引入骨架屏或永久的 CSS 合成优化提示（`will-change`）。
- 编辑和手动高度卡片允许内容跟随 GridStack 外框收缩，避免越界覆盖相邻卡片。

## 前后对比

| 场景 | 优化前 | 优化后 |
| --- | --- | --- |
| 桌面冷载 | 生产观测 CLS（累积布局偏移）为 `0.2792`，首帧默认布局随后切换到用户布局 | 本地有效前台采样三次 CLS 均为 `0.000590`，三轮卡片坐标一致 |
| 移动冷载 | 生产观测 CLS 为 `0.8362`，卡片存在明显纵向重排 | 本地有效前台采样为 `0.003623 / 0.003623 / 0.003624`，首屏坐标稳定 |
| 宽屏 -> 移动 -> 宽屏 | GridStack 自动断点与 Vue 档位切换竞争，“推荐媒体”可能移动到第一项或无法恢复原位 | Vue 单独管理档位，移动端首个 `50 ms` 采样点已稳定，返回宽屏后恢复原坐标 |
| 编辑缩放 | 卡片内容最小高度可能越过缩小后的 GridStack 外框，出现错位或覆盖 | “近期整理”从 `3 x 14` 缩到 `2 x 6` 后仍受外框约束，不覆盖相邻组件 |
| 动画体感 | 程序化布局重建会暴露中间坐标变化，完全关闭动画又会降低交互反馈 | 程序化重建不播放中间态，首屏保留轻量整体入场，拖拽、缩放和让位动画在稳定后恢复 |

CLS 数据分别来自生产问题基线和优化后的本地有效前台采样，用于说明问题量级与收敛效果；由于运行环境不同，不作为严格的同环境实验对照。

## 影响与风险

- 不修改后端接口、服务端配置结构或用户现有布局字段，不需要数据迁移、清理缓存或重新配置仪表盘。
- 自动高度只作为按设备档位隔离的本地首屏提示，不改变用户手动高度的持久化语义。
- 普通主题和透明主题继续使用原有透明度与模糊策略；本改动不增加永久合成层。
- 无本地缓存时仍保留默认卡片的渐进显示，避免为了等待远端配置而显示空白或全屏骨架。
- 共享顺序独立于设备档位立即生效，避免慢档位请求期间的旧顺序显示及旧顺序回写；档位配置仍受代次校验保护。
- 本地与远端布局完全相同时仍会执行一次不删除页面节点、无动画的 GridStack 校验重建；当前运行态未观察到可见位移或长任务，因此未在本次拉取请求（PR）扩大处理范围。
- 兼容迁移的服务端回填失败仍沿用既有本地缓存兜底；当前页面布局不再等待该请求完成。

## 验证

- `yarn test:run`：58 个测试文件、638 个测试通过。
- `yarn test:coverage`：58 个测试文件、638 个测试均通过；命令最终被上游基线已有的三个无关文件覆盖率门槛拦截，失败数值与上游 PR #570 完全相同，本次拉取请求未降低门槛或修改无关组件。
- `yarn typecheck`
- `yarn lint`
- `yarn lint:suppressions:prune`
- `yarn format:check`
- `yarn build`
- `git diff --check`
- 轻量入场和交互动画定稿后的有效前台采样中，桌面三次冷载 CLS 均为 `0.000590`；移动三次为 `0.003623 / 0.003623 / 0.003624`，三轮卡片坐标一致。该采样早于最后一次响应式职责收敛，最新代码的自然前台 CLS 随维护者视觉验收复核。
- 宽屏切换移动端再返回宽屏时，移动档位在首个 `50 ms` 采样点已稳定，返回后“推荐媒体”“内存”和“近期整理”恢复到原坐标。
- 编辑模式将“近期整理”从 `3 x 14` 缩放到 `2 x 6`，卡片高度受 GridStack 外框约束，没有覆盖相邻组件。
- 普通主题和透明轻量主题均渲染 10 张卡片，无坐标重叠或新增控制台错误。
- 回归测试确认：服务端清空布局覆盖后连续同步均保持默认坐标；空布局进入编辑模式仍保留实时自动高度；旧格式档位迁移的远端保存未完成时，目标档位网格已经完成重建；兼容回填失败时仍应用远端较新布局；共享顺序已返回而档位请求保持未完成时，页面立即应用新顺序。

## PR-Agent（自动代码评审）摘要

<!-- pr-agent-summary:start -->
### 由 PR-Agent 自动生成，基于提交 `ac7c7725`

- 稳定仪表盘首屏与响应式布局
- 本地预加载档位布局和自动高度
- 批量恢复坐标，避免重排跳动
- 共享顺序返回后立即独立应用
- 覆盖缓存、迁移、顺序和档位切换测试
<!-- pr-agent-summary:end -->
