### PR TITLE
fix(grid): refresh scroll target after overlay unlock

### DIFF
--- a/src/components/misc/ProgressiveCardGrid.vue
+++ b/src/components/misc/ProgressiveCardGrid.vue
@@ -70,6 +70,7 @@ let mounted = false
 let pendingRevealIndex: number | null = null
 let lastMeasuredColumnCount = 0
 let lastMeasuredColumnWidth = 0
+let documentOverlayLocked = false
 
 const safeGap = computed(() => Math.max(0, props.gap))
 const safeMinItemWidth = computed(() => Math.max(1, props.minItemWidth))
@@ -338,11 +339,20 @@ function releaseVisibleRange() {
 }
 
 function handleOverlayLockChange() {
+  const nextOverlayLocked = isDocumentOverlayLocked()
+
+  if (nextOverlayLocked === documentOverlayLocked) {
+    return
+  }
+
+  documentOverlayLocked = nextOverlayLocked
+
   if (shouldPauseVirtualSync()) {
     freezeVisibleRange()
     return
   }
 
+  invalidateScrollTargetCache()
   releaseVisibleRange()
   queueLayoutSync()
 }
@@ -790,6 +800,7 @@ function invalidateMeasurementsForLayoutChange() {
 
 onMounted(() => {
   mounted = true
+  documentOverlayLocked = isDocumentOverlayLocked()
   syncOverlayGridState()
   scrollTarget = findScrollTarget()
   addScrollListener(scrollTarget)

--- a/src/components/misc/__tests__/ProgressiveCardGrid.spec.ts
+++ b/src/components/misc/__tests__/ProgressiveCardGrid.spec.ts
@@ -1,0 +1,37 @@
+import ProgressiveCardGrid from '@/components/misc/ProgressiveCardGrid.vue'
+import { render, waitFor } from '@testing-library/vue'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+describe('ProgressiveCardGrid scroll target lifecycle', () => {
+  afterEach(() => {
+    document.documentElement.classList.remove('v-overlay-scroll-blocked')
+  })
+
+  it('recomputes the scroll target after an overlay unlocks', async () => {
+    const scrollParent = document.createElement('div')
+    const addScrollListener = vi.spyOn(scrollParent, 'addEventListener')
+    scrollParent.style.overflowY = 'hidden'
+    document.body.append(scrollParent)
+    document.documentElement.classList.add('v-overlay-scroll-blocked')
+
+    render(ProgressiveCardGrid, {
+      container: scrollParent,
+      props: {
+        items: [{ id: 1 }],
+        getItemKey: (item: { id: number }) => item.id,
+      },
+      slots: {
+        default: '<div>item</div>',
+      },
+    })
+
+    expect(addScrollListener).not.toHaveBeenCalledWith('scroll', expect.any(Function), expect.anything())
+
+    scrollParent.style.overflowY = 'auto'
+    document.documentElement.classList.remove('v-overlay-scroll-blocked')
+
+    await waitFor(() => {
+      expect(addScrollListener).toHaveBeenCalledWith('scroll', expect.any(Function), { passive: true })
+    })
+  })
+})


### PR DESCRIPTION
## 问题与背景

这是已合并 PR #580 的 reviewer follow-up。

`ProgressiveCardGrid` 会缓存最近的祖先滚动容器，以避免多个媒体网格重复执行祖先链样式查询。Vuetify overlay 锁滚动时会临时把可滚动祖先的 `overflow-y` 改为 `hidden`；如果网格恰好在锁定期间首次 mount 或 activate，缓存会把 `window` 或更外层节点记录为滚动目标。

overlay 关闭后原有逻辑只重新同步布局，没有清除该缓存，因此网格可能继续监听错误的滚动源，直到窗口 resize 或组件重新激活。

## 原因分析

现有 MutationObserver 监听 `<html>` 的 class 变化，但 `handleOverlayLockChange()` 没有区分：

- overlay 锁状态真正发生变化；
- 主题或其他逻辑导致的普通 class 变化。

同时，缓存只在窗口 resize 时失效。锁定期间首次建立的结果因此可能在解锁后继续命中。

正常的“网格已挂载后打开并关闭弹窗”不会触发此问题，因为缓存是在锁定前建立的正确结果；受影响的是锁定期间首次 mount/activate 的窄生命周期场景。

## 解决方案

- 在组件挂载时记录当前 document overlay 锁状态。
- MutationObserver 回调只处理锁状态真实发生变化的情况，避免普通 `<html>` class 变化无条件清除缓存。
- overlay 外网格在锁定时继续冻结当前可见范围。
- 从 locked 恢复为 unlocked 时清除祖先滚动容器缓存，并通过既有布局同步重新绑定正确滚动源。
- 增加组件级回归测试，模拟可滚动祖先在锁定期间临时变为 `hidden`、网格此时首次挂载、解锁后恢复 `auto` 的完整链路。

## 影响与风险

- 只影响 `ProgressiveCardGrid` 的 overlay 解锁生命周期，不改变正常滚动、虚拟列表计算或 overlay 内网格策略。
- 不修改玻璃材质、质量预算、renderer、主题样式、接口或持久化数据。
- 缓存只在真实锁状态跃迁时失效，不会因任意 document class 变化退回频繁祖先查询。
- 无配置或数据迁移要求。

## 验证

- 聚焦组件测试：`1/1` 通过。
- `yarn test:run`：`78` 个测试文件、`736` 项测试通过。
- `yarn typecheck`：通过。
- `yarn lint`：通过。
- `yarn lint:suppressions:prune`：通过。
- `yarn format:check`：通过。
- `yarn build`：生产构建与 PWA service worker 构建通过。
- `git diff --check`：通过。

## 关联

Refs #580

Reviewer thread: https://github.com/jxxghp/MoviePilot-Frontend/pull/580#discussion_r3638012404

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 7a565882a605e0485bd3d2084337acee913f7125

- 修复遮罩解锁后的滚动目标缓存
- 仅在锁定状态变化时重新同步
- 新增锁定期间挂载的回归测试
- 不影响常规滚动与虚拟列表行为
<!-- pr-agent-summary:end -->
