### PR TITLE
test(subscribe): stabilize calendar and season coverage

### DIFF
--- a/src/components/dialog/__tests__/SubscribeSeasonDialog.spec.ts
+++ b/src/components/dialog/__tests__/SubscribeSeasonDialog.spec.ts
@@ -188,6 +188,37 @@ describe('SubscribeSeasonDialog', () => {
     expect(within(row).queryByText(/首播于/)).not.toBeInTheDocument()
   })
 
+  it('renders safe fallbacks for incomplete season metadata', async () => {
+    const media = createTvMedia({ poster_path: '' })
+    server.use(
+      mediaSeasonsHandler([
+        createMediaSeason({
+          air_date: 'unknown',
+          episode_count: 0,
+          name: '来源特别篇',
+          poster_path: '',
+          season_number: undefined,
+        }),
+        createMediaSeason({
+          air_date: '',
+          episode_count: undefined,
+          name: 'Season 01',
+          poster_path: '/images/season-one.jpg',
+          season_number: 1,
+        }),
+      ]),
+      mediaNotExistsHandler([]),
+      mediaEpisodeGroupsHandler(media.tmdb_id!, []),
+    )
+
+    await renderDialog({ media })
+
+    expect(await screen.findByText('第 0 季')).toBeInTheDocument()
+    expect(seasonRow(0)).toHaveTextContent('unknown')
+    expect(within(seasonRow(0)).getByAltText('第 0 季')).toHaveAttribute('src')
+    expect(seasonRow(1)).not.toHaveTextContent('Season 01')
+  })
+
   it.each([
     ['Douban', { douban_id: 'db-7303', source: 'douban', tmdb_id: undefined }, 'douban:db-7303'],
     [

--- a/src/views/subscribe/__tests__/FullCalendarView.spec.ts
+++ b/src/views/subscribe/__tests__/FullCalendarView.spec.ts
@@ -266,9 +266,7 @@ describe('FullCalendarView', () => {
       ...sameDaySubscriptions.map(subscribe =>
         tmdbSeasonEpisodesHandler(subscribe.tmdbid as number, 1, [sameDayEpisode]),
       ),
-      tmdbSeasonEpisodesHandler(3499, 1, [
-        createTmdbEpisode({ air_date: '2026-08-02', episode_number: 1 }),
-      ]),
+      tmdbSeasonEpisodesHandler(3499, 1, [createTmdbEpisode({ air_date: '2026-08-02', episode_number: 1 })]),
     )
     Object.defineProperty(window, 'scrollY', { configurable: true, value: 240 })
     Object.defineProperty(window, 'scrollX', { configurable: true, value: 16 })
@@ -377,9 +375,7 @@ describe('FullCalendarView', () => {
       '.mobile-calendar-event-card',
     )
     const noneCard = screen.getByRole('heading', { name: '年度剧集' }).closest('.mobile-calendar-event-card')
-    const partialCard = screen
-      .getByRole('heading', { name: '第一集 / 第二集' })
-      .closest('.mobile-calendar-event-card')
+    const partialCard = screen.getByRole('heading', { name: '第一集 / 第二集' }).closest('.mobile-calendar-event-card')
     expect(completeCard).toHaveClass('mobile-calendar-event-card--complete')
     expect(noneCard).toHaveClass('mobile-calendar-event-card--none')
     expect(partialCard).toHaveClass('mobile-calendar-event-card--partial')
@@ -415,13 +411,7 @@ describe('FullCalendarView', () => {
     const recovered = movieSubscribe(3701, '恢复后的电影')
     const onListRequest = vi.fn()
     server.use(
-      sequenceSubscribeList(
-        [
-          { body: [], status: 500 },
-          { body: [recovered] },
-        ],
-        onListRequest,
-      ),
+      sequenceSubscribeList([{ body: [], status: 500 }, { body: [recovered] }], onListRequest),
       mediaDetailsHandler(3701, createMediaInfo({ release_date: '2026-08-12', tmdb_id: 3701 })),
     )
 
@@ -494,6 +484,8 @@ describe('FullCalendarView', () => {
   })
 
   it('filters mobile calendar events by media type', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] })
+    vi.setSystemTime(new Date('2026-07-23T12:00:00+08:00'))
     setViewport(480)
     const movie = movieSubscribe(3901, '移动筛选电影')
     const tv = tvSubscribe(3902, '移动筛选剧集')


### PR DESCRIPTION
## 问题与背景

`v2` 的前端覆盖测试在日期跨过 `2026-07-24` 后开始失败。移动端订阅日历默认隐藏过期事件，但媒体类型筛选用例使用固定的 `2026-07-24` 事件并依赖运行当天仍可见，因此该用例会随时间失效。

修正日期夹具后，全量测试继续暴露 `SubscribeSeasonDialog.vue` 的分支覆盖率为 `81.38%`，低于仓库既有的 `85%` 阈值。该下降来自近期新增的不完整季元数据容错分支缺少对应测试。

## 原因分析

- 移动日历用例没有固定系统时间，业务逻辑会按真实当前日期判断事件是否过期。
- 季订阅弹窗已经支持缺失季号、海报、标准日期和通用季名，但测试只覆盖了完整数据，新增分支未进入覆盖路径。

## 解决方案

- 在移动媒体类型筛选用例中仅固定 `Date`，使测试日期边界确定，同时保留真实异步计时行为。
- 增加不完整季元数据场景，验证缺失季号和海报、非标准日期及通用季名的现有回退行为。
- 不修改生产逻辑，不降低或绕过覆盖阈值。

## 影响与风险

- 仅修改两个订阅相关测试文件，不影响运行时行为。
- 日历用例不再随执行日期漂移；季订阅分支覆盖率提升至 `88.14%`。

## 验证

- 专项测试：`2 files / 32 tests` 通过。
- 全量覆盖测试：`79 files / 747 tests` 通过。
- `yarn lint:suppressions:prune`
- `yarn typecheck`
- `yarn lint`
- `yarn format:check`
- `yarn build`
- `git diff --check`

## 关联

- 该基线问题由 #585 的 CI 暴露；本 PR 独立修复，不包含玻璃主题改动。

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at afc82e94b5b492ed4d2ff082da35a2f854a7926e

- 固定移动日历测试日期，消除过期事件漂移
- 覆盖季元数据缺失时的安全回退
- 不修改生产逻辑或运行时行为
<!-- pr-agent-summary:end -->
