### PR TITLE
perf(glass): complete phase three optimization

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,4 +1,5 @@
 <script lang="ts" setup>
+import { usePreferredReducedMotion } from '@vueuse/core'
 import { useTheme } from 'vuetify'
 import { ensureRenderComplete, removeEl } from './@core/utils/dom'
 import api, { type ConnectionAwareRequestConfig } from '@/api'
@@ -30,7 +31,6 @@ import { commitPreloadedBackgroundRotation } from '@/utils/backgroundRotation'
 
 const LOGIN_WALLPAPER_ROUTE = '/login'
 const BACKGROUND_CROSSFADE_DURATION_MS = 1500
-const MEDIA_DENSE_OPTICAL_DEFER_MS = 1_600
 
 // 生效主题
 const vuetifyTheme = useTheme()
@@ -75,12 +75,13 @@ const activeImageIndex = ref(0)
 const previousImageIndex = ref<number | null>(null)
 const isBackgroundCrossfading = ref(false)
 const { allowsDecorativeMotion, isSuspended: isRenderThrottled, state: appActivityState } = useAppActivityLifecycle()
+const preferredMotion = usePreferredReducedMotion()
+// 壁纸轮播同时服从应用活动状态与系统动态效果偏好。
+const allowsBackgroundRotation = computed(() => allowsDecorativeMotion.value && preferredMotion.value !== 'reduce')
 const isTransparentTheme = computed(() => globalTheme.name.value === 'transparent')
 const isGlassTheme = computed(() => globalTheme.name.value === 'glass')
 const effectiveGlassSettings = useEffectiveGlassSettings()
 const isInitialRouteReady = ref(false)
-const isGlassOpticalLayerDeferred = ref(true)
-let glassOpticalLayerDeferTimer: number | null = null
 const isBackdropTheme = computed(() => isTransparentTheme.value || isGlassTheme.value)
 const isLoginWallpaperRoute = computed(() => !isLogin.value && route.path === LOGIN_WALLPAPER_ROUTE)
 const shouldUseTransparentBackgroundTreatment = computed(() => Boolean(isLogin.value) && isTransparentTheme.value)
@@ -100,7 +101,7 @@ const shouldRenderGlassOpticalLayer = computed(
   () =>
     isGlassTheme.value &&
     effectiveGlassSettings.value.glassQuality !== 'css' &&
-    !isGlassOpticalLayerDeferred.value &&
+    isInitialRouteReady.value &&
     !isRenderThrottled.value &&
     Boolean(activeBackgroundImage.value),
 )
@@ -138,35 +139,6 @@ function handleTransparencySettingsChanged(event: Event) {
 }
 
 applyTransparentBackgroundSettings()
-
-/** 推荐页高质量光学层让首屏海报优先完成解码与合成。 */
-watch(
-  () => [route.fullPath, effectiveGlassSettings.value.glassQuality, isInitialRouteReady.value] as const,
-  ([, quality, routeReady]) => {
-    if (glassOpticalLayerDeferTimer !== null) {
-      window.clearTimeout(glassOpticalLayerDeferTimer)
-      glassOpticalLayerDeferTimer = null
-    }
-
-    // 首次导航完成前 route 仍可能是重定向来源，禁止 renderer 按错误页面短暂挂载。
-    if (!routeReady) {
-      isGlassOpticalLayerDeferred.value = true
-      return
-    }
-
-    if (route.path !== '/recommend' || quality !== 'high') {
-      isGlassOpticalLayerDeferred.value = false
-      return
-    }
-
-    isGlassOpticalLayerDeferred.value = true
-    glassOpticalLayerDeferTimer = window.setTimeout(() => {
-      isGlassOpticalLayerDeferred.value = false
-      glassOpticalLayerDeferTimer = null
-    }, MEDIA_DENSE_OPTICAL_DEFER_MS)
-  },
-  { immediate: true },
-)
 
 void router.isReady().then(() => {
   isInitialRouteReady.value = true
@@ -412,7 +384,7 @@ async function fetchBackgroundImages() {
 
 // 背景图片轮换函数
 function rotateBackgroundImage() {
-  if (!allowsDecorativeMotion.value) return
+  if (!allowsBackgroundRotation.value) return
 
   if (backgroundImages.value.length > 1) {
     // 计算下一个图片索引
@@ -420,7 +392,7 @@ function rotateBackgroundImage() {
     const requestVersion = ++backgroundRotationVersion
 
     void commitPreloadedBackgroundRotation({
-      canCommit: () => allowsDecorativeMotion.value && requestVersion === backgroundRotationVersion,
+      canCommit: () => allowsBackgroundRotation.value && requestVersion === backgroundRotationVersion,
       commit: () => activateBackgroundImage(nextIndex),
       preload: () => preloadImage(backgroundImages.value[nextIndex]),
     })
@@ -437,7 +409,7 @@ function stopBackgroundRotation() {
 function startBackgroundRotation() {
   stopBackgroundRotation()
 
-  if (allowsDecorativeMotion.value && backgroundImages.value.length > 1) {
+  if (allowsBackgroundRotation.value && backgroundImages.value.length > 1) {
     // 使用优化的定时器管理器，后台时自动暂停
     addBackgroundTimer(
       'background-rotation',
@@ -451,10 +423,10 @@ function startBackgroundRotation() {
   }
 }
 
-watch(appActivityState, state => {
+watch(allowsBackgroundRotation, allowsRotation => {
   resetBackgroundCrossfade()
 
-  if (state === 'active') {
+  if (allowsRotation) {
     startBackgroundRotation()
   } else {
     stopBackgroundRotation()
@@ -655,7 +627,6 @@ onMounted(async () => {
 })
 
 onUnmounted(() => {
-  if (glassOpticalLayerDeferTimer !== null) window.clearTimeout(glassOpticalLayerDeferTimer)
   // 清除背景轮换定时器
   stopBackgroundLoading()
   if (authenticatedStateTimer) {

--- a/src/components/cards/MediaCard.vue
+++ b/src/components/cards/MediaCard.vue
@@ -464,6 +464,7 @@ onBeforeUnmount(() => {
           class="app-hover-lift-card outline-none ring-gray-500 media-card"
           :class="{
             'app-hover-lift-card--hovering': isMediaCardActive(hover.isHovering),
+            'media-card--image-loaded': isImageLoaded,
             'ring-1': isImageLoaded,
           }"
           @click.stop="handleMediaCardClick(hover.isHovering)"

--- a/src/components/dialog/SearchBarDialog.vue
+++ b/src/components/dialog/SearchBarDialog.vue
@@ -520,8 +520,10 @@ onMounted(() => {
           <input
             ref="searchWordInput"
             v-model="searchWord"
+            id="global-media-search"
             type="text"
             class="search-native-input"
+            :aria-label="t('dialog.searchBar.searchPlaceholder')"
             :placeholder="t('dialog.searchBar.searchPlaceholder')"
             @keydown.enter="searchMedia('media')"
             @keydown.escape.stop="closeSearch"
@@ -539,8 +541,10 @@ onMounted(() => {
           <input
             ref="searchWordInput"
             v-model="searchWord"
+            id="global-media-search"
             type="text"
             class="search-native-input"
+            :aria-label="t('dialog.searchBar.searchPlaceholder')"
             :placeholder="t('dialog.searchBar.searchPlaceholder')"
             @keydown.enter="searchMedia('media')"
             @keydown.escape.stop="closeSearch"

--- a/src/components/dialog/__tests__/SearchBarDialog.spec.ts
+++ b/src/components/dialog/__tests__/SearchBarDialog.spec.ts
@@ -43,6 +43,9 @@ describe('SearchBarDialog media source selection', () => {
     const { router } = await renderSearchBar()
     const input = await screen.findByPlaceholderText('搜索电影、剧集以及更多...')
 
+    expect(input.getAttribute('id')).toBe('global-media-search')
+    expect(input.getAttribute('aria-label')).toBe('搜索电影、剧集以及更多...')
+
     await user.type(input, '流浪地球{Enter}')
 
     await waitFor(() => {

--- a/src/components/misc/ProgressiveCardGrid.vue
+++ b/src/components/misc/ProgressiveCardGrid.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
+import { findNearestScrollTarget, invalidateScrollTargetCache, type ScrollTarget } from '@/utils/scrollTarget'
 import type { ComponentPublicInstance } from 'vue'
 
 type ItemKey = string | number
-type ScrollTarget = Window | HTMLElement
 
 const props = withDefaults(
   defineProps<{
@@ -513,19 +513,7 @@ function getItemRef(key: ItemKey) {
 }
 
 function findScrollTarget(): ScrollTarget {
-  let parent = containerRef.value?.parentElement ?? null
-
-  while (parent && parent !== document.body && parent !== document.documentElement) {
-    const overflowY = window.getComputedStyle(parent).overflowY
-
-    if (overflowY === 'auto' || overflowY === 'scroll' || overflowY === 'overlay') {
-      return parent
-    }
-
-    parent = parent.parentElement
-  }
-
-  return window
+  return findNearestScrollTarget(containerRef.value)
 }
 
 function addScrollListener(target: ScrollTarget) {
@@ -550,6 +538,11 @@ function refreshScrollTarget() {
   removeScrollListener(scrollTarget)
   scrollTarget = nextTarget
   addScrollListener(scrollTarget)
+}
+
+function handleWindowResize() {
+  invalidateScrollTargetCache()
+  queueLayoutSync()
 }
 
 function syncLayoutWidth() {
@@ -780,10 +773,7 @@ function invalidateMeasurementsForLayoutChange() {
   const nextColumnCount = columnCount.value
   const nextColumnWidth = columnWidth.value
 
-  if (
-    lastMeasuredColumnCount === nextColumnCount &&
-    Math.abs(lastMeasuredColumnWidth - nextColumnWidth) < 1
-  ) {
+  if (lastMeasuredColumnCount === nextColumnCount && Math.abs(lastMeasuredColumnWidth - nextColumnWidth) < 1) {
     return
   }
 
@@ -817,7 +807,7 @@ onMounted(() => {
     })
   }
 
-  window.addEventListener('resize', queueLayoutSync, { passive: true })
+  window.addEventListener('resize', handleWindowResize, { passive: true })
 
   queueLayoutSync()
 })
@@ -840,7 +830,7 @@ onUnmounted(() => {
   removeScrollListener(scrollTarget)
   scrollTarget = null
 
-  window.removeEventListener('resize', queueLayoutSync)
+  window.removeEventListener('resize', handleWindowResize)
   resizeObserver?.disconnect()
   resizeObserver = null
   itemResizeObserver?.disconnect()
@@ -881,13 +871,10 @@ watch(
   },
 )
 
-watch(
-  [columnCount, columnWidth],
-  () => {
-    invalidateMeasurementsForLayoutChange()
-    queueViewportSync()
-  },
-)
+watch([columnCount, columnWidth], () => {
+  invalidateMeasurementsForLayoutChange()
+  queueViewportSync()
+})
 
 watch(
   [() => props.scrollToIndex, () => props.items.length, columnCount],

--- a/src/composables/__tests__/useGlassOpticalRenderer.spec.ts
+++ b/src/composables/__tests__/useGlassOpticalRenderer.spec.ts
@@ -167,4 +167,78 @@ describe('glass optical surface discovery', () => {
 
     scope.stop()
   })
+
+  it('releases renderer resources before restoring a single active instance', async () => {
+    const three = await import('three')
+    const canvas = document.createElement('canvas')
+    const active = ref(true)
+    const scope = effectScope()
+    let frameId = 0
+    const requestFrame = vi.spyOn(window, 'requestAnimationFrame').mockImplementation(() => ++frameId)
+    const cancelFrame = vi.spyOn(window, 'cancelAnimationFrame')
+    const rendererDispose = vi.spyOn(three.WebGLRenderer.prototype, 'dispose')
+    const contextLoss = vi.spyOn(three.WebGLRenderer.prototype, 'forceContextLoss')
+    const resizeDisconnect = vi.spyOn(ResizeObserverMock.prototype, 'disconnect')
+    const mutationDisconnect = vi.spyOn(MutationObserver.prototype, 'disconnect')
+    const addWindowListener = vi.spyOn(window, 'addEventListener')
+    const addDocumentListener = vi.spyOn(document, 'addEventListener')
+    const addCanvasListener = vi.spyOn(canvas, 'addEventListener')
+    const countListenerAdds = (calls: readonly (readonly unknown[])[], eventName: string) =>
+      calls.filter(([event]) => String(event) === eventName).length
+    const renderer = scope.run(() =>
+      useGlassOpticalRenderer({
+        active,
+        appearance: ref('clear'),
+        canvas: ref(canvas),
+        quality: ref('high'),
+        routeKey: ref('/recommend'),
+        tintColor: ref('#8D51F9'),
+        wallpaperUrl: ref('https://example.com/wallpaper.jpg'),
+      }),
+    )
+
+    await vi.waitFor(() => expect(renderer?.state.value).toBe('ready'))
+    expect(requestFrame).toHaveBeenCalled()
+    expect(countListenerAdds(addWindowListener.mock.calls, 'pointermove')).toBe(1)
+    expect(countListenerAdds(addWindowListener.mock.calls, 'resize')).toBe(1)
+    expect(countListenerAdds(addWindowListener.mock.calls, 'scroll')).toBe(1)
+    expect(countListenerAdds(addDocumentListener.mock.calls, 'visibilitychange')).toBe(1)
+    expect(countListenerAdds(addCanvasListener.mock.calls, 'webglcontextlost')).toBe(1)
+    expect(countListenerAdds(addCanvasListener.mock.calls, 'webglcontextrestored')).toBe(1)
+
+    active.value = false
+    await nextTick()
+
+    expect(rendererDispose).toHaveBeenCalledTimes(1)
+    expect(contextLoss).toHaveBeenCalledTimes(1)
+    expect(resizeDisconnect).toHaveBeenCalledTimes(1)
+    expect(mutationDisconnect).toHaveBeenCalledTimes(1)
+    expect(cancelFrame).toHaveBeenCalledTimes(2)
+
+    addWindowListener.mockClear()
+    addDocumentListener.mockClear()
+    addCanvasListener.mockClear()
+    active.value = true
+    await nextTick()
+    await vi.waitFor(() => expect(countListenerAdds(addWindowListener.mock.calls, 'pointermove')).toBe(1))
+
+    expect(renderer?.state.value).toBe('ready')
+    expect(countListenerAdds(addWindowListener.mock.calls, 'pointermove')).toBe(1)
+    expect(countListenerAdds(addWindowListener.mock.calls, 'resize')).toBe(1)
+    expect(countListenerAdds(addWindowListener.mock.calls, 'scroll')).toBe(1)
+    expect(countListenerAdds(addDocumentListener.mock.calls, 'visibilitychange')).toBe(1)
+    expect(countListenerAdds(addCanvasListener.mock.calls, 'webglcontextlost')).toBe(1)
+    expect(countListenerAdds(addCanvasListener.mock.calls, 'webglcontextrestored')).toBe(1)
+
+    active.value = false
+    await nextTick()
+
+    expect(rendererDispose).toHaveBeenCalledTimes(2)
+    expect(contextLoss).toHaveBeenCalledTimes(2)
+    expect(resizeDisconnect).toHaveBeenCalledTimes(2)
+    expect(mutationDisconnect).toHaveBeenCalledTimes(2)
+    expect(cancelFrame).toHaveBeenCalledTimes(4)
+
+    scope.stop()
+  })
 })

--- a/src/composables/useGlassOpticalRenderer.ts
+++ b/src/composables/useGlassOpticalRenderer.ts
@@ -379,17 +379,31 @@ export function useGlassOpticalRenderer(options: UseGlassOpticalRendererOptions)
     resources.uniforms.uCoverScale.value.set(cover.x, cover.y)
   }
 
+  function getRenderProfile(routeKey = toValue(options.routeKey)) {
+    return getGlassOpticalRenderProfile(toValue(options.quality), routeKey)
+  }
+
   function resizeRenderer() {
     if (!resources) return
 
     const viewportWidth = window.innerWidth
     const viewportHeight = window.innerHeight
-    const profile = getGlassOpticalRenderProfile(toValue(options.quality), toValue(options.routeKey))
+    const profile = getRenderProfile()
     const buffer = getGlassOpticalBufferSize(viewportWidth, viewportHeight, viewportWidth <= 600, profile.bufferQuality)
     resources.renderer.setSize(buffer.width, buffer.height, false)
     resources.uniforms.uViewportSize.value.set(viewportWidth, viewportHeight)
     syncCoverScale(viewportWidth, viewportHeight)
     scheduleSurfaceUpdate()
+  }
+
+  function profileRequiresTextureReload(
+    previousProfile: ReturnType<typeof getGlassOpticalRenderProfile>,
+    nextProfile: ReturnType<typeof getGlassOpticalRenderProfile>,
+  ) {
+    return (
+      previousProfile.textureLimit !== nextProfile.textureLimit ||
+      previousProfile.textureSource !== nextProfile.textureSource
+    )
   }
 
   function handlePointerMove(event: PointerEvent) {
@@ -555,7 +569,7 @@ export function useGlassOpticalRenderer(options: UseGlassOpticalRendererOptions)
   async function loadWallpaper(url: string, version: number) {
     if (!resources || !three || !url) return
 
-    const profile = getGlassOpticalRenderProfile(toValue(options.quality), toValue(options.routeKey))
+    const profile = getRenderProfile()
     const shouldUseProceduralTexture =
       profile.textureSource === 'procedural' ||
       (profile.textureSource === 'auto' && !canUseGlassWallpaperTexture(url, window.location.href))
@@ -784,17 +798,13 @@ export function useGlassOpticalRenderer(options: UseGlassOpticalRendererOptions)
   watch(
     () => toValue(options.routeKey),
     async (routeKey, previousRouteKey) => {
+      const previousProfile = getRenderProfile(previousRouteKey ?? '')
       await nextTick()
       if (resources) {
-        const previousProfile = getGlassOpticalRenderProfile(toValue(options.quality), previousRouteKey ?? '')
-        const nextProfile = getGlassOpticalRenderProfile(toValue(options.quality), routeKey)
+        const nextProfile = getRenderProfile(routeKey)
         resizeRenderer()
 
-        if (
-          previousProfile.bufferQuality !== nextProfile.bufferQuality ||
-          previousProfile.textureLimit !== nextProfile.textureLimit ||
-          previousProfile.textureSource !== nextProfile.textureSource
-        ) {
+        if (profileRequiresTextureReload(previousProfile, nextProfile)) {
           const version = ++loadVersion
           setGlassRendererState(state, 'loading')
 

--- a/src/styles/themes/glass.scss
+++ b/src/styles/themes/glass.scss
@@ -64,6 +64,7 @@ html[data-theme='glass'] {
   --glass-blur: 22px;
   --glass-blur-raised: 32px;
   --glass-saturate: 145%;
+  --glass-content-reveal-duration: 160ms;
   --glass-motion: 180ms cubic-bezier(0.2, 0.8, 0.2, 1);
   --app-card-rest-shadow: var(--glass-shadow);
   --app-card-hover-shadow: var(--glass-shadow-hover);
@@ -322,6 +323,21 @@ html[data-theme='glass'] {
     background-color: var(--glass-surface) !important;
   }
 
+  // 海报完成绘制后已完全遮住卡片底面，释放不可见的实时背景采样。
+  .media-card.media-card--image-loaded {
+    -webkit-backdrop-filter: none !important;
+    backdrop-filter: none !important;
+  }
+
+  .media-card .v-img__img {
+    opacity: 0;
+    transition: opacity var(--glass-content-reveal-duration) cubic-bezier(0.2, 0.8, 0.2, 1);
+  }
+
+  .media-card--image-loaded .v-img__img {
+    opacity: 1;
+  }
+
   .v-toolbar {
     border-color: var(--glass-border);
     -webkit-backdrop-filter: var(--glass-raised-backdrop-filter);
@@ -336,10 +352,7 @@ html[data-theme='glass'] {
     backdrop-filter: var(--glass-dashboard-backdrop-filter);
   }
 
-  :where(
-    .layout-navbar,
-    .Vue-Toastification__toast
-  ) {
+  :where(.layout-navbar, .Vue-Toastification__toast) {
     border-color: var(--glass-border-raised) !important;
     -webkit-backdrop-filter: var(--glass-raised-backdrop-filter);
     backdrop-filter: var(--glass-raised-backdrop-filter);
@@ -896,7 +909,19 @@ html[data-theme='glass'] {
     ) {
       -webkit-backdrop-filter: none !important;
       backdrop-filter: none !important;
-      background-color: rgba(11, 19, 34, 94%) !important;
+      background-color: rgb(11, 19, 34) !important;
+    }
+
+    .layout-vertical-nav::before {
+      -webkit-backdrop-filter: none !important;
+      backdrop-filter: none !important;
+      background-color: rgb(11, 19, 34) !important;
+    }
+
+    .playing-card__percent {
+      -webkit-backdrop-filter: none !important;
+      backdrop-filter: none !important;
+      background-color: rgba(11, 19, 34, 88%) !important;
     }
   }
 
@@ -906,6 +931,10 @@ html[data-theme='glass'] {
     .v-field,
     .background-image {
       transition-duration: 0.01ms !important;
+    }
+
+    .media-card .v-img__img {
+      transition-duration: 0.01ms;
     }
   }
 }
@@ -1127,6 +1156,12 @@ html[data-theme='glass'][data-glass-appearance='frosted'] body[data-theme='glass
     backdrop-filter: var(--glass-control-prominent-backdrop-filter);
     box-shadow: var(--glass-control-prominent-shadow);
   }
+}
+
+html[data-theme='glass'] body[data-theme='glass'] .native-login-field:focus-within {
+  border-color: rgba(var(--v-theme-primary), 70%);
+  background: var(--glass-control-prominent-focus);
+  box-shadow: var(--glass-control-prominent-focus-shadow);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/utils/__tests__/glassOptics.spec.ts
+++ b/src/utils/__tests__/glassOptics.spec.ts
@@ -22,15 +22,20 @@ describe('glass optics geometry', () => {
     expect(getGlassCoverScale(900, 1600, 2400, 1600)).toEqual({ x: 0.375, y: 1 })
   })
 
-  it('keeps high quality optics while reducing the media-dense recommendation budget', () => {
+  it('keeps the selected optical quality on every route', () => {
     expect(getGlassOpticalRenderProfile('high', '/dashboard')).toEqual({
       bufferQuality: 'high',
       textureLimit: 3072,
       textureSource: 'wallpaper',
     })
     expect(getGlassOpticalRenderProfile('high', '/recommend?source=tmdb')).toEqual({
-      bufferQuality: 'balanced',
-      textureLimit: 2048,
+      bufferQuality: 'high',
+      textureLimit: 3072,
+      textureSource: 'wallpaper',
+    })
+    expect(getGlassOpticalRenderProfile('high', '/subscribe/movie')).toEqual({
+      bufferQuality: 'high',
+      textureLimit: 3072,
       textureSource: 'wallpaper',
     })
     expect(getGlassOpticalRenderProfile('balanced', '/dashboard')).toEqual({

--- a/src/utils/__tests__/scrollTarget.spec.ts
+++ b/src/utils/__tests__/scrollTarget.spec.ts
@@ -1,0 +1,54 @@
+import { findNearestScrollTarget, invalidateScrollTargetCache } from '@/utils/scrollTarget'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+describe('findNearestScrollTarget', () => {
+  beforeEach(() => {
+    invalidateScrollTargetCache()
+    document.body.innerHTML = ''
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns the nearest scrollable ancestor', () => {
+    const scrollable = document.createElement('div')
+    const wrapper = document.createElement('div')
+    const grid = document.createElement('div')
+    scrollable.style.overflowY = 'auto'
+    scrollable.append(wrapper)
+    wrapper.append(grid)
+    document.body.append(scrollable)
+
+    expect(findNearestScrollTarget(grid)).toBe(scrollable)
+  })
+
+  it('reuses ancestor results across sibling grids', () => {
+    const getComputedStyle = vi.spyOn(window, 'getComputedStyle')
+    const wrapper = document.createElement('div')
+    const firstGrid = document.createElement('div')
+    const secondGrid = document.createElement('div')
+    wrapper.append(firstGrid, secondGrid)
+    document.body.append(wrapper)
+
+    expect(findNearestScrollTarget(firstGrid)).toBe(window)
+    const callsAfterFirstGrid = getComputedStyle.mock.calls.length
+    expect(findNearestScrollTarget(secondGrid)).toBe(window)
+
+    expect(getComputedStyle).toHaveBeenCalledTimes(callsAfterFirstGrid)
+  })
+
+  it('recomputes targets after cache invalidation', () => {
+    const wrapper = document.createElement('div')
+    const grid = document.createElement('div')
+    wrapper.append(grid)
+    document.body.append(wrapper)
+
+    expect(findNearestScrollTarget(grid)).toBe(window)
+
+    wrapper.style.overflowY = 'auto'
+    invalidateScrollTargetCache()
+
+    expect(findNearestScrollTarget(grid)).toBe(wrapper)
+  })
+})

--- a/src/utils/glassOptics.ts
+++ b/src/utils/glassOptics.ts
@@ -24,7 +24,7 @@ export interface GlassOpticalBufferSize {
 }
 
 export interface GlassOpticalRenderProfile {
-  /** 实际内部缓冲档位；媒体密集场景可保留高质量光学但降低合成分辨率。 */
+  /** 光学层内部缓冲使用的质量档位。 */
   bufferQuality: GlassOpticalQuality
   /** 活动壁纸进入 GPU 前的最长边限制。 */
   textureLimit: number
@@ -32,16 +32,14 @@ export interface GlassOpticalRenderProfile {
   textureSource: 'auto' | 'procedural' | 'wallpaper'
 }
 
-/** 按质量与场景分配合成预算，避免推荐页海报解码与高分辨率光学层争抢资源。 */
+/** 质量决定合成缓冲与纹理上限；路由只切换纹理来源，不改变质量档位。 */
 export function getGlassOpticalRenderProfile(
   quality: GlassOpticalQuality,
   routeKey: string,
 ): GlassOpticalRenderProfile {
-  const mediaDenseRoute = routeKey.startsWith('/recommend')
-
   return {
-    bufferQuality: quality === 'high' && !mediaDenseRoute ? 'high' : 'balanced',
-    textureLimit: quality === 'high' && !mediaDenseRoute ? 3072 : 2048,
+    bufferQuality: quality,
+    textureLimit: quality === 'high' ? 3072 : 2048,
     textureSource: routeKey.startsWith('/login') ? 'auto' : 'wallpaper',
   }
 }

--- a/src/utils/scrollTarget.ts
+++ b/src/utils/scrollTarget.ts
@@ -1,0 +1,46 @@
+export type ScrollTarget = Window | HTMLElement
+
+let targetCache = new WeakMap<HTMLElement, ScrollTarget>()
+
+/**
+ * 清除祖先滚动容器缓存。响应式布局或 overlay 状态改变后必须重新解析。
+ */
+export function invalidateScrollTargetCache() {
+  targetCache = new WeakMap<HTMLElement, ScrollTarget>()
+}
+
+function isScrollableOverflow(overflowY: string) {
+  return overflowY === 'auto' || overflowY === 'scroll' || overflowY === 'overlay'
+}
+
+/**
+ * 解析元素最近的纵向滚动容器，并让同一祖先链上的网格复用样式查询结果。
+ */
+export function findNearestScrollTarget(element: HTMLElement | null): ScrollTarget {
+  if (!element) return window
+
+  let parent = element.parentElement
+  const visited: HTMLElement[] = []
+  let target: ScrollTarget = window
+
+  while (parent && parent !== document.body && parent !== document.documentElement) {
+    const cachedTarget = targetCache.get(parent)
+    if (cachedTarget) {
+      target = cachedTarget
+      break
+    }
+
+    visited.push(parent)
+
+    if (isScrollableOverflow(window.getComputedStyle(parent).overflowY)) {
+      target = parent
+      break
+    }
+
+    parent = parent.parentElement
+  }
+
+  visited.forEach(ancestor => targetCache.set(ancestor, target))
+
+  return target
+}


### PR DESCRIPTION
## 问题与背景

玻璃主题的材质与质量档已由 #577 建立，全局活动生命周期由 #579 统一管理。本阶段继续收敛真实使用中的性能与可访问性边界：

- 推荐页高质量档此前会固定等待 `1.6s` 才挂载光学层，并把内部缓冲隐式降为均衡档，用户选择的质量与实际渲染预算不一致。
- 媒体密集页面的多个渐进网格会重复向上遍历 DOM 并查询滚动容器样式；海报已经完全绘制后，卡片底层仍保留不可见的实时背景模糊。
- 路由变化会把纯缓冲尺寸变化也当成纹理变化处理，产生不必要的纹理重载。
- 系统“减少动态效果”未覆盖壁纸轮播；renderer 停用与恢复的资源唯一性缺少完整回归保护。
- Dashboard 全局搜索 input 缺少稳定标识与显式可访问名称。

目标是在不降低 Dashboard 视觉质量、不隐式降档、不改变其他主题材质的前提下，减少滚动和路由切换中的无效工作，并补齐 renderer 生命周期与系统偏好的可验证契约。

## 原因分析

持续滚动热点并非来自高质量 shader 的单一参数，而是多类工作叠加：

1. 每个 `ProgressiveCardGrid` 都会重复执行祖先链 `getComputedStyle()` 查询；
2. 海报完成合成后，完全被遮挡的卡片表面仍参与 `backdrop-filter`；
3. 推荐页通过路由特判推迟 renderer，并把高质量缓冲降为均衡，增加固定空窗但没有带来稳定的 GPU 或帧间隔收益；
4. 路由 watcher 把缓冲变化、纹理上限和纹理来源混为同一重载条件；
5. 壁纸轮播只服从应用活动状态，没有同时读取 `prefers-reduced-motion`。

正式矩阵表明，质量档之间没有稳定、单调的 GPU 或 P95 回退；磨砂材质的额外成本主要来自 CSS 实时模糊。因此本 PR 不通过路由降档或延迟内容换取数字，而是收敛不可见模糊、重复 DOM 查询、纹理重载和非必要动效。

## 解决方案

- 固定质量预算：
  - 标准档不创建 WebGL canvas；
  - 均衡和高质量在所有业务路由保持用户选择的缓冲与纹理上限；
  - 移除推荐页 `1.6s` renderer 延迟和高质量隐式降档。
- 降低媒体密集页面滚动成本：
  - 缓存最近祖先滚动容器，同一祖先链上的网格复用查询结果；
  - 窗口布局变化时统一失效缓存；
  - 海报完成绘制后以 `160ms` 淡入，并关闭已被海报完全遮挡的卡片实时模糊；
  - `prefers-reduced-motion` 下将淡入缩短为近即时。
- 收敛 renderer 路由切换：
  - 缓冲尺寸变化直接 resize；
  - 仅纹理来源或纹理上限变化时重新加载纹理；
  - 增加资源级测试，覆盖 WebGL context、ResizeObserver、MutationObserver、RAF、窗口/文档/canvas 监听的释放与单实例恢复。
- 补齐系统偏好与输入语义：
  - 壁纸轮播同时服从应用活动生命周期和 `prefers-reduced-motion`；
  - reduced transparency 回退使用不透明表面并移除残留模糊；
  - 登录字段补统一的可见 focus ring；
  - Dashboard 搜索 input 增加稳定 `id` 和显式 `aria-label`。该控件不参与表单提交，因此不添加可能暗示提交字段或触发自动填充的 `name`。

## 性能报告

### 采样方法

矩阵覆盖 DEBUG / Production、`1920x1080@1x` / `1512x862@2x`、透明 / 色调 / 磨砂、标准 / 均衡 / 高质量，共 `4 x 3 x 3 = 36` 组。

每组均先等待可见海报完成请求、`load`、`naturalWidth > 0`、`img.decode()` 和两个 `requestAnimationFrame`，再稳定 `1s`，随后连续滚动 `5s`。标准档无 canvas；均衡缓冲为 `960x540/547`，高质量为 `1440x810/821`，按 CSS 视口固定预算计算，不随 DPR 线性放大。

### 三材质 x 三质量矩阵

表内为 GPU Helper CPU 中位数，顺序均为“标准 / 均衡 / 高质量”：

| 构建与视口 | 透明 | 色调 | 磨砂 | P95 帧间隔范围 |
| --- | ---: | ---: | ---: | ---: |
| DEBUG `1920x1080@1x` | `14.2 / 12.3 / 11.6%` | `12.4 / 11.8 / 12.0%` | `19.8 / 20.0 / 20.0%` | `8.9-11.3ms` |
| DEBUG `1512x862@2x` | `17.7 / 16.2 / 15.6%` | `16.5 / 16.0 / 16.1%` | `23.5 / 24.9 / 25.3%` | `9.0-9.3ms` |
| Production `1920x1080@1x` | `19.6 / 19.8 / 20.4%` | `20.6 / 20.1 / 20.8%` | `33.5 / 32.5 / 32.6%` | `9.4-12.2ms` |
| Production `1512x862@2x` | `25.4 / 24.8 / 25.0%` | `25.4 / 26.0 / 25.8%` | `36.8 / 35.7 / 36.7%` | `9.3-10.0ms` |

Production 高 DPI 的磨砂高质量首轮为 `43.8%`，同时出现异常样式重算；两次独立复跑为 `36.7% / 34.4%`，P95 为 `9.8 / 9.5ms`，因此首轮按离群样本处理，不作为降档依据。

矩阵结论：

- 四组总体 P95 为 `8.9-12.2ms`，均衡或高质量相对标准档没有稳定、单调的帧间隔回退。
- 透明与色调在相同构建和设备下成本接近，说明色调层没有引入独立的显著 GPU 负担。
- 磨砂在三个质量档下均稳定高于透明和色调，差异主要来自材质自身的 CSS 实时模糊，而不是高质量 WebGL 缓冲。
- 降低推荐页缓冲的 A/B 没有证明存在稳定收益，因此保留 `1440` 高质量上限，并在所有页面保持用户选择的固定质量。
- 优化方向限定为减少不可见实时模糊、缓存滚动容器查询、限制光学表面数量和事件驱动调度，不通过压暗壁纸、延迟 renderer、取消海报反馈或削弱 Dashboard 材质换取结果。

### 内容就绪分段

- 推荐页冷刷新：`48` 张卡片约 `1.134s` 出现，`24` 张主海报约 `1.212s` 全部加载，最慢解码约 `1.272s`，两个绘制帧约 `1.283s`。
- 全新 SPA 首次进入且禁用缓存：卡片约 `1.059s` 出现；当前外部图片网络下，最慢主海报约 `6.190s` 完成解码、`6.203s` 完成两个绘制帧。主要空窗来自图片网络，不是 renderer 延迟挂载。
- 暖返回：现有海报约 `48ms` 完成解码与两个绘制帧。
- 热门订阅密集样本：虚拟化首屏 `14` 张主海报，最慢两个绘制帧约 `4.864s`，高质量缓冲保持不变。

`160ms` 海报淡入仅平滑已完成绘制的晚到图片，不参与请求、解码或 renderer 挂载，也不把动画时长当作加载性能。

## 影响与风险

- 玻璃材质样式与 renderer 预算只影响玻璃主题；壁纸轮播的 reduced motion 行为对所有使用轮播背景的主题生效。
- 不修改配置结构、持久化字段、接口或后端契约，无数据迁移要求。
- 高质量档在推荐页不再隐式降为均衡，内部缓冲与纹理上限会按用户选择真实生效；正式矩阵未显示稳定帧间隔回退。
- 磨砂仍比透明和色调更昂贵，这是材质的 CSS 实时模糊成本，不通过隐式降档掩盖。
- 登录页外链壁纸仍使用现有 CSS/SVG 与程序化高光回退；真实纹理折射留待未来同源壁纸契约。

## 验证

- `yarn test:run`：`77` 个测试文件、`734` 项测试通过。
- `yarn typecheck`：通过。
- `yarn lint`：通过。
- `yarn lint:suppressions:prune`：通过。
- `yarn format:check`：通过。
- `yarn build`：生产构建与 PWA service worker 构建通过。
- `git diff --check`：通过。
- 运行态覆盖 Dashboard、推荐页、浏览媒体列表、热门订阅、登录页，复核桌面与 `390x844@3x` 触摸视口、跨壁纸、侧栏边界、路由往返、renderer 停用/恢复、系统减少透明度与动态效果；稳定页面无新增控制台 warning/error。

## 关联

Refs #577

Refs #579

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at cfc9a728c14d7f10998f0e0085cc97db171ce8bb

- 保持玻璃高质量档全路由一致
- 移除推荐页光学层延迟挂载
- 缓存滚动容器，减少网格样式查询
- 海报加载后关闭被遮挡背景模糊
- 壁纸轮播遵循系统减少动态效果
- 优化 renderer 路由切换纹理重载
- 补齐搜索输入无障碍标识
- 新增 renderer 与滚动缓存测试
<!-- pr-agent-summary:end -->
