### PR TITLE
fix(theme): refine mobile glass controls

### DIFF
--- a/src/components/dialog/GlassSettingsDialog.vue
+++ b/src/components/dialog/GlassSettingsDialog.vue
@@ -8,7 +8,6 @@ import {
   type ThemeCustomizerGlassQuality,
 } from '@/composables/useThemeCustomizer'
 import { useI18n } from 'vue-i18n'
-import { useDisplay } from 'vuetify'
 
 const props = withDefaults(
   defineProps<{
@@ -25,7 +24,6 @@ const emit = defineEmits<{
 }>()
 
 const { t } = useI18n()
-const display = useDisplay()
 const { settings } = useThemeCustomizer()
 const draftAppearance = ref<ThemeCustomizerGlassAppearance>(settings.value.glassAppearance)
 const draftQuality = ref<ThemeCustomizerGlassQuality>(settings.value.glassQuality)
@@ -91,7 +89,7 @@ function updateQuality(value: unknown) {
 /** 将当前草稿恢复为玻璃主题默认值并立即预览。 */
 function resetSettings() {
   draftAppearance.value = 'clear'
-  draftQuality.value = 'css'
+  draftQuality.value = 'balanced'
   previewGlassSettings({
     glassAppearance: draftAppearance.value,
     glassQuality: draftQuality.value,
@@ -121,7 +119,7 @@ onScopeDispose(cancelGlassPreview)
 </script>
 
 <template>
-  <VDialog v-if="visible" v-model="visible" max-width="30rem" scrollable :fullscreen="!display.mdAndUp.value">
+  <VDialog v-if="visible" v-model="visible" width="100%" max-width="30rem" scrollable>
     <VCard>
       <VCardItem>
         <VCardTitle>

--- a/src/components/dialog/TransparencySettingsDialog.vue
+++ b/src/components/dialog/TransparencySettingsDialog.vue
@@ -1,13 +1,9 @@
 <script setup lang="ts">
 import { useTransparencySettings } from '@/composables/useTransparencySettings'
 import { useI18n } from 'vue-i18n'
-import { useDisplay } from 'vuetify'
 
 // 国际化
 const { t } = useI18n()
-
-// 显示器宽度
-const display = useDisplay()
 
 // 输入参数
 const props = withDefaults(
@@ -72,7 +68,7 @@ onScopeDispose(cancelTransparencySettings)
 </script>
 
 <template>
-  <VDialog v-if="visible" v-model="visible" max-width="30rem" scrollable :fullscreen="!display.mdAndUp.value">
+  <VDialog v-if="visible" v-model="visible" width="100%" max-width="30rem" scrollable>
     <VCard>
       <VCardItem>
         <VCardTitle>

--- a/src/components/dialog/__tests__/GlassSettingsDialog.spec.ts
+++ b/src/components/dialog/__tests__/GlassSettingsDialog.spec.ts
@@ -76,7 +76,7 @@ describe('GlassSettingsDialog', () => {
 
     expect(mocks.previewGlassSettings).toHaveBeenCalledWith({
       glassAppearance: 'clear',
-      glassQuality: 'css',
+      glassQuality: 'balanced',
     })
     expect(mocks.commitGlassPreview).not.toHaveBeenCalled()
   })

--- a/src/composables/__tests__/useThemeCustomizer.spec.ts
+++ b/src/composables/__tests__/useThemeCustomizer.spec.ts
@@ -17,11 +17,11 @@ describe('useThemeCustomizer glass settings', () => {
     localStorage.clear()
   })
 
-  it('uses clear appearance and CSS quality by default', () => {
+  it('uses clear appearance and balanced quality by default', () => {
     const settings = readThemeCustomizerSettings()
 
     expect(settings.glassAppearance).toBe('clear')
-    expect(settings.glassQuality).toBe('css')
+    expect(settings.glassQuality).toBe('balanced')
   })
 
   it.each(['balanced', 'high'] as const)('preserves the %s quality contract', quality => {
@@ -45,7 +45,7 @@ describe('useThemeCustomizer glass settings', () => {
     const settings = readThemeCustomizerSettings()
 
     expect(settings.glassAppearance).toBe('clear')
-    expect(settings.glassQuality).toBe('css')
+    expect(settings.glassQuality).toBe('balanced')
   })
 
   it('syncs glass settings to the document roots', () => {
@@ -88,7 +88,7 @@ describe('useThemeCustomizer glass settings', () => {
     previewGlassSettings({ glassAppearance: 'frosted' })
 
     expect(document.documentElement.dataset.glassAppearance).toBe('frosted')
-    expect(readThemeCustomizerSettings()).toMatchObject({ glassAppearance: 'clear', glassQuality: 'css' })
+    expect(readThemeCustomizerSettings()).toMatchObject({ glassAppearance: 'clear', glassQuality: 'balanced' })
 
     commitGlassPreview()
 

--- a/src/composables/useThemeCustomizer.ts
+++ b/src/composables/useThemeCustomizer.ts
@@ -87,6 +87,7 @@ type VuetifyThemeApi = ReturnType<typeof useTheme>
 const defaultPrimaryColor = themeCustomizerPrimaryColors[0].value
 const validGlassAppearances: ThemeCustomizerGlassAppearance[] = ['clear', 'tinted', 'frosted']
 const validGlassQualities: ThemeCustomizerGlassQuality[] = ['css', 'balanced', 'high']
+const defaultGlassQuality: ThemeCustomizerGlassQuality = 'balanced'
 const validLayouts: ThemeCustomizerLayout[] = ['vertical', 'collapsed', 'horizontal']
 const validRadii: ThemeCustomizerRadius[] = ['none', 'small', 'default', 'large', 'extra']
 const validShadows: readonly ThemeCustomizerShadow[] = themeCustomizerShadowLevels
@@ -124,7 +125,7 @@ function readStoredThemePreference(): ThemeCustomizerTheme {
 function getDefaultThemeCustomizerSettings(): ThemeCustomizerSettings {
   return {
     glassAppearance: 'clear',
-    glassQuality: 'css',
+    glassQuality: defaultGlassQuality,
     layout: 'vertical',
     primaryColor: defaultPrimaryColor,
     radius: 'default',
@@ -386,7 +387,7 @@ export function cancelGlassPreview() {
 export function isDefaultThemeCustomizerSettings(settings: ThemeCustomizerSettings) {
   const defaults = normalizeThemeCustomizerSettings({
     glassAppearance: 'clear',
-    glassQuality: 'css',
+    glassQuality: defaultGlassQuality,
     layout: 'vertical',
     primaryColor: defaultPrimaryColor,
     radius: 'default',
@@ -487,7 +488,7 @@ export function useThemeCustomizer() {
   async function resetSettings() {
     await updateSettings({
       glassAppearance: 'clear',
-      glassQuality: 'css',
+      glassQuality: defaultGlassQuality,
       layout: 'vertical',
       primaryColor: defaultPrimaryColor,
       radius: 'default',

--- a/src/styles/common.scss
+++ b/src/styles/common.scss
@@ -7,8 +7,7 @@
 
 // 返回 Vuetify 指定 elevation 的完整三层 box-shadow，供主题定制器映射全局阴影档位。
 @function app-vuetify-elevation($level) {
-  @return map.get(vuetify-settings.$shadow-key-umbra, $level),
-    map.get(vuetify-settings.$shadow-key-penumbra, $level),
+  @return map.get(vuetify-settings.$shadow-key-umbra, $level), map.get(vuetify-settings.$shadow-key-penumbra, $level),
     map.get(vuetify-settings.$shadow-key-ambient, $level);
 }
 
@@ -50,14 +49,15 @@ html.quick-access-scroll-locked body {
 @mixin hide-scrollbar {
   -ms-overflow-style: none;
   scrollbar-width: none;
-  
+
   &::-webkit-scrollbar {
     display: none;
   }
 }
 
 @media (width <= 768px) {
-  html,body {
+  html,
+  body {
     @include hide-scrollbar;
   }
 }
@@ -82,10 +82,12 @@ html {
   --app-overlay-radius: var(--app-vuetify-rounded-lg);
   --app-surface-border-width: 0;
   --app-surface-border-opacity: 0.06;
-  --app-surface-border: var(--app-surface-border-width) solid rgba(var(--v-theme-on-surface), var(--app-surface-border-opacity));
+  --app-surface-border: var(--app-surface-border-width) solid
+    rgba(var(--v-theme-on-surface), var(--app-surface-border-opacity));
   --app-card-light-border-width: var(--app-surface-border-width);
   --app-card-light-border-opacity: 0.12;
-  --app-card-light-border: var(--app-card-light-border-width) solid rgba(var(--v-theme-on-surface), var(--app-card-light-border-opacity));
+  --app-card-light-border: var(--app-card-light-border-width) solid
+    rgba(var(--v-theme-on-surface), var(--app-card-light-border-opacity));
   --app-overlay-border: var(--app-surface-border);
   --app-card-rest-shadow: var(--app-elevation-0);
   --app-card-hover-shadow: var(--app-elevation-0);
@@ -187,7 +189,9 @@ html[data-theme-radius='extra'] {
 }
 
 #nprogress .peg {
-  box-shadow: 0 0 10px rgb(var(--v-theme-primary)), 0 0 5px rgb(var(--v-theme-primary)) !important;
+  box-shadow:
+    0 0 10px rgb(var(--v-theme-primary)),
+    0 0 5px rgb(var(--v-theme-primary)) !important;
   inline-size: 5px;
   transform: rotate(0deg) translate(0, 0);
 }
@@ -207,13 +211,19 @@ html[data-theme-radius='extra'] {
   border: var(--app-surface-border);
   border-radius: var(--app-surface-radius) !important;
   box-shadow: var(--app-surface-shadow) !important;
-  transition: border-color 0.2s ease, border-radius 0.2s ease, border-width 0.2s ease, box-shadow 0.2s ease;
+  transition:
+    border-color 0.2s ease,
+    border-radius 0.2s ease,
+    border-width 0.2s ease,
+    box-shadow 0.2s ease;
 }
 
 .v-list {
   border-radius: var(--app-surface-radius) !important;
   box-shadow: var(--app-surface-shadow) !important;
-  transition: border-radius 0.2s ease, box-shadow 0.2s ease;
+  transition:
+    border-radius 0.2s ease,
+    box-shadow 0.2s ease;
 }
 
 .app-surface-static {
@@ -243,7 +253,9 @@ html[data-theme-radius='extra'] {
 
 .app-hover-lift-card {
   transform: translateZ(0);
-  transition: transform 0.3s ease, box-shadow 0.2s ease;
+  transition:
+    transform 0.3s ease,
+    box-shadow 0.2s ease;
 }
 
 .app-hover-lift-card--hovering {
@@ -478,17 +490,19 @@ html[data-theme-radius='extra'] {
   [class*=' rounded-']
 ) {
   border-radius: var(--app-field-radius);
-  transition: border-radius 0.2s ease, box-shadow 0.2s ease;
+  transition:
+    border-radius 0.2s ease,
+    box-shadow 0.2s ease;
 }
 
 // 自定义字段圆角时，outlined 字段带左侧 inner icon 需要同步放大左侧描边弧度。
 .v-field:not(
-  .v-field--variant-plain,
-  .v-field--variant-underlined,
-  .v-field--rounded,
-  [class^='rounded-'],
-  [class*=' rounded-']
-).v-field--variant-outlined.v-field--prepended {
+    .v-field--variant-plain,
+    .v-field--variant-underlined,
+    .v-field--rounded,
+    [class^='rounded-'],
+    [class*=' rounded-']
+  ).v-field--variant-outlined.v-field--prepended {
   --app-field-outline-start-size: max(12px, calc(var(--app-field-radius) + 8px));
 
   .v-field__outline__start {
@@ -568,7 +582,9 @@ html[data-theme-radius='extra'] {
 .app-responsive-input--multiline .v-field {
   border-radius: var(--app-control-radius) !important;
   background-color: transparent;
-  transition: background-color 0.18s ease, box-shadow 0.18s ease;
+  transition:
+    background-color 0.18s ease,
+    box-shadow 0.18s ease;
 }
 
 .app-responsive-input--empty:not(:has(.v-field--dirty)) .v-field {
@@ -601,62 +617,50 @@ html[data-theme-radius='extra'] {
   flex-wrap: nowrap;
 }
 
-.app-responsive-input--field :is(
-  input.v-field__input,
-  .v-field__input > input,
-  .v-select__selection,
-  .v-select__selection-text,
-  .v-autocomplete__selection,
-  .v-autocomplete__selection-text,
-  .v-combobox__selection,
-  .v-combobox__selection-text
-) {
+.app-responsive-input--field
+  :is(
+    input.v-field__input,
+    .v-field__input > input,
+    .v-select__selection,
+    .v-select__selection-text,
+    .v-autocomplete__selection,
+    .v-autocomplete__selection-text,
+    .v-combobox__selection,
+    .v-combobox__selection-text
+  ) {
   overflow: hidden;
   min-inline-size: 0;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.app-responsive-input__native:is(
-  .v-select--multiple,
-  .v-autocomplete--multiple,
-  .v-combobox--multiple
-) .v-field__input {
+.app-responsive-input__native:is(.v-select--multiple, .v-autocomplete--multiple, .v-combobox--multiple)
+  .v-field__input {
   overflow: visible;
   flex-wrap: wrap;
   row-gap: 0.25rem;
 }
 
-.app-responsive-input__native:is(
-  .v-select--multiple,
-  .v-autocomplete--multiple,
-  .v-combobox--multiple
-) :is(
-  .v-select__selection,
-  .v-select__selection-text,
-  .v-autocomplete__selection,
-  .v-autocomplete__selection-text,
-  .v-combobox__selection,
-  .v-combobox__selection-text
-) {
+.app-responsive-input__native:is(.v-select--multiple, .v-autocomplete--multiple, .v-combobox--multiple)
+  :is(
+    .v-select__selection,
+    .v-select__selection-text,
+    .v-autocomplete__selection,
+    .v-autocomplete__selection-text,
+    .v-combobox__selection,
+    .v-combobox__selection-text
+  ) {
   overflow: visible;
   text-overflow: clip;
   white-space: normal;
 }
 
-.app-responsive-input__native:is(
-  .v-select--multiple,
-  .v-autocomplete--multiple,
-  .v-combobox--multiple
-) .v-chip {
+.app-responsive-input__native:is(.v-select--multiple, .v-autocomplete--multiple, .v-combobox--multiple) .v-chip {
   max-inline-size: 100%;
 }
 
-.app-responsive-input__native:is(
-  .v-select--multiple,
-  .v-autocomplete--multiple,
-  .v-combobox--multiple
-) .v-chip__content {
+.app-responsive-input__native:is(.v-select--multiple, .v-autocomplete--multiple, .v-combobox--multiple)
+  .v-chip__content {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -754,21 +758,36 @@ html[data-theme-radius='extra'] {
   }
 
   // 表单顶层在桌面也占满 12 格的字段改为上下两行，避免把嵌套 md=12 字段误判为整行字段。
-  .v-form > .v-row > :is(
-    .v-col-12:not([class*='v-col-sm-']):not([class*='v-col-md-']):not([class*='v-col-lg-']):not([class*='v-col-xl-']):not([class*='v-col-xxl-']),
-    .v-col-sm-12:not([class*='v-col-md-']):not([class*='v-col-lg-']):not([class*='v-col-xl-']):not([class*='v-col-xxl-']),
-    .v-col-md-12:not([class*='v-col-lg-']):not([class*='v-col-xl-']):not([class*='v-col-xxl-'])
-  ) > :is(.app-responsive-input--field, .app-responsive-input--range) {
+  .v-form
+    > .v-row
+    > :is(
+      .v-col-12:not([class*='v-col-sm-']):not([class*='v-col-md-']):not([class*='v-col-lg-']):not(
+          [class*='v-col-xl-']
+        ):not([class*='v-col-xxl-']),
+      .v-col-sm-12:not([class*='v-col-md-']):not([class*='v-col-lg-']):not([class*='v-col-xl-']):not(
+          [class*='v-col-xxl-']
+        ),
+      .v-col-md-12:not([class*='v-col-lg-']):not([class*='v-col-xl-']):not([class*='v-col-xxl-'])
+    )
+    > :is(.app-responsive-input--field, .app-responsive-input--range) {
     row-gap: 0.5rem;
     align-items: start;
     grid-template-columns: minmax(0, 1fr);
   }
 
-  .v-form > .v-row > :is(
-    .v-col-12:not([class*='v-col-sm-']):not([class*='v-col-md-']):not([class*='v-col-lg-']):not([class*='v-col-xl-']):not([class*='v-col-xxl-']),
-    .v-col-sm-12:not([class*='v-col-md-']):not([class*='v-col-lg-']):not([class*='v-col-xl-']):not([class*='v-col-xxl-']),
-    .v-col-md-12:not([class*='v-col-lg-']):not([class*='v-col-xl-']):not([class*='v-col-xxl-'])
-  ) > :is(.app-responsive-input--field, .app-responsive-input--range) .app-responsive-input__control {
+  .v-form
+    > .v-row
+    > :is(
+      .v-col-12:not([class*='v-col-sm-']):not([class*='v-col-md-']):not([class*='v-col-lg-']):not(
+          [class*='v-col-xl-']
+        ):not([class*='v-col-xxl-']),
+      .v-col-sm-12:not([class*='v-col-md-']):not([class*='v-col-lg-']):not([class*='v-col-xl-']):not(
+          [class*='v-col-xxl-']
+        ),
+      .v-col-md-12:not([class*='v-col-lg-']):not([class*='v-col-xl-']):not([class*='v-col-xxl-'])
+    )
+    > :is(.app-responsive-input--field, .app-responsive-input--range)
+    .app-responsive-input__control {
     inline-size: 100%;
   }
 }
@@ -793,125 +812,138 @@ html[data-theme-radius='extra'] {
 .v-btn-group:not(.v-btn-group--variant-plain, .v-btn-group--variant-text) {
   border-radius: var(--app-control-radius);
   box-shadow: var(--app-surface-shadow) !important;
-  transition: box-shadow 0.2s ease, border-radius 0.2s ease;
+  transition:
+    box-shadow 0.2s ease,
+    border-radius 0.2s ease;
 }
 
 // 只给外层卡片和弹窗外壳保留阴影，内部 surface / control / elevation 工具类统一保持平面，避免多层阴影叠加。
-.v-card :where(
-  .app-surface,
-  .app-surface-static,
-  .v-alert,
-  .v-avatar,
-  .v-btn,
-  .v-btn-group,
-  .v-card,
-  .v-chip,
-  .v-expansion-panel,
-  .v-expansion-panel__shadow,
-  .v-list,
-  .v-navigation-drawer,
-  .v-sheet,
-  .v-stepper,
-  .v-table,
-  .v-toolbar,
-  .v-window,
-  [class^='elevation-'],
-  [class*=' elevation-'],
-  [class^='shadow-'],
-  [class*=' shadow-']
-),
-.v-overlay__content > .v-card :where(
-  .app-surface,
-  .app-surface-static,
-  .v-alert,
-  .v-avatar,
-  .v-btn,
-  .v-btn-group,
-  .v-card,
-  .v-chip,
-  .v-expansion-panel,
-  .v-expansion-panel__shadow,
-  .v-list,
-  .v-navigation-drawer,
-  .v-sheet,
-  .v-stepper,
-  .v-table,
-  .v-toolbar,
-  .v-window,
-  [class^='elevation-'],
-  [class*=' elevation-'],
-  [class^='shadow-'],
-  [class*=' shadow-']
-),
-.v-overlay__content > .v-sheet :where(
-  .app-surface,
-  .app-surface-static,
-  .v-alert,
-  .v-avatar,
-  .v-btn,
-  .v-btn-group,
-  .v-card,
-  .v-chip,
-  .v-expansion-panel,
-  .v-expansion-panel__shadow,
-  .v-list,
-  .v-navigation-drawer,
-  .v-sheet,
-  .v-stepper,
-  .v-table,
-  .v-toolbar,
-  .v-window,
-  [class^='elevation-'],
-  [class*=' elevation-'],
-  [class^='shadow-'],
-  [class*=' shadow-']
-),
-.v-overlay__content > form > .v-card :where(
-  .app-surface,
-  .app-surface-static,
-  .v-alert,
-  .v-avatar,
-  .v-btn,
-  .v-btn-group,
-  .v-card,
-  .v-chip,
-  .v-expansion-panel,
-  .v-expansion-panel__shadow,
-  .v-list,
-  .v-navigation-drawer,
-  .v-sheet,
-  .v-stepper,
-  .v-table,
-  .v-toolbar,
-  .v-window,
-  [class^='elevation-'],
-  [class*=' elevation-'],
-  [class^='shadow-'],
-  [class*=' shadow-']
-),
-.v-overlay__content > form > .v-sheet :where(
-  .app-surface,
-  .app-surface-static,
-  .v-alert,
-  .v-avatar,
-  .v-btn,
-  .v-btn-group,
-  .v-card,
-  .v-chip,
-  .v-expansion-panel,
-  .v-expansion-panel__shadow,
-  .v-list,
-  .v-navigation-drawer,
-  .v-sheet,
-  .v-stepper,
-  .v-table,
-  .v-toolbar,
-  .v-window,
-  [class^='elevation-'],
-  [class*=' elevation-'],
-  [class^='shadow-'],
-  [class*=' shadow-']
-) {
+.v-card
+  :where(
+    .app-surface,
+    .app-surface-static,
+    .v-alert,
+    .v-avatar,
+    .v-btn,
+    .v-btn-group,
+    .v-card,
+    .v-chip,
+    .v-expansion-panel,
+    .v-expansion-panel__shadow,
+    .v-list,
+    .v-navigation-drawer,
+    .v-sheet,
+    .v-stepper,
+    .v-table,
+    .v-toolbar,
+    .v-window,
+    [class^='elevation-'],
+    [class*=' elevation-'],
+    [class^='shadow-'],
+    [class*=' shadow-']
+  ),
+.v-overlay__content
+  > .v-card
+  :where(
+    .app-surface,
+    .app-surface-static,
+    .v-alert,
+    .v-avatar,
+    .v-btn,
+    .v-btn-group,
+    .v-card,
+    .v-chip,
+    .v-expansion-panel,
+    .v-expansion-panel__shadow,
+    .v-list,
+    .v-navigation-drawer,
+    .v-sheet,
+    .v-stepper,
+    .v-table,
+    .v-toolbar,
+    .v-window,
+    [class^='elevation-'],
+    [class*=' elevation-'],
+    [class^='shadow-'],
+    [class*=' shadow-']
+  ),
+.v-overlay__content
+  > .v-sheet
+  :where(
+    .app-surface,
+    .app-surface-static,
+    .v-alert,
+    .v-avatar,
+    .v-btn,
+    .v-btn-group,
+    .v-card,
+    .v-chip,
+    .v-expansion-panel,
+    .v-expansion-panel__shadow,
+    .v-list,
+    .v-navigation-drawer,
+    .v-sheet,
+    .v-stepper,
+    .v-table,
+    .v-toolbar,
+    .v-window,
+    [class^='elevation-'],
+    [class*=' elevation-'],
+    [class^='shadow-'],
+    [class*=' shadow-']
+  ),
+.v-overlay__content
+  > form
+  > .v-card
+  :where(
+    .app-surface,
+    .app-surface-static,
+    .v-alert,
+    .v-avatar,
+    .v-btn,
+    .v-btn-group,
+    .v-card,
+    .v-chip,
+    .v-expansion-panel,
+    .v-expansion-panel__shadow,
+    .v-list,
+    .v-navigation-drawer,
+    .v-sheet,
+    .v-stepper,
+    .v-table,
+    .v-toolbar,
+    .v-window,
+    [class^='elevation-'],
+    [class*=' elevation-'],
+    [class^='shadow-'],
+    [class*=' shadow-']
+  ),
+.v-overlay__content
+  > form
+  > .v-sheet
+  :where(
+    .app-surface,
+    .app-surface-static,
+    .v-alert,
+    .v-avatar,
+    .v-btn,
+    .v-btn-group,
+    .v-card,
+    .v-chip,
+    .v-expansion-panel,
+    .v-expansion-panel__shadow,
+    .v-list,
+    .v-navigation-drawer,
+    .v-sheet,
+    .v-stepper,
+    .v-table,
+    .v-toolbar,
+    .v-window,
+    [class^='elevation-'],
+    [class*=' elevation-'],
+    [class^='shadow-'],
+    [class*=' shadow-']
+  ) {
   --app-card-hover-shadow: none;
   --app-card-rest-shadow: none;
   --app-fab-shadow: none;
@@ -945,7 +977,10 @@ html[data-theme-radius='extra'] {
     ),
     rgba(var(--v-theme-surface), var(--app-card-surface-opacity));
   color: rgb(var(--v-theme-on-surface));
-  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease,
+    transform 0.2s ease;
 
   --app-card-accent-rgb: var(--v-theme-primary);
   --app-card-accent-end-rgb: var(--app-card-accent-rgb);
@@ -955,7 +990,8 @@ html[data-theme-radius='extra'] {
   --app-card-hover-border-opacity: 0.16;
   --app-card-stripe-opacity: 0.22;
   --app-card-surface-opacity: 0.92;
-  --app-surface-border: var(--app-surface-border-width) solid rgba(var(--app-card-accent-rgb), var(--app-card-border-opacity));
+  --app-surface-border: var(--app-surface-border-width) solid
+    rgba(var(--app-card-accent-rgb), var(--app-card-border-opacity));
   --app-surface-hover-shadow: var(--app-card-hover-shadow);
   --app-surface-shadow: var(--app-card-rest-shadow);
 }
@@ -964,7 +1000,7 @@ html[data-theme-radius='extra'] {
   position: absolute;
   background: rgb(var(--app-card-accent-rgb));
   block-size: 100%;
-  content: "";
+  content: '';
   inline-size: 0.125rem;
   inset-block: 0;
   inset-inline-start: 0;
@@ -973,7 +1009,8 @@ html[data-theme-radius='extra'] {
 }
 
 .app-card-colorful:hover {
-  --app-surface-border: var(--app-surface-border-width) solid rgba(var(--app-card-accent-rgb), var(--app-card-hover-border-opacity));
+  --app-surface-border: var(--app-surface-border-width) solid
+    rgba(var(--app-card-accent-rgb), var(--app-card-hover-border-opacity));
 }
 
 .app-card-colorful:focus-visible {
@@ -991,7 +1028,7 @@ html[data-theme-radius='extra'] {
   pointer-events: none;
 }
 
-html[data-theme="transparent"] .app-card-colorful,
+html[data-theme='transparent'] .app-card-colorful,
 .v-theme--transparent .app-card-colorful {
   backdrop-filter: blur(var(--transparent-blur, 10px));
 
@@ -1001,13 +1038,14 @@ html[data-theme="transparent"] .app-card-colorful,
   --app-card-hover-border-opacity: var(--app-surface-border-opacity);
   --app-card-stripe-opacity: 0.16;
   --app-card-surface-opacity: var(--transparent-opacity-light, 0.2);
-  --app-surface-border: var(--app-surface-border-width) solid rgba(var(--v-theme-on-surface), var(--app-surface-border-opacity));
+  --app-surface-border: var(--app-surface-border-width) solid
+    rgba(var(--v-theme-on-surface), var(--app-surface-border-opacity));
 }
 
-html[data-theme="transparent"].transparent-glass-lightweight .app-card-colorful,
-html[data-theme="transparent"].transparent-glass-lightweight .v-theme--transparent .app-card-colorful,
-html[data-theme="transparent"].transparent-glass-realtime .app-card-colorful,
-html[data-theme="transparent"].transparent-glass-realtime .v-theme--transparent .app-card-colorful {
+html[data-theme='transparent'].transparent-glass-lightweight .app-card-colorful,
+html[data-theme='transparent'].transparent-glass-lightweight .v-theme--transparent .app-card-colorful,
+html[data-theme='transparent'].transparent-glass-realtime .app-card-colorful,
+html[data-theme='transparent'].transparent-glass-realtime .v-theme--transparent .app-card-colorful {
   backdrop-filter: none;
 }
 
@@ -1148,7 +1186,7 @@ html[data-theme="transparent"].transparent-glass-realtime .v-theme--transparent 
   margin-block: env(safe-area-inset-top) env(safe-area-inset-bottom);
 }
 
-@media only screen and (width <= 600px){
+@media only screen and (width <= 600px) {
   .Vue-Toastification__container {
     inline-size: 100vw;
     padding-block: 4.5rem;
@@ -1346,11 +1384,11 @@ html[data-theme="transparent"].transparent-glass-realtime .v-theme--transparent 
 // 文本样式
 .text-moviepilot {
   background-clip: text;
-  background-image: linear-gradient(to bottom right,var(--tw-gradient-stops));
+  background-image: linear-gradient(to bottom right, var(--tw-gradient-stops));
   color: transparent;
 
   --tw-gradient-from: #818cf8;
-  --tw-gradient-stops: var(--tw-gradient-from),var(--tw-gradient-to);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
   --tw-gradient-to: #c084fc;
 }
 
@@ -1372,7 +1410,7 @@ html[data-theme="transparent"].transparent-glass-realtime .v-theme--transparent 
   line-height: 1.75rem;
 }
 
-@media (width >= 640px){
+@media (width >= 640px) {
   .slider-title {
     overflow: hidden;
     font-size: 1.5rem;
@@ -1393,10 +1431,10 @@ html[data-theme="transparent"].transparent-glass-realtime .v-theme--transparent 
 ::-webkit-scrollbar-thumb {
   border-radius: 2px;
   background: rgb(var(--v-theme-perfect-scrollbar-thumb));
-  box-shadow: inset 0 0 10px rgba(0,0,0,20%);
+  box-shadow: inset 0 0 10px rgba(0, 0, 0, 20%);
 
-  @media(hover){
-    &:hover{
+  @media (hover) {
+    &:hover {
       background: #a1a1a1;
     }
   }
@@ -1411,25 +1449,28 @@ html[data-theme="transparent"].transparent-glass-realtime .v-theme--transparent 
 }
 
 // 组件样式
-.v-alert--variant-elevated, .v-alert--variant-flat {
+.v-alert--variant-elevated,
+.v-alert--variant-flat {
   border-radius: var(--app-surface-radius);
   background: rgb(var(--v-table-header-background));
   color: rgba(var(--v-theme-on-surface), var(--v-high-emphasis-opacity));
 }
 
 .backdrop-blur {
-  --tw-backdrop-blur: blur(8px)!important;
+  --tw-backdrop-blur: blur(8px) !important;
 
-  backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia)!important;
+  backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast)
+    var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity)
+    var(--tw-backdrop-saturate) var(--tw-backdrop-sepia) !important;
 }
 
-.v-toolbar{
+.v-toolbar {
   background: rgb(var(--v-table-header-background));
 }
 
 .v-divider {
   border-color: rgba(var(--v-theme-on-background), var(--v-selected-opacity));
-  opacity:0.75;
+  opacity: 0.75;
 }
 
 :root {
@@ -1677,8 +1718,8 @@ html[data-theme="transparent"].transparent-glass-realtime .v-theme--transparent 
   }
 
   .compact-fab--secondary .v-btn {
-    block-size: 3rem !important;
-    inline-size: 3rem !important;
+    block-size: 3.5rem !important;
+    inline-size: 3.5rem !important;
   }
 }
 
@@ -1735,7 +1776,7 @@ html[data-theme="transparent"].transparent-glass-realtime .v-theme--transparent 
 }
 
 // 弹出层样式
-.v-overlay__content .v-list{
+.v-overlay__content .v-list {
   border: var(--app-overlay-border);
   border-radius: var(--app-surface-radius);
   backdrop-filter: blur(6px);
@@ -1744,14 +1785,15 @@ html[data-theme="transparent"].transparent-glass-realtime .v-theme--transparent 
   padding-inline: 0.5rem !important;
 }
 
-.v-overlay__content .v-card:not(.bg-primary){
+.v-overlay__content .v-card:not(.bg-primary) {
   border: var(--app-overlay-border);
   border-radius: var(--app-surface-radius);
   backdrop-filter: blur(8px);
   background-color: rgb(var(--v-theme-surface), 0.95);
   box-shadow: none;
 
-  .v-list, .v-table {
+  .v-list,
+  .v-table {
     backdrop-filter: none;
     background-color: transparent;
     box-shadow: none;
@@ -1776,7 +1818,9 @@ html[data-theme="transparent"].transparent-glass-realtime .v-theme--transparent 
   background: transparent;
   box-shadow: none;
   margin-block: env(safe-area-inset-top) env(safe-area-inset-bottom);
-  transition: opacity 0.2s ease, box-shadow 0.2s ease;
+  transition:
+    opacity 0.2s ease,
+    box-shadow 0.2s ease;
 }
 
 .v-menu > .v-overlay__content {
@@ -1885,9 +1929,7 @@ html[data-theme="transparent"].transparent-glass-realtime .v-theme--transparent 
 
 .v-menu .v-overlay__content {
   box-shadow: none;
-} 
-
-
+}
 
 // 主界面下拉入口提示：放在公共样式中，避免 scoped 样式无法响应根节点主题属性。
 .app-pull-indicator {
@@ -1927,7 +1969,9 @@ html[data-theme="transparent"].transparent-glass-realtime .v-theme--transparent 
   background: rgba(var(--v-theme-primary), var(--app-pull-indicator-icon-surface-opacity));
   block-size: 40px;
   inline-size: 40px;
-  transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1), background-color 0.2s ease;
+  transition:
+    transform 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+    background-color 0.2s ease;
 }
 
 html[data-theme='light'] .app-pull-indicator {


### PR DESCRIPTION
## 问题与背景

玻璃主题在移动端存在三处体验不一致：

- 透明度与玻璃设置内容较少，却在小屏被强制展开为全屏弹窗，留白较多且操作层级显得过重。
- `compact-fab` 的主按钮为 `56px`，次按钮仍为 `48px`，桌面模式入口、插件市场等复用该样式的入口均会出现同组按钮尺寸不一致。
- 新配置与重置操作仍默认使用“标准”质量，没有采用性能验证后更适合作为默认体验的“均衡”档。

## 原因分析

两个短内容设置弹窗直接以移动端断点控制 `fullscreen`，没有根据内容量决定呈现方式。`compact-fab` 的移动端规则只放大了主按钮，次按钮保留桌面尺寸，因此所有复用该公共样式的移动入口都会出现相同问题。

玻璃质量此前沿用了功能引入时的“标准”默认值。第三阶段的正式三材质 x 三质量矩阵表明，同一材质下“标准 / 均衡 / 高质量”没有稳定的 GPU 或 P95 帧间隔单调回退，因此没有性能证据要求继续把“标准”作为新配置默认值。

## 解决方案

- 透明度与玻璃设置统一改为 `width="100%"`、最大宽度 `30rem` 的可滚动内容弹窗，移动端不再强制全屏。
- 所有 `compact-fab` 在移动端统一使用 `56x56px`；桌面端主、次按钮继续保持 `48x48px`。主次层级仍由颜色、阴影和排列顺序表达。
- 将玻璃质量的新配置默认值、无效值回退、全局重置值与设置弹窗重置值统一为“均衡”。
- 已保存的合法“标准”或“高质量”选择不会迁移或覆盖，现有用户偏好保持不变。

`src/styles/common.scss` 的大部分行级 diff 来自当前 Prettier 规则对既有 SCSS 的机械格式化；该文件的实际行为变化仅为移动端次级 `compact-fab` 的宽高从 `3rem` 调整为 `3.5rem`。

## 性能矩阵结论

默认值选择沿用已完成的第三阶段正式矩阵。每组在可见海报完成加载、解码和两个绘制帧后稳定 `1s`，再连续滚动 `5s`；覆盖 DEBUG / Production 与 `1920x1080@1x` / `1512x862@2x` 四组环境。下表为 GPU Helper CPU 中位数，顺序均为“标准 / 均衡 / 高质量”：

| 构建与视口 | 透明 | 色调 | 磨砂 | P95 帧间隔范围 |
| --- | ---: | ---: | ---: | ---: |
| DEBUG `1920x1080@1x` | `14.2 / 12.3 / 11.6%` | `12.4 / 11.8 / 12.0%` | `19.8 / 20.0 / 20.0%` | `8.9-11.3ms` |
| DEBUG `1512x862@2x` | `17.7 / 16.2 / 15.6%` | `16.5 / 16.0 / 16.1%` | `23.5 / 24.9 / 25.3%` | `9.0-9.3ms` |
| Production `1920x1080@1x` | `19.6 / 19.8 / 20.4%` | `20.6 / 20.1 / 20.8%` | `33.5 / 32.5 / 32.6%` | `9.4-12.2ms` |
| Production `1512x862@2x` | `25.4 / 24.8 / 25.0%` | `25.4 / 26.0 / 25.8%` | `36.8 / 35.7 / 36.7%` | `9.3-10.0ms` |

矩阵支持以下结论：

- 四组总体 P95 为 `8.9-12.2ms`，均衡档相对标准档没有稳定的帧间隔回退。
- 透明与色调在相同环境下成本接近；磨砂的额外成本主要来自 CSS 实时模糊，而不是均衡档的 WebGL 缓冲。
- 标准档不挂载 canvas；均衡档内部缓冲约为 `960x540/547`，高质量约为 `1440x810/821`，缓冲按 CSS 视口固定预算计算，不随 DPR 线性放大。
- Production 高 DPI 磨砂高质量首轮 `43.8%` 伴随异常样式重算，两次独立复跑为 `36.7% / 34.4%`，P95 为 `9.8 / 9.5ms`，因此该首轮作为离群样本，不构成默认降为标准档的依据。
- “均衡”能够默认提供完整光学 renderer，同时保留固定资源预算；标准档仍作为明确的低成本手动选择。

本 PR 没有修改 renderer、shader、缓冲预算、帧调度或材质实现，因此不改变上述性能边界。

## 影响与风险

- 影响范围仅为两个主题设置弹窗、玻璃质量默认/重置语义和公共 `compact-fab` 的移动端尺寸。
- 所有复用 `compact-fab` 的移动入口会同步统一尺寸，这是公共样式修正的预期结果；桌面布局不变。
- 新配置和无效存储值会使用“均衡”，已有合法质量设置不迁移，无数据结构或接口变化。
- 登录表单、密码自动填充和 Passkey Conditional UI 不属于本 PR。Chrome DevTools 设备预览在 `50%` 缩放时出现的 1Password 扩展填充失败也未通过业务代码规避。

## 验证

- `yarn test:run`：`78` 个测试文件、`736` 项测试通过。
- `yarn typecheck`：通过。
- `yarn lint`：通过。
- `yarn lint:suppressions:prune`：通过。
- `yarn format:check`：通过。
- `yarn build`：生产构建与 PWA service worker 构建通过。
- `git diff --check`：通过。
- 移动端实际页面验收：短内容弹窗、玻璃质量重置、桌面模式入口与插件市场 `compact-fab` 尺寸符合预期。

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 8a0f9b3d9334ab2646cdce15cab42de64bf8bd03

- 优化移动端玻璃主题控制体验
  - 短设置弹窗改为全宽限宽
  - 次级 `compact-fab` 统一为 `56px`
- 默认玻璃质量调整为 `balanced`
  - 重置与无效值回退保持一致
  - 已保存的合法偏好不受影响
- 更新组件与定制器默认值测试
- 包含 `common.scss` 格式化调整
<!-- pr-agent-summary:end -->
