### PR TITLE
fix(glass): support pointer input in Safari

### DIFF
--- a/src/composables/__tests__/useGlassOpticalRenderer.spec.ts
+++ b/src/composables/__tests__/useGlassOpticalRenderer.spec.ts
@@ -263,6 +263,37 @@ describe('glass optical surface discovery', () => {
     scope.stop()
   })
 
+  it('routes desktop pointer input when the browser does not expose TouchEvent', () => {
+    vi.stubGlobal('TouchEvent', undefined)
+    const scrollListener = vi.fn()
+    const scope = effectScope()
+    scope.run(() => {
+      const source = useGlassOpticalInteractionSource()
+      source.subscribe('scroll', scrollListener)
+    })
+
+    window.dispatchEvent(new MouseEvent('pointermove', { clientX: 400, clientY: 400 }))
+
+    expect(scrollListener).toHaveBeenCalledOnce()
+    scope.stop()
+  })
+
+  it('keeps touch ownership when the browser does not expose TouchEvent', () => {
+    vi.stubGlobal('TouchEvent', undefined)
+    const scrollListener = vi.fn()
+    const scope = effectScope()
+    scope.run(() => {
+      const source = useGlassOpticalInteractionSource()
+      source.subscribe('scroll', scrollListener)
+    })
+
+    dispatchTouchEvent('touchstart', [{ clientX: 400, clientY: 400, identifier: 7 }])
+    dispatchTouchEvent('touchmove', [{ clientX: 420, clientY: 420, identifier: 7 }])
+
+    expect(scrollListener).toHaveBeenCalledTimes(2)
+    scope.stop()
+  })
+
   it('detects a target surface added directly', () => {
     const surface = document.createElement('section')
     surface.dataset.glassOpticalSurface = ''

--- a/src/composables/useGlassOpticalRenderer.ts
+++ b/src/composables/useGlassOpticalRenderer.ts
@@ -193,15 +193,17 @@ export function useGlassOpticalInteractionSource(): GlassOpticalInteractionSourc
     return touchOwners.get(changedTouch.identifier) ?? null
   }
 
+  const isTouchInteractionEvent = (event: PointerEvent | TouchEvent): event is TouchEvent =>
+    event.type.startsWith('touch')
+
   const dispatch = (event: PointerEvent | TouchEvent) => {
-    const owner =
-      event instanceof TouchEvent
-        ? resolveTouchOwner(event)
-        : resolvePointOwner((event as PointerEvent).clientX, (event as PointerEvent).clientY)
+    const owner = isTouchInteractionEvent(event)
+      ? resolveTouchOwner(event)
+      : resolvePointOwner(event.clientX, event.clientY)
     if (!owner) return
 
     for (const listener of listeners[owner]) listener(event)
-    if (event instanceof TouchEvent && (event.type === 'touchend' || event.type === 'touchcancel')) {
+    if (isTouchInteractionEvent(event) && (event.type === 'touchend' || event.type === 'touchcancel')) {
       for (const touch of Array.from(event.changedTouches)) touchOwners.delete(touch.identifier)
     }
   }

--- a/src/composables/useGlassOpticalRenderer.ts
+++ b/src/composables/useGlassOpticalRenderer.ts
@@ -1903,8 +1903,7 @@ export function useGlassOpticalRenderer(options: UseGlassOpticalRendererOptions)
       ? candidates.findIndex(candidate => candidate.key === activeInteractionClip)
       : -1
     if (activeIndex > 0) candidates.unshift(...candidates.splice(activeIndex, 1))
-    const maxCount =
-      window.innerWidth <= 600 ? GLASS_OPTICAL_MAX_SURFACES_MOBILE : GLASS_OPTICAL_MAX_SURFACES_DESKTOP
+    const maxCount = window.innerWidth <= 600 ? GLASS_OPTICAL_MAX_SURFACES_MOBILE : GLASS_OPTICAL_MAX_SURFACES_DESKTOP
     interactionClips = candidates.slice(0, maxCount)
   }
 


### PR DESCRIPTION
## 问题与背景

PR #598 合并后的 GPU 玻璃动态层在 macOS Safari 中无法响应鼠标移动，但同一页面在 Chrome 桌面端和移动端触摸输入下可以工作。

## 原因分析

共享交互源使用 `event instanceof TouchEvent` 区分鼠标与触摸事件。macOS Safari 支持 `pointermove`，但不暴露全局 `TouchEvent` 构造器，因此每次桌面鼠标移动都会在事件分发前抛出 `ReferenceError`。

Chrome 桌面端暴露该构造器，判断可以正常返回 `false`；移动端 Safari 的触摸路径也不触发这一桌面边界，所以此前测试未覆盖该差异。

## 解决方案

- 改用事件类型前缀识别触摸输入，不再依赖可选的全局构造器。
- 保持原有 pointer、touch owner、overlay 排除与 fixed/scroll 分发语义不变。
- 增加 Safari 能力边界测试，覆盖全局 `TouchEvent` 缺失时的桌面 pointer 分发和触摸 owner 连续性。

## 影响与风险

改动仅影响玻璃动态层的输入事件分类，不调整 shader、材质参数、共享场传播或滚动行为。Chrome 与移动端继续使用原有事件来源和分发语义，无配置或数据迁移要求。

## 验证

- `yarn vitest run src/composables/__tests__/useGlassOpticalRenderer.spec.ts`：66 个测试通过
- `yarn typecheck`：通过
- `yarn lint`：通过
- `yarn build`：通过
- macOS Safari 实测：全局 `TouchEvent` 为 `undefined` 时，桌面 pointer 路径可正常执行，fixed/scroll 两个光学 canvas 均保持 `ready`，控制台无对应异常

## 关联

Follow-up to #598

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 2095e170da642e859c5b01be867c8aef1cb42821

- 修复 Safari 缺失 `TouchEvent` 时的指针分发
- 按事件类型识别触摸，保留触摸归属清理
- 新增桌面指针与触摸连续性回归测试
- 无配置、数据或渲染行为兼容性影响
<!-- pr-agent-summary:end -->
