### PR TITLE
fix(glass): reset renderer state on unmount

### DIFF
--- a/src/components/theme/GlassOpticalLayer.vue
+++ b/src/components/theme/GlassOpticalLayer.vue
@@ -93,6 +93,10 @@ watchEffect(() => {
 
   setGlassRendererState(rendererState, state)
 })
+
+onScopeDispose(() => {
+  setGlassRendererState(rendererState, 'fallback')
+})
 </script>
 
 <template>

--- a/src/components/theme/__tests__/GlassOpticalLayer.spec.ts
+++ b/src/components/theme/__tests__/GlassOpticalLayer.spec.ts
@@ -5,11 +5,14 @@ import GlassOpticalLayer from '@/components/theme/GlassOpticalLayer.vue'
 
 const rendererCalls = vi.hoisted(() => [] as Array<Record<string, unknown>>)
 const interactionSource = vi.hoisted(() => ({ subscribe: vi.fn() }))
-
-vi.mock('@/composables/useGlassOpticalRenderer', () => ({
-  setGlassRendererState: vi.fn((state: { value: string }, value: string) => {
+const setRendererState = vi.hoisted(() =>
+  vi.fn((state: { value: string }, value: string) => {
     state.value = value
   }),
+)
+
+vi.mock('@/composables/useGlassOpticalRenderer', () => ({
+  setGlassRendererState: setRendererState,
   useGlassOpticalInteractionSource: vi.fn(() => interactionSource),
   useGlassOpticalRenderer: vi.fn((options: Record<string, unknown>) => {
     rendererCalls.push(options)
@@ -24,6 +27,7 @@ vi.mock('@/composables/useGlassOpticalRenderer', () => ({
 describe('GlassOpticalLayer', () => {
   it('uses exactly two visible presentation contexts with one interaction source', () => {
     rendererCalls.length = 0
+    setRendererState.mockClear()
     const wrapper = shallowMount(GlassOpticalLayer, {
       props: {
         appearance: 'clear',
@@ -48,5 +52,8 @@ describe('GlassOpticalLayer', () => {
     expect(rendererCalls.map(options => options.surfaceSpace)).toEqual(['fixed', 'scroll'])
     expect(rendererCalls.every(options => options.interactionSource === interactionSource)).toBe(true)
     expect(rendererCalls.every(options => options.syncDocumentState === false)).toBe(true)
+
+    wrapper.unmount()
+    expect(setRendererState).toHaveBeenLastCalledWith(expect.any(Object), 'fallback')
   })
 })


### PR DESCRIPTION
## 问题与背景

玻璃主题的 fixed-space 与 scroll-space renderer 由 `GlassOpticalLayer` 聚合为一个文档级接管状态。两个子 renderer 都关闭了各自的文档状态同步，但聚合层只在运行期间写入状态，没有显式声明自身销毁后的最终状态。

当前子 renderer 的资源清理会删除根节点属性，因此通常仍能回到 CSS 材质；但这让聚合状态的生命周期依赖子实现的清理副作用，所有权不完整。

## 原因分析

文档级 `data-glass-renderer-state` 由聚合层决定，却没有由同一所有者在 scope 销毁时恢复为非就绪状态。后续若子 renderer 的清理顺序或属性策略变化，标准档、非玻璃主题或无壁纸状态可能残留 WebGL 接管语义。

## 解决方案

- 在 `GlassOpticalLayer` scope 销毁时显式将聚合状态设置为 `fallback`。
- 扩展组件测试，卸载组件后确认最后一次文档状态写入为 `fallback`。

## 影响与风险

- 仅影响光学层卸载时的状态收尾，不改变渲染参数、画面或资源预算。
- 修正后 CSS 材质接管不再依赖两个子 renderer 的内部清理副作用。

## 验证

- 专项测试：`2 files / 24 tests` 通过。
- 全量覆盖测试：`80 files / 784 tests` 通过。
- `yarn lint:suppressions:prune`
- `yarn typecheck`
- `yarn lint`
- `yarn format:check`
- `yarn build`
- `git diff --check`

## 关联

- Follow-up to #585
- 对应 #585 合并后收到的 renderer 聚合状态生命周期 review。

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at ebb7b836ffe0df33f4324eef49d25ec3da74d672

- 卸载光学层时重置渲染器状态
- 防止残留 WebGL 接管语义
- 新增卸载后 `fallback` 状态断言
<!-- pr-agent-summary:end -->
