### PR TITLE
fix(mobile): 修复移动端 TMDB 搜索图标不可见及弹窗交互问题

### DIFF
--- a/src/components/dialog/AddDownloadDialog.vue
+++ b/src/components/dialog/AddDownloadDialog.vue
@@ -280,6 +280,7 @@ onMounted(() => {
           <VCol cols="12">
             <VTextField
               v-model="mediaId"
+              class="app-responsive-input--keep-append-action"
               :label="mediaIdLabel"
               :placeholder="t('dialog.reorganize.mediaIdPlaceholder')"
               :rules="[numberValidator]"

--- a/src/components/dialog/AddSubtitleDownloadDialog.vue
+++ b/src/components/dialog/AddSubtitleDownloadDialog.vue
@@ -232,6 +232,7 @@ onMounted(() => {
           <VCol cols="12">
             <VTextField
               v-model="mediaId"
+              class="app-responsive-input--keep-append-action"
               :label="mediaIdLabel"
               :placeholder="t('dialog.reorganize.mediaIdPlaceholder')"
               :rules="[numberValidator]"

--- a/src/components/dialog/ReorganizeDialog.vue
+++ b/src/components/dialog/ReorganizeDialog.vue
@@ -1451,6 +1451,7 @@ onUnmounted(() => {
                   <VCol cols="12" md="4">
                     <VTextField
                       v-model="transferForm.media_id"
+                      class="app-responsive-input--keep-append-action"
                       :disabled="transferForm.type_name === ''"
                       :label="mediaIdLabel"
                       :placeholder="t('dialog.reorganize.mediaIdPlaceholder')"

--- a/src/components/dialog/ScrapeDialog.vue
+++ b/src/components/dialog/ScrapeDialog.vue
@@ -147,6 +147,7 @@ watch(mediaSource, () => {
           <VCol cols="12" md="4">
             <VTextField
               v-model="mediaId"
+              class="app-responsive-input--keep-append-action"
               :disabled="mediaType === ''"
               :label="mediaIdLabel"
               :placeholder="t('dialog.reorganize.mediaIdPlaceholder')"

--- a/src/components/misc/MediaIdSelector.vue
+++ b/src/components/misc/MediaIdSelector.vue
@@ -105,29 +105,32 @@ onMounted(() => {
 
 <template>
   <VCard class="mx-auto" width="100%">
-    <VToolbar flat class="p-0">
+    <VCardTitle class="d-flex align-center justify-space-between">
+      <span>{{ t('dialog.reorganize.mediaSearchInput') }}</span>
+      <VDialogCloseBtn
+        inner-class="static"
+        @click="
+          () => {
+            emit('close')
+          }
+        "
+      />
+    </VCardTitle>
+    <VCardText class="pt-0">
       <VTextField
         ref="inputKeyword"
         v-model="keyword"
-        :label="t('dialog.reorganize.mediaSearchInput')"
+        :mobile-layout="false"
         single-line
         :placeholder="t('dialog.reorganize.mediaSearchPlaceholder')"
         variant="solo"
-        prepend-inner-icon="mdi-magnify"
+        append-inner-icon="mdi-magnify"
         flat
-        class="mx-1"
         :loading="loading"
         @click:append-inner="searchMedias"
         @keydown.enter="searchMedias"
       />
-    </VToolbar>
-    <VDialogCloseBtn
-      @click="
-        () => {
-          emit('close')
-        }
-      "
-    />
+    </VCardText>
     <VDivider />
     <VList v-if="items.length > 0" lines="three">
       <template v-for="(item, i) in items" :key="i">

--- a/src/styles/common.scss
+++ b/src/styles/common.scss
@@ -558,6 +558,12 @@ html[data-theme-radius='extra'] {
   display: none;
 }
 
+// 少数字段的内嵌图标承担了唯一的交互入口（如按名称搜索媒体编号），
+// 不是纯装饰，移动端也需要保留可点击。
+.app-responsive-input--keep-append-action .app-responsive-input__native .v-field__append-inner {
+  display: inline-flex;
+}
+
 .app-responsive-input--field .v-field,
 .app-responsive-input--multiline .v-field {
   border-radius: var(--app-control-radius) !important;


### PR DESCRIPTION
## 摘要

修复 #567 —— 移动端 TMDB 编号字段旁的搜索图标（用于打开 `MediaIdSelector` 搜索弹窗）不显示，根因并不是 issue 里推测的嵌套全屏对话框层级冲突。

**根因**：项目里有一条全局移动端 CSS 规则，统一隐藏"标签在左、紧凑控件在右"这种响应式输入行内嵌的所有 prepend/append 图标，因为这些图标通常只是装饰。但 TMDB 编号字段的搜索图标不是装饰——它是移动端打开搜索弹窗的唯一入口，被这条"一刀切"规则误伤了。

### 改动内容

1. **图标可见性**（`a0662fa`）：新增一个 `app-responsive-input--keep-append-action` modifier class，让指定字段可以在移动端保留 append-inner 图标的显示。应用到了用同一种"按名称搜索 TMDB 编号"写法的四个字段：`ReorganizeDialog`、`ScrapeDialog`、`AddDownloadDialog`、`AddSubtitleDownloadDialog`。

2. **`MediaIdSelector` 组件本身**（`9637ebc`）在验证过程中又发现两个问题：
   - 这个搜索框其实**根本没有可用的提交按钮**——声明了一个纯装饰的 prepend-inner 图标，却把 `@click:append-inner` 绑在了一个从未声明过的 append-inner 图标上，导致这个事件永远不会触发。搜索唯一能触发的方式是键盘回车。
   - 这个字段还设置了 `label`，导致移动端会被路由进"设置行"两栏布局——但这是弹窗里唯一的主搜索输入框，不应该套用这种给多行堆叠表单字段设计的布局。

   修复方式：给这个字段声明一个真正生效的 append-inner 搜索图标，并用 `mobile-layout="false"` 让它退出移动端两栏布局。这里有一个必须说明的连锁影响：字段一旦恢复全宽显示，就会跟默认绝对定位在卡片右上角的 `VDialogCloseBtn` 撞在一起——这个冲突之前一直被"字段被同一个布局 bug 挤窄"这件事意外挡住了，没有暴露出来。所以把弹窗头部重构成了一个标题行（复用了原本挂在输入框上的 `mediaSearchInput` 文案作为标题），关闭按钮放进这一行正常排布，不再悬浮重叠。

### 验证情况

- `ReorganizeDialog`、`ScrapeDialog`：已经在真实后端 + 移动端宽度下实机验证过（两者都在"文件管理"页面下，验证过程中交换过截图）。
- `AddDownloadDialog`、`AddSubtitleDownloadDialog`：入口在搜索页，由于我的账号未认证，这次没有可用账号访问，无法实机验证。修复依据是代码走查确认这两处用的是完全相同的 `VTextField` 写法、走的是同一套响应式输入适配器——**没有做过实机独立验证**，如实说明，不谎报已验证。
- `npx vitest run`：全量测试通过（666/666）
- `eslint --max-warnings=0`：改动文件全部通过
- `vue-tsc --noEmit`：无类型错误

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 9637ebccdcd5a2792e31ae70b02ac7bc605351e7

- 修复移动端媒体编号搜索入口被隐藏
- 为四处 TMDB 输入框保留搜索图标
- 修正 `MediaIdSelector` 搜索按钮与移动布局
- 改善手机端搜索弹窗可见性和交互
<!-- pr-agent-summary:end -->
