### PR TITLE
test(subscribe): stabilize mobile calendar filter

### DIFF
--- a/src/views/subscribe/__tests__/FullCalendarView.spec.ts
+++ b/src/views/subscribe/__tests__/FullCalendarView.spec.ts
@@ -266,9 +266,7 @@ describe('FullCalendarView', () => {
       ...sameDaySubscriptions.map(subscribe =>
         tmdbSeasonEpisodesHandler(subscribe.tmdbid as number, 1, [sameDayEpisode]),
       ),
-      tmdbSeasonEpisodesHandler(3499, 1, [
-        createTmdbEpisode({ air_date: '2026-08-02', episode_number: 1 }),
-      ]),
+      tmdbSeasonEpisodesHandler(3499, 1, [createTmdbEpisode({ air_date: '2026-08-02', episode_number: 1 })]),
     )
     Object.defineProperty(window, 'scrollY', { configurable: true, value: 240 })
     Object.defineProperty(window, 'scrollX', { configurable: true, value: 16 })
@@ -377,9 +375,7 @@ describe('FullCalendarView', () => {
       '.mobile-calendar-event-card',
     )
     const noneCard = screen.getByRole('heading', { name: '年度剧集' }).closest('.mobile-calendar-event-card')
-    const partialCard = screen
-      .getByRole('heading', { name: '第一集 / 第二集' })
-      .closest('.mobile-calendar-event-card')
+    const partialCard = screen.getByRole('heading', { name: '第一集 / 第二集' }).closest('.mobile-calendar-event-card')
     expect(completeCard).toHaveClass('mobile-calendar-event-card--complete')
     expect(noneCard).toHaveClass('mobile-calendar-event-card--none')
     expect(partialCard).toHaveClass('mobile-calendar-event-card--partial')
@@ -415,13 +411,7 @@ describe('FullCalendarView', () => {
     const recovered = movieSubscribe(3701, '恢复后的电影')
     const onListRequest = vi.fn()
     server.use(
-      sequenceSubscribeList(
-        [
-          { body: [], status: 500 },
-          { body: [recovered] },
-        ],
-        onListRequest,
-      ),
+      sequenceSubscribeList([{ body: [], status: 500 }, { body: [recovered] }], onListRequest),
       mediaDetailsHandler(3701, createMediaInfo({ release_date: '2026-08-12', tmdb_id: 3701 })),
     )
 
@@ -494,6 +484,8 @@ describe('FullCalendarView', () => {
   })
 
   it('filters mobile calendar events by media type', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] })
+    vi.setSystemTime(new Date('2026-07-23T12:00:00+08:00'))
     setViewport(480)
     const movie = movieSubscribe(3901, '移动筛选电影')
     const tv = tvSubscribe(3902, '移动筛选剧集')


### PR DESCRIPTION
## 问题与背景

`FullCalendarView > filters mobile calendar events by media type` 使用固定的 `2026-07-24` 作为电影和剧集日期。移动端默认隐藏过期事件，因此真实日期进入 `2026-07-25` 后，两个测试事件都会在媒体类型筛选开始前被过滤，导致最新 `v2` 的全量测试稳定失败。

## 原因分析

该用例验证的是移动端电影/电视剧筛选，但没有固定系统时间，测试结果意外依赖执行当天。桌面同类用例不应用移动端“隐藏过期”规则，因此没有暴露相同失败。

## 解决方案

在该用例中仅模拟 `Date`，将系统时间固定在事件日期前一天。测试数据继续保持“尚未过期”，用例可以专注验证媒体类型筛选，不修改生产过滤逻辑。

同时按仓库 Prettier 规则格式化同一测试文件。

## 影响与风险

- 仅修改测试，不影响运行时代码。
- 日期相关业务测试仍由已有的移动历史窗口和跨年用例覆盖。

## 验证

- `src/views/subscribe/__tests__/FullCalendarView.spec.ts`: `12/12` 通过
- 全量测试：`79 files / 746 tests` 通过
- `yarn lint:suppressions:prune`
- `yarn typecheck`
- `yarn lint`
- `yarn format:check`
- `yarn build`
- `git diff --check`

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 4d03c388dec6d580c0177c75b49ba9d653469370

- 固定移动端筛选测试系统日期
- 避免过期事件规则导致测试波动
- 同步格式化测试代码
- 不影响生产逻辑与兼容性
<!-- pr-agent-summary:end -->
