### PR TITLE
fix(glass): preserve collapsed interaction clips

### DIFF
--- a/src/composables/__tests__/useGlassOpticalRenderer.spec.ts
+++ b/src/composables/__tests__/useGlassOpticalRenderer.spec.ts
@@ -1960,6 +1960,64 @@ describe('glass optical surface discovery', () => {
     scope.stop()
   })
 
+  it('restores a temporarily collapsed interaction clip without rebuilding registry membership', async () => {
+    vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(1200)
+    vi.spyOn(window, 'innerHeight', 'get').mockReturnValue(800)
+    const three = await import('three')
+    const render = vi.spyOn(three.WebGLRenderer.prototype, 'render')
+    const outerSurface = appendOpticalSurface('v-card', { height: 500, width: 900, x: 80, y: 100 })
+    outerSurface.dataset.glassOpticalSurface = ''
+    const card = document.createElement('article')
+    card.className = 'app-hover-lift-card'
+    setOpticalSurfaceBounds(card, { height: 180, width: 360, x: 100, y: 140 })
+    outerSurface.append(card)
+    const querySelectorAll = vi.spyOn(outerSurface, 'querySelectorAll')
+    const scope = effectScope()
+    const renderer = scope.run(() =>
+      useGlassOpticalRenderer({
+        active: ref(true),
+        appearance: ref('clear'),
+        canvas: ref(document.createElement('canvas')),
+        quality: ref('balanced'),
+        routeKey: ref('/dashboard'),
+        surfaceSpace: 'scroll',
+        tintColor: ref('#8D51F9'),
+        wallpaperUrl: ref('https://example.com/wallpaper.jpg'),
+      }),
+    )
+
+    await vi.waitFor(() => expect(renderer?.state.value).toBe('ready'))
+    window.dispatchEvent(new MouseEvent('pointermove', { clientX: 160, clientY: 180 }))
+    await vi.waitFor(() => expect(render).toHaveBeenCalled())
+    const getInteractionRectCount = () => {
+      const scene = render.mock.calls.at(-1)?.[0] as unknown as {
+        children: Array<{
+          material: {
+            uniforms: {
+              uInteractionRectCount: { value: number }
+            }
+          }
+        }>
+      }
+
+      return scene.children[0].material.uniforms.uInteractionRectCount.value
+    }
+
+    expect(getInteractionRectCount()).toBe(1)
+    querySelectorAll.mockClear()
+
+    setOpticalSurfaceBounds(card, { height: 12, width: 12, x: 100, y: 140 })
+    ResizeObserverMock.instances.forEach(observer => observer.trigger())
+    await vi.waitFor(() => expect(getInteractionRectCount()).toBe(0))
+
+    setOpticalSurfaceBounds(card, { height: 180, width: 360, x: 100, y: 140 })
+    ResizeObserverMock.instances.forEach(observer => observer.trigger())
+    await vi.waitFor(() => expect(getInteractionRectCount()).toBe(1))
+
+    expect(querySelectorAll).not.toHaveBeenCalled()
+    scope.stop()
+  })
+
   it('keeps the active texture and ready state when a replacement wallpaper fails', async () => {
     const three = await import('three')
     const canvas = document.createElement('canvas')

--- a/src/composables/useGlassOpticalRenderer.ts
+++ b/src/composables/useGlassOpticalRenderer.ts
@@ -1930,7 +1930,6 @@ export function useGlassOpticalRenderer(options: UseGlassOpticalRendererOptions)
       if (seen.has(element) || !element.isConnected || resolveGlassOpticalSurfaceMode(element) !== mode) return
 
       const rect = committedRect ?? getElementPresentationRect(element)
-      if (rect.width < 24 || rect.height < 24) return
 
       seen.add(element)
       candidates.push({ key: element, mode, owner, rect })
@@ -1968,10 +1967,12 @@ export function useGlassOpticalRenderer(options: UseGlassOpticalRendererOptions)
       }
 
       const rect = committedSurfaces.get(clip.key)?.rect ?? getElementPresentationRect(clip.key)
-      if (rect.width < 24 || rect.height < 24) return []
-
       return [{ ...clip, rect }]
     })
+  }
+
+  function isInteractionClipRenderable(rect: GlassOpticalRect) {
+    return rect.width >= 24 && rect.height >= 24
   }
 
   function updateInteractionClips() {
@@ -2003,7 +2004,11 @@ export function useGlassOpticalRenderer(options: UseGlassOpticalRendererOptions)
           inOverscan,
         }
       })
-      .filter(entry => entry.candidate.key === activeInteractionClip || entry.inOverscan)
+      .filter(
+        entry =>
+          isInteractionClipRenderable(entry.candidate.rect) &&
+          (entry.candidate.key === activeInteractionClip || entry.inOverscan),
+      )
       .sort((left, right) => {
         const leftActive = left.candidate.key === activeInteractionClip
         const rightActive = right.candidate.key === activeInteractionClip
@@ -2445,7 +2450,12 @@ export function useGlassOpticalRenderer(options: UseGlassOpticalRendererOptions)
     if (!surface) return null
 
     const matchingClips = interactionClipRegistry
-      .filter(candidate => candidate.owner === surface.key && rectContainsPoint(candidate.rect, x, y))
+      .filter(
+        candidate =>
+          candidate.owner === surface.key &&
+          isInteractionClipRenderable(candidate.rect) &&
+          rectContainsPoint(candidate.rect, x, y),
+      )
       .sort((left, right) => left.rect.width * left.rect.height - right.rect.width * right.rect.height)
 
     return {


### PR DESCRIPTION
## 问题与背景

长列表交互裁剪注册表建立后，卡片在折叠动画、响应式布局或虚拟列表提交期间可能暂时缩小到 `24px` 以下。卡片恢复正常尺寸后，局部玻璃交互仍可能长期缺失。

## 原因分析

注册表刷新把“是否属于当前 surface”与“当前帧是否值得占用 shader 预算”合并成了同一个尺寸判断。候选节点一旦因瞬时尺寸过小被移出注册表，后续 `ResizeObserver` 只会刷新剩余成员，无法让该节点重新获得交互裁剪，除非再次执行完整 DOM 扫描。

## 解决方案

- 注册表成员资格只由 DOM 连接状态、surface owner 和材质模式决定。
- `24px` 尺寸阈值只在 shader 预算选择和 pointer 命中阶段生效。
- 增加折叠后恢复测试，确认节点尺寸恢复时无需重新扫描 DOM 即可重新参与裁剪。

## 影响与风险

改动仅影响均衡和高质量玻璃渲染器的交互裁剪生命周期。暂时折叠的节点会保留在注册表中，但不会占用 shader 槽位或参与 pointer 命中；断开连接、owner 变化和材质模式变化仍沿用原有清理路径。标准 CSS 质量、配置和数据均不受影响，无需迁移。

## 验证

- `yarn test:run`：94 个测试文件、914 个测试通过
- `yarn typecheck`
- `yarn lint`
- `yarn lint:suppressions:prune`
- `yarn build`
- `git diff --check`

## 关联

Refs #600

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 0f1c4df1bd4551849ded97e823da08e9c463bb16

- 保留临时折叠卡片的交互裁剪成员资格
- 将 `24px` 阈值限定于渲染与命中阶段
- 尺寸恢复后无需重新扫描 DOM 即可恢复裁剪
- 新增折叠恢复的回归测试
<!-- pr-agent-summary:end -->
