### PR TITLE
fix(glass): stabilize optical surfaces after scrolling

### DIFF
--- a/src/composables/__tests__/useGlassOpticalRenderer.spec.ts
+++ b/src/composables/__tests__/useGlassOpticalRenderer.spec.ts
@@ -752,6 +752,184 @@ describe('glass optical surface discovery', () => {
     scope.stop()
   })
 
+  it('coalesces scroll updates and renders two stable tail frames without injecting motion', async () => {
+    vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(1200)
+    vi.spyOn(window, 'innerHeight', 'get').mockReturnValue(800)
+    let scrollY = 0
+    vi.spyOn(window, 'scrollY', 'get').mockImplementation(() => scrollY)
+    const three = await import('three')
+    const render = vi.spyOn(three.WebGLRenderer.prototype, 'render')
+    const callbacks = new Map<number, FrameRequestCallback>()
+    let frameId = 0
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation(callback => {
+      frameId += 1
+      callbacks.set(frameId, callback)
+
+      return frameId
+    })
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(id => {
+      callbacks.delete(id)
+    })
+    const surface = appendOpticalSurface('test-surface', { height: 300, width: 400, x: 40, y: 120 })
+    surface.dataset.glassOpticalSurface = ''
+    const scope = effectScope()
+    const renderer = scope.run(() =>
+      useGlassOpticalRenderer({
+        active: ref(true),
+        appearance: ref('clear'),
+        canvas: ref(document.createElement('canvas')),
+        quality: ref('balanced'),
+        routeKey: ref('/dashboard'),
+        surfaceSpace: 'scroll',
+        tintColor: ref('#8D51F9'),
+        wallpaperUrl: ref('https://example.com/wallpaper.jpg'),
+      }),
+    )
+
+    await vi.waitFor(() => expect(renderer?.state.value).toBe('ready'))
+    for (let pass = 0; pass < 4 && callbacks.size > 0; pass += 1) {
+      const scheduledCallbacks = [...callbacks.values()]
+      callbacks.clear()
+      scheduledCallbacks.forEach(callback => callback(performance.now() + pass * 16))
+    }
+    expect(callbacks.size).toBe(0)
+    render.mockClear()
+
+    scrollY = 80
+    window.dispatchEvent(new Event('scroll'))
+    scrollY = 160
+    window.dispatchEvent(new Event('scroll'))
+    expect(callbacks.size).toBe(1)
+
+    const renderedScrollOffsets: number[] = []
+    for (let pass = 0; pass < 3; pass += 1) {
+      const scheduledCallbacks = [...callbacks.values()]
+      callbacks.clear()
+      scheduledCallbacks.forEach(callback => {
+        callback(performance.now() + 100 + pass * 16)
+        const scene = render.mock.calls.at(-1)?.[0] as unknown as {
+          children: Array<{
+            material: {
+              uniforms: {
+                uMotion: { value: number }
+                uScrollOffset: { value: { y: number } }
+                uTrail: { value: Array<{ z: number }> }
+              }
+            }
+          }>
+        }
+        const uniforms = scene.children[0].material.uniforms
+        renderedScrollOffsets.push(uniforms.uScrollOffset.value.y)
+        expect(uniforms.uMotion.value).toBe(0)
+        expect(uniforms.uTrail.value.every(trail => trail.z === 0)).toBe(true)
+      })
+    }
+
+    expect(renderedScrollOffsets).toEqual([160, 160, 160])
+    expect(callbacks.size).toBe(0)
+
+    render.mockClear()
+    window.dispatchEvent(new Event('scrollend'))
+    for (let pass = 0; pass < 2; pass += 1) {
+      const scheduledCallbacks = [...callbacks.values()]
+      callbacks.clear()
+      scheduledCallbacks.forEach(callback => callback(performance.now() + 200 + pass * 16))
+    }
+    expect(render).toHaveBeenCalledTimes(2)
+    expect(callbacks.size).toBe(0)
+
+    window.dispatchEvent(new Event('scroll'))
+    expect(callbacks.size).toBe(1)
+    scope.stop()
+    expect(callbacks.size).toBe(0)
+  })
+
+  it('refreshes visible surface slots after scrolling settles', async () => {
+    vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(1200)
+    vi.spyOn(window, 'innerHeight', 'get').mockReturnValue(800)
+    let scrollY = 0
+    vi.spyOn(window, 'scrollY', 'get').mockImplementation(() => scrollY)
+    vi.spyOn(document.documentElement, 'scrollHeight', 'get').mockReturnValue(2000)
+    const three = await import('three')
+    const render = vi.spyOn(three.WebGLRenderer.prototype, 'render')
+    const callbacks = new Map<number, FrameRequestCallback>()
+    let frameId = 0
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation(callback => {
+      frameId += 1
+      callbacks.set(frameId, callback)
+
+      return frameId
+    })
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(id => {
+      callbacks.delete(id)
+    })
+    const firstSurface = appendOpticalSurface('app-hover-lift-card', {
+      height: 240,
+      width: 360,
+      x: 80,
+      y: 100,
+    })
+    const secondSurface = appendOpticalSurface('app-hover-lift-card', {
+      height: 240,
+      width: 360,
+      x: 80,
+      y: 1100,
+    })
+    const scope = effectScope()
+    const renderer = scope.run(() =>
+      useGlassOpticalRenderer({
+        active: ref(true),
+        appearance: ref('clear'),
+        canvas: ref(document.createElement('canvas')),
+        quality: ref('balanced'),
+        routeKey: ref('/dashboard'),
+        surfaceSpace: 'scroll',
+        tintColor: ref('#8D51F9'),
+        wallpaperUrl: ref('https://example.com/wallpaper.jpg'),
+      }),
+    )
+
+    await vi.waitFor(() => expect(renderer?.state.value).toBe('ready'))
+    for (let pass = 0; pass < 4 && callbacks.size > 0; pass += 1) {
+      const scheduledCallbacks = [...callbacks.values()]
+      callbacks.clear()
+      scheduledCallbacks.forEach(callback => callback(performance.now() + pass * 16))
+    }
+    expect(callbacks.size).toBe(0)
+
+    scrollY = 1000
+    setOpticalSurfaceBounds(firstSurface, { height: 240, width: 360, x: 80, y: -900 })
+    setOpticalSurfaceBounds(secondSurface, { height: 240, width: 360, x: 80, y: 100 })
+    window.dispatchEvent(new Event('scroll'))
+    for (let pass = 0; pass < 3 && callbacks.size > 0; pass += 1) {
+      const scheduledCallbacks = [...callbacks.values()]
+      callbacks.clear()
+      scheduledCallbacks.forEach(callback => callback(performance.now() + 100 + pass * 16))
+    }
+    expect(callbacks.size).toBe(0)
+
+    render.mockClear()
+    window.dispatchEvent(new MouseEvent('pointermove', { clientX: 160, clientY: 160 }))
+    const interactionFrames = [...callbacks.values()]
+    callbacks.clear()
+    interactionFrames.forEach(callback => callback(performance.now() + 200))
+
+    const scene = render.mock.calls.at(-1)?.[0] as unknown as {
+      children: Array<{
+        material: {
+          uniforms: {
+            uMotion: { value: number }
+            uRects: { value: Array<{ y: number }> }
+          }
+        }
+      }>
+    }
+    const uniforms = scene.children[0].material.uniforms
+    expect(uniforms.uMotion.value).toBeGreaterThan(0)
+    expect(uniforms.uRects.value[0].y).toBeCloseTo(1 - (1100 + 240) / 2000)
+    scope.stop()
+  })
+
   it('keeps local material response stable while moving from card A through a gap to card B', async () => {
     vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(1200)
     vi.spyOn(window, 'innerHeight', 'get').mockReturnValue(700)

--- a/src/composables/useGlassOpticalRenderer.ts
+++ b/src/composables/useGlassOpticalRenderer.ts
@@ -433,13 +433,14 @@ void main() {
   vec2 wakePerpendicular = vec2(-wakeDirection.y, wakeDirection.x);
   vec2 trailRefraction = vec2(0.0);
   float trailEnergy = 0.0;
+  float motionRangeCompression = mix(1.0, 1.34, uMotionExpansion);
 
   for (int trailIndex = 0; trailIndex < 4; trailIndex++) {
     if (trailIndex >= uTrailCount) break;
 
     vec4 trail = uTrail[trailIndex];
     vec2 trailDelta = vUv - trail.xy;
-    trailDelta *= uPresentationSize / max(uVisibleViewportSize.y, 1.0);
+    trailDelta *= uPresentationSize / max(uVisibleViewportSize.y, 1.0) * motionRangeCompression;
     float along = dot(trailDelta, wakeDirection);
     float across = dot(trailDelta, wakePerpendicular);
     float trailAlongDensity = mix(42.0, 22.0, uMotionExpansion);
@@ -505,13 +506,13 @@ void main() {
     float localBacklightAbsorption = max(rightEdge * 0.72, bottomEdge * 0.46) * rectMask;
     vec2 pointerDelta = uPointer - vUv;
     vec2 pointerDeltaAspect = pointerDelta;
-    pointerDeltaAspect *= uPresentationSize / max(uVisibleViewportSize.y, 1.0);
+    pointerDeltaAspect *= uPresentationSize / max(uVisibleViewportSize.y, 1.0) * motionRangeCompression;
     float pointerSpread = mix(mix(26.0, 17.0, uQuality), mix(12.0, 8.0, uQuality), frosted);
     pointerSpread *= mix(1.0, 0.46, uMotionExpansion);
     float pointerEnergy =
       clamp(exp(-dot(pointerDeltaAspect, pointerDeltaAspect) * pointerSpread) * uMotion, 0.0, 1.0);
     vec2 wakeDelta = vUv - uPointer;
-    wakeDelta *= uPresentationSize / max(uVisibleViewportSize.y, 1.0);
+    wakeDelta *= uPresentationSize / max(uVisibleViewportSize.y, 1.0) * motionRangeCompression;
     float wakeAlong = dot(wakeDelta, wakeDirection);
     float wakeAcross = dot(wakeDelta, wakePerpendicular);
     float wakeTravel =
@@ -541,7 +542,7 @@ void main() {
     float trailStrength = mix(mix(0.78, 1.08, uQuality), mix(0.96, 1.3, uQuality), frosted);
     float temporalStrength = mix(0.032, 0.042, frosted) * uQuality * (1.0 + flowSurfaceDetail * 0.5);
     vec2 specularDelta = vUv - (uPointer - wakeDirection * mix(0.006, 0.022, uMotionExpansion));
-    specularDelta *= uPresentationSize / max(uVisibleViewportSize.y, 1.0);
+    specularDelta *= uPresentationSize / max(uVisibleViewportSize.y, 1.0) * motionRangeCompression;
     float specularAlong = dot(specularDelta, wakeDirection);
     float specularAcross = dot(specularDelta, wakePerpendicular);
     float singleSpecular =

--- a/src/composables/useGlassOpticalRenderer.ts
+++ b/src/composables/useGlassOpticalRenderer.ts
@@ -686,6 +686,7 @@ void main() {
 `
 
 const SCROLL_SURFACE_UPDATE_INTERVAL_MS = 32
+const SCROLL_STABLE_TAIL_FRAMES = 2
 const FLOW_BUFFER_SCALE = 0.25
 const SURFACE_TRANSITION_DURATION_MS = 96
 
@@ -847,6 +848,12 @@ export function useGlassOpticalRenderer(options: UseGlassOpticalRendererOptions)
   let pendingFlowInjection = 0
   let interactionAnimating = false
   let surfaceResizeTimer: number | null = null
+  let scrollAnimationFrame: number | null = null
+  let scrollDirty = false
+  let scrollSurfaceRefreshPending = false
+  let scrollStableFrameCount = 0
+  let lastRenderedScrollX = window.scrollX
+  let lastRenderedScrollY = window.scrollY
   let scrollSurfaceTimer: number | null = null
   let unsubscribeInteractionSource: (() => void) | null = null
   let lastScrollSurfaceUpdateAt = 0
@@ -896,6 +903,14 @@ export function useGlassOpticalRenderer(options: UseGlassOpticalRendererOptions)
 
     cancelAnimationFrame(animationFrame)
     animationFrame = null
+  }
+
+  function cancelScrollFrame() {
+    if (scrollAnimationFrame !== null) cancelAnimationFrame(scrollAnimationFrame)
+    scrollAnimationFrame = null
+    scrollDirty = false
+    scrollSurfaceRefreshPending = false
+    scrollStableFrameCount = 0
   }
 
   function cancelWallpaperTransitionFrame() {
@@ -1107,7 +1122,7 @@ export function useGlassOpticalRenderer(options: UseGlassOpticalRendererOptions)
     resources.uniforms.uRectCount.value = normalized.length
   }
 
-  function updateSurfaceUniforms(timestamp = performance.now()) {
+  function updateSurfaceUniforms(timestamp = performance.now(), scheduleRender = true) {
     if (!resources) return
 
     const viewportWidth = window.innerWidth
@@ -1147,7 +1162,7 @@ export function useGlassOpticalRenderer(options: UseGlassOpticalRendererOptions)
       for (const element of observedSurfaces) resizeObserver?.observe(element)
     }
     tracksScrollingSurfaces = observedSurfaces.length > 0
-    scheduleFrame()
+    if (scheduleRender) scheduleFrame()
   }
 
   function scheduleSurfaceUpdate() {
@@ -1614,10 +1629,56 @@ export function useGlassOpticalRenderer(options: UseGlassOpticalRendererOptions)
     handleTouchEnd(event as TouchEvent)
   }
 
+  /**
+   * 滚动坐标连续稳定两帧后停止刷新，给 compositor 留出提交最终位置的机会。
+   * 滚动期间只更新采样坐标；稳定后同步一次可见表面，不改变交互能量或时序流场。
+   */
+  function renderScrollFrame(timestamp: number) {
+    scrollAnimationFrame = null
+    if (
+      presentationSpace !== 'scroll' ||
+      !resources ||
+      !toValue(options.active) ||
+      document.visibilityState === 'hidden'
+    ) {
+      scrollDirty = false
+      scrollStableFrameCount = 0
+      return
+    }
+
+    const receivedScrollEvent = scrollDirty
+    scrollDirty = false
+    const scrollX = window.scrollX
+    const scrollY = window.scrollY
+    const coordinatesChanged = scrollX !== lastRenderedScrollX || scrollY !== lastRenderedScrollY
+    lastRenderedScrollX = scrollX
+    lastRenderedScrollY = scrollY
+    resources.uniforms.uScrollOffset.value.set(scrollX, scrollY)
+
+    scrollStableFrameCount = receivedScrollEvent || coordinatesChanged ? 0 : scrollStableFrameCount + 1
+    if (scrollStableFrameCount >= SCROLL_STABLE_TAIL_FRAMES && scrollSurfaceRefreshPending) {
+      scrollSurfaceRefreshPending = false
+      updateSurfaceUniforms(timestamp, false)
+    }
+    if (!interactionAnimating) renderFrame(timestamp)
+
+    if (scrollStableFrameCount < SCROLL_STABLE_TAIL_FRAMES) {
+      scrollAnimationFrame = requestAnimationFrame(renderScrollFrame)
+    }
+  }
+
+  function scheduleScrollFrame() {
+    if (scrollAnimationFrame !== null || presentationSpace !== 'scroll' || !resources) return
+
+    scrollAnimationFrame = requestAnimationFrame(renderScrollFrame)
+  }
+
   function handleScroll() {
     if (presentationSpace === 'scroll' && resources) {
       resources.uniforms.uScrollOffset.value.set(window.scrollX, window.scrollY)
-      scheduleFrame()
+      scrollDirty = true
+      scrollSurfaceRefreshPending = true
+      scheduleScrollFrame()
       return
     }
 
@@ -1633,9 +1694,19 @@ export function useGlassOpticalRenderer(options: UseGlassOpticalRendererOptions)
     }, delay)
   }
 
+  function handleScrollEnd() {
+    if (presentationSpace !== 'scroll' || !resources) return
+
+    scrollDirty = false
+    scrollSurfaceRefreshPending = true
+    scrollStableFrameCount = 0
+    scheduleScrollFrame()
+  }
+
   /** 暂停事件驱动帧但保留 WebGL context、纹理、流场和最后一张稳定画面。 */
   function pauseRenderer() {
     cancelScheduledFrame()
+    cancelScrollFrame()
     cancelWallpaperTransitionFrame()
     interactionAnimating = false
   }
@@ -1742,6 +1813,7 @@ export function useGlassOpticalRenderer(options: UseGlassOpticalRendererOptions)
     }
     window.addEventListener('resize', resizeRenderer, { passive: true })
     window.addEventListener('scroll', handleScroll, { capture: true, passive: true })
+    if (presentationSpace === 'scroll') window.addEventListener('scrollend', handleScrollEnd, { passive: true })
     options.canvas.value?.addEventListener('webglcontextlost', handleContextLost)
     options.canvas.value?.addEventListener('webglcontextrestored', handleContextRestored)
   }
@@ -1758,6 +1830,7 @@ export function useGlassOpticalRenderer(options: UseGlassOpticalRendererOptions)
     }
     window.removeEventListener('resize', resizeRenderer)
     window.removeEventListener('scroll', handleScroll, true)
+    if (presentationSpace === 'scroll') window.removeEventListener('scrollend', handleScrollEnd)
     options.canvas.value?.removeEventListener('webglcontextlost', handleContextLost)
     options.canvas.value?.removeEventListener('webglcontextrestored', handleContextRestored)
   }
@@ -1767,6 +1840,7 @@ export function useGlassOpticalRenderer(options: UseGlassOpticalRendererOptions)
     contextRecoveryPending = false
     interactionAnimating = false
     cancelScheduledFrame()
+    cancelScrollFrame()
     cancelWallpaperTransitionFrame()
     clearBackgroundDisposeTimer()
     if (surfaceUpdateFrame !== null) {

--- a/src/locales/en-US.ts
+++ b/src/locales/en-US.ts
@@ -169,9 +169,9 @@ export default {
     glassReflectionStrength: 'Reflection Brightness',
     glassTransparencyStrength: 'Clarity',
     glassOpticalStrengthHint:
-      'Sample translation, local deformation, and flow memory stay independent; clarity and reflection do not replace motion.',
+      'Sample Translation moves the shared wallpaper. Deformation controls local bending. Flow Strength controls trail range and inertia.',
     glassOpticalStrengthUnavailableHint:
-      'This environment keeps clarity and static reflection; the three dynamic controls return with desktop live quality.',
+      'Standard quality provides clarity and static reflection only. Switch to Balanced or High to adjust sample translation, deformation, and flow.',
     purple: 'Purple',
     custom: 'Custom Style',
     transparency: 'Transparency',

--- a/src/locales/zh-CN.ts
+++ b/src/locales/zh-CN.ts
@@ -166,8 +166,9 @@ export default {
     glassFlowStrength: '流动强度',
     glassReflectionStrength: '反射亮度',
     glassTransparencyStrength: '通透度',
-    glassOpticalStrengthHint: '采样平移、局部形变与流动记忆互相独立；通透度和反射不代替动态参数。',
-    glassOpticalStrengthUnavailableHint: '当前环境保留通透度和静态反射；三个动态参数会在桌面实时质量下恢复。',
+    glassOpticalStrengthHint: '采样平移控制整体滑移，形变强度控制局部弯曲，流动强度控制轨迹范围与惯性。',
+    glassOpticalStrengthUnavailableHint:
+      '标准质量仅提供通透度和静态反射。切换到均衡或高质量后，可调整采样平移、形变和流动。',
     purple: '幻紫',
     custom: '附加样式',
     transparency: '透明度',

--- a/src/locales/zh-TW.ts
+++ b/src/locales/zh-TW.ts
@@ -166,8 +166,9 @@ export default {
     glassFlowStrength: '流動強度',
     glassReflectionStrength: '反射亮度',
     glassTransparencyStrength: '通透度',
-    glassOpticalStrengthHint: '採樣平移、局部形變與流動記憶互相獨立；通透度和反射不代替動態參數。',
-    glassOpticalStrengthUnavailableHint: '目前環境保留通透度和靜態反射；三個動態參數會在桌面即時品質下恢復。',
+    glassOpticalStrengthHint: '採樣平移控制整體滑移，形變強度控制局部彎曲，流動強度控制軌跡範圍與慣性。',
+    glassOpticalStrengthUnavailableHint:
+      '標準品質僅提供通透度和靜態反射。切換到均衡或高品質後，可調整採樣平移、形變和流動。',
     purple: '幻紫',
     custom: '附加樣式',
     transparency: '透明度',


### PR DESCRIPTION
## 问题与背景

玻璃主题的 scroll-space 光学层在用户只滚动、不继续移动指针时，可能停留在滚动过程中的旧壁纸采样。跨越较长页面后还可能出现当前视口卡片无法响应流体交互，直到布局变化或 renderer 被其他事件唤醒。

高质量液态方案的局部指针核、轨迹和尾波覆盖范围也偏大，小范围移动时接近半个视口仍能感知明显变化。设置面板原有提示偏实现术语，且仍把实时质量描述为桌面专属，与当前能力不符。

## 原因分析

scroll-space renderer 原先在 `scroll` 事件中只更新采样坐标并请求单帧。该帧可能早于 compositor 的最终可见位置，也没有滚动事务或稳定收尾帧。

表面集合按当前视口收集，并由 ResizeObserver、DOM 变化等路径重扫。如果另一段内容在滚动后触发重扫，有限表面槽位可能停留在该视口；纯滚动返回时只更新坐标，不会恢复当前可见卡片。

液态方案会随流动强度扩大局部指针核、轨迹、尾波与焦散范围。高区间的空间扩张过于明显，但共享采样平移和动态强度本身没有问题。

## 解决方案

- 将 scroll-space 滚动合并为短时、事件驱动的 rAF 事务，每帧读取最新实际滚动坐标。
- 坐标连续稳定后补两帧同材质重绘，并通过 `scrollend` 强制开始最终稳定确认。
- 在第二个稳定尾帧一次性同步当前视口表面槽位，滚动过程中不反复重排表面。
- pause 和 dispose 都会取消未完成的滚动事务，不创建常驻 rAF。
- 仅收紧高流动区间的局部空间范围。流动强度 50 及以下不变，液态的强度、持续时间和跨卡片共享采样平移保持不变。
- 重写三种语言的设置提示，直接说明标准质量的能力边界和三个动态参数各自控制的视觉结果。

## 影响与风险

改动只影响玻璃主题的共享 optical renderer 和对应设置提示，不涉及登录页、路由、后端、构建配置或数据迁移。

仍然只使用 fixed-space 与 scroll-space 两个有界可见 canvas，不创建每卡 canvas、壁纸副本、隐藏 canvas 或额外 RenderTarget。滚动结束时增加一次可见表面收集，CPU 开销仅发生在短时滚动事务的稳定尾部。

局部范围调整不限制活动卡片，也不改变采样平移的共享语义。流动强度 80 时空间半径约收紧 13%，最大强度时约收紧 25%，保留液态方案的可感知差异。

## 验证

- `yarn test:run`：80 个测试文件、797 项测试通过
- `yarn lint:suppressions:prune`
- `yarn typecheck`
- `yarn lint`
- `yarn format:check`
- `yarn build`
- `git diff --check`
- 真实浏览器覆盖桌面与移动视口的慢速、快速和反向滚动
- 桌面连续六次顶部与底部往返后，当前视口卡片均能立即响应流体交互
- 验证期间始终保持两个 optical canvas，renderer 为 ready，控制台无 WebGL 或 shader 错误，交互结束后帧调度停止

未附公开截图。该问题的关键差异需要连续交互观察，且本地页面包含不适合作为公开材料的媒体数据。

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 04a200f1cf6a33096f0535386f1a5309a4935222

- 稳定滚动空间玻璃渲染收尾
  - 合并滚动事件，连续稳定两帧后停止刷新
  - `scrollend` 触发最终表面同步
  - 暂停与销毁取消待处理动画帧
- 滚动稳定后刷新可见表面槽位
  - 防止长页面滚动后卡片交互失效
- 收紧高流动强度的局部光学范围
  - 保持采样平移和动态能量逻辑
- 补充滚动收尾与表面恢复测试
- 更新三语动态参数与质量提示
- 风险：依赖浏览器 `scrollend` 支持
<!-- pr-agent-summary:end -->
