### PR TITLE
fix(glass): scope fixed shell backplate

### DIFF
--- a/src/@layouts/components/VerticalNavLayout.vue
+++ b/src/@layouts/components/VerticalNavLayout.vue
@@ -76,6 +76,8 @@ export default defineComponent({
     })
 
     return () => {
+      const hasFixedShellBackplate = fixedShellBackplate.layers.value.length > 0
+
       // 👉 Vertical nav
       const verticalNav = h(
         VerticalNav,
@@ -88,15 +90,14 @@ export default defineComponent({
         },
       )
 
-      const fixedShellBackplateNode =
-        fixedShellBackplate.layers.value.length > 0
-          ? h(GlassFixedShellBackplate, {
-              isOverlayNav: mdAndDown.value,
-              isOverlayNavActive: isOverlayNavActive.value,
-              layers: fixedShellBackplate.layers.value,
-              transitionDurationMs: fixedShellBackplate.transitionDurationMs,
-            })
-          : null
+      const fixedShellBackplateNode = hasFixedShellBackplate
+        ? h(GlassFixedShellBackplate, {
+            isOverlayNav: mdAndDown.value,
+            isOverlayNavActive: isOverlayNavActive.value,
+            layers: fixedShellBackplate.layers.value,
+            transitionDurationMs: fixedShellBackplate.transitionDurationMs,
+          })
+        : null
 
       // 👉 Navbar
       const navbar = h(
@@ -158,6 +159,7 @@ export default defineComponent({
             isCollapsedLayout.value && 'layout-vertical-nav-collapsed',
             isHorizontalLayout.value && 'layout-horizontal-nav-active',
             isHorizontalLayout.value && isNavbarScrolled && 'layout-horizontal-nav-scrolled',
+            hasFixedShellBackplate && 'layout-fixed-shell-backplate-active',
             route.meta.layoutWrapperClasses,
             !isHorizontalLayout.value && isNavbarScrolled && 'window-scrolled',
           ],

--- a/src/App.vue
+++ b/src/App.vue
@@ -29,6 +29,7 @@ import { useGlobalOfflineStatus, type ConnectionFailureReason } from '@/composab
 import { useAppActivityLifecycle } from '@/composables/useAppActivityLifecycle'
 import { useGlassWallpaperTransaction } from '@/composables/useGlassWallpaperTransaction'
 import {
+  isChromeFixedShellBackplateBrowser,
   provideGlassFixedShellBackplate,
   shouldUseGlassFixedShellBackplate,
   type GlassFixedShellBackplateLayer,
@@ -308,6 +309,7 @@ function getBackgroundLayerStyle(layer: LoginBackgroundLayer) {
   }
 }
 
+const needsStableFixedBackdrop = isChromeFixedShellBackplateBrowser()
 const fixedShellBackplateLayers = computed<readonly GlassFixedShellBackplateLayer[]>(() => {
   const hasWallpaper = renderedBackgroundLayers.value.some(layer => Boolean(layer.url))
   if (
@@ -315,6 +317,7 @@ const fixedShellBackplateLayers = computed<readonly GlassFixedShellBackplateLaye
       appearance: effectiveGlassSettings.value.glassAppearance,
       hasWallpaper,
       isAuthenticated: Boolean(isLogin.value),
+      needsStableFixedBackdrop,
       quality: effectiveGlassSettings.value.glassQuality,
       themeName: globalTheme.name.value,
     })

--- a/src/App.vue
+++ b/src/App.vue
@@ -29,7 +29,7 @@ import { useGlobalOfflineStatus, type ConnectionFailureReason } from '@/composab
 import { useAppActivityLifecycle } from '@/composables/useAppActivityLifecycle'
 import { useGlassWallpaperTransaction } from '@/composables/useGlassWallpaperTransaction'
 import {
-  isChromeFixedShellBackplateBrowser,
+  isChromiumFixedShellBackplateBrowser,
   provideGlassFixedShellBackplate,
   shouldUseGlassFixedShellBackplate,
   type GlassFixedShellBackplateLayer,
@@ -309,7 +309,7 @@ function getBackgroundLayerStyle(layer: LoginBackgroundLayer) {
   }
 }
 
-const needsStableFixedBackdrop = isChromeFixedShellBackplateBrowser()
+const needsStableFixedBackdrop = isChromiumFixedShellBackplateBrowser()
 const fixedShellBackplateLayers = computed<readonly GlassFixedShellBackplateLayer[]>(() => {
   const hasWallpaper = renderedBackgroundLayers.value.some(layer => Boolean(layer.url))
   if (

--- a/src/composables/__tests__/useGlassFixedShellBackplate.spec.ts
+++ b/src/composables/__tests__/useGlassFixedShellBackplate.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
-  isChromeFixedShellBackplateBrowser,
+  isChromiumFixedShellBackplateBrowser,
   shouldUseGlassFixedShellBackplate,
 } from '@/composables/useGlassFixedShellBackplate'
 
@@ -14,7 +14,7 @@ describe('shouldUseGlassFixedShellBackplate', () => {
     themeName: 'glass',
   }
 
-  it('enables the direct wallpaper backplate only for affected authenticated Chrome rendering', () => {
+  it('enables the direct wallpaper backplate only for affected authenticated Chromium rendering', () => {
     expect(shouldUseGlassFixedShellBackplate(eligible)).toBe(true)
     expect(shouldUseGlassFixedShellBackplate({ ...eligible, needsStableFixedBackdrop: false })).toBe(false)
     expect(shouldUseGlassFixedShellBackplate({ ...eligible, appearance: 'clear' })).toBe(false)
@@ -27,10 +27,10 @@ describe('shouldUseGlassFixedShellBackplate', () => {
   })
 })
 
-describe('isChromeFixedShellBackplateBrowser', () => {
-  it('uses Chrome browser identity without applying the workaround to other Chromium brands', () => {
+describe('isChromiumFixedShellBackplateBrowser', () => {
+  it('uses the Chromium engine brand for Chrome and Edge', () => {
     expect(
-      isChromeFixedShellBackplateBrowser({
+      isChromiumFixedShellBackplateBrowser({
         userAgent: 'Mozilla/5.0 Chrome/140.0.0.0 Safari/537.36',
         userAgentData: {
           brands: [{ brand: 'Chromium' }, { brand: 'Google Chrome' }],
@@ -38,28 +38,44 @@ describe('isChromeFixedShellBackplateBrowser', () => {
       }),
     ).toBe(true)
     expect(
-      isChromeFixedShellBackplateBrowser({
+      isChromiumFixedShellBackplateBrowser({
         userAgent: 'Mozilla/5.0 Chrome/140.0.0.0 Safari/537.36 Edg/140.0.0.0',
         userAgentData: {
           brands: [{ brand: 'Chromium' }, { brand: 'Microsoft Edge' }],
         },
       }),
+    ).toBe(true)
+    expect(
+      isChromiumFixedShellBackplateBrowser({
+        userAgent: 'Mozilla/5.0 Version/26.4 Safari/605.1.15',
+        userAgentData: {
+          brands: [{ brand: 'Safari' }],
+        },
+      }),
     ).toBe(false)
   })
 
-  it('falls back to the traditional user agent while leaving Safari and iOS Chrome unchanged', () => {
+  it.each([
+    ['Chrome', 'Mozilla/5.0 Chrome/140.0.0.0 Safari/537.36'],
+    ['Edge', 'Mozilla/5.0 Chrome/140.0.0.0 Safari/537.36 Edg/140.0.0.0'],
+    ['Opera', 'Mozilla/5.0 Chrome/140.0.0.0 Safari/537.36 OPR/121.0.0.0'],
+    ['Vivaldi', 'Mozilla/5.0 Chrome/140.0.0.0 Safari/537.36 Vivaldi/7.6.0.0'],
+    ['Yandex Browser', 'Mozilla/5.0 Chrome/140.0.0.0 Safari/537.36 YaBrowser/25.8.0.0'],
+    ['Samsung Internet', 'Mozilla/5.0 Chrome/140.0.0.0 Mobile Safari/537.36 SamsungBrowser/28.0'],
+    ['Android WebView', 'Mozilla/5.0; wv) Version/4.0 Chrome/140.0.0.0 Mobile Safari/537.36'],
+    ['Chromium', 'Mozilla/5.0 Chromium/140.0.0.0 Safari/537.36'],
+  ])('falls back to Chromium UA tokens for %s', (_browser, userAgent) => {
+    expect(isChromiumFixedShellBackplateBrowser({ userAgent })).toBe(true)
+  })
+
+  it('leaves Safari and iOS Chrome on the native backdrop path', () => {
     expect(
-      isChromeFixedShellBackplateBrowser({
-        userAgent: 'Mozilla/5.0 Chrome/140.0.0.0 Safari/537.36',
-      }),
-    ).toBe(true)
-    expect(
-      isChromeFixedShellBackplateBrowser({
+      isChromiumFixedShellBackplateBrowser({
         userAgent: 'Mozilla/5.0 Version/26.4 Safari/605.1.15',
       }),
     ).toBe(false)
     expect(
-      isChromeFixedShellBackplateBrowser({
+      isChromiumFixedShellBackplateBrowser({
         userAgent: 'Mozilla/5.0 CriOS/140.0.0.0 Mobile/15E148 Safari/604.1',
       }),
     ).toBe(false)

--- a/src/composables/__tests__/useGlassFixedShellBackplate.spec.ts
+++ b/src/composables/__tests__/useGlassFixedShellBackplate.spec.ts
@@ -1,17 +1,22 @@
 import { describe, expect, it } from 'vitest'
-import { shouldUseGlassFixedShellBackplate } from '@/composables/useGlassFixedShellBackplate'
+import {
+  isChromeFixedShellBackplateBrowser,
+  shouldUseGlassFixedShellBackplate,
+} from '@/composables/useGlassFixedShellBackplate'
 
 describe('shouldUseGlassFixedShellBackplate', () => {
   const eligible = {
     appearance: 'frosted' as const,
     hasWallpaper: true,
     isAuthenticated: true,
+    needsStableFixedBackdrop: true,
     quality: 'css' as const,
     themeName: 'glass',
   }
 
-  it('enables the direct wallpaper backplate only for authenticated frosted CSS rendering', () => {
+  it('enables the direct wallpaper backplate only for affected authenticated Chrome rendering', () => {
     expect(shouldUseGlassFixedShellBackplate(eligible)).toBe(true)
+    expect(shouldUseGlassFixedShellBackplate({ ...eligible, needsStableFixedBackdrop: false })).toBe(false)
     expect(shouldUseGlassFixedShellBackplate({ ...eligible, appearance: 'clear' })).toBe(false)
     expect(shouldUseGlassFixedShellBackplate({ ...eligible, appearance: 'tinted' })).toBe(false)
     expect(shouldUseGlassFixedShellBackplate({ ...eligible, quality: 'balanced' })).toBe(false)
@@ -19,5 +24,44 @@ describe('shouldUseGlassFixedShellBackplate', () => {
     expect(shouldUseGlassFixedShellBackplate({ ...eligible, themeName: 'transparent' })).toBe(false)
     expect(shouldUseGlassFixedShellBackplate({ ...eligible, isAuthenticated: false })).toBe(false)
     expect(shouldUseGlassFixedShellBackplate({ ...eligible, hasWallpaper: false })).toBe(false)
+  })
+})
+
+describe('isChromeFixedShellBackplateBrowser', () => {
+  it('uses Chrome browser identity without applying the workaround to other Chromium brands', () => {
+    expect(
+      isChromeFixedShellBackplateBrowser({
+        userAgent: 'Mozilla/5.0 Chrome/140.0.0.0 Safari/537.36',
+        userAgentData: {
+          brands: [{ brand: 'Chromium' }, { brand: 'Google Chrome' }],
+        },
+      }),
+    ).toBe(true)
+    expect(
+      isChromeFixedShellBackplateBrowser({
+        userAgent: 'Mozilla/5.0 Chrome/140.0.0.0 Safari/537.36 Edg/140.0.0.0',
+        userAgentData: {
+          brands: [{ brand: 'Chromium' }, { brand: 'Microsoft Edge' }],
+        },
+      }),
+    ).toBe(false)
+  })
+
+  it('falls back to the traditional user agent while leaving Safari and iOS Chrome unchanged', () => {
+    expect(
+      isChromeFixedShellBackplateBrowser({
+        userAgent: 'Mozilla/5.0 Chrome/140.0.0.0 Safari/537.36',
+      }),
+    ).toBe(true)
+    expect(
+      isChromeFixedShellBackplateBrowser({
+        userAgent: 'Mozilla/5.0 Version/26.4 Safari/605.1.15',
+      }),
+    ).toBe(false)
+    expect(
+      isChromeFixedShellBackplateBrowser({
+        userAgent: 'Mozilla/5.0 CriOS/140.0.0.0 Mobile/15E148 Safari/604.1',
+      }),
+    ).toBe(false)
   })
 })

--- a/src/composables/useGlassFixedShellBackplate.ts
+++ b/src/composables/useGlassFixedShellBackplate.ts
@@ -21,10 +21,23 @@ interface GlassFixedShellBackplateEligibility {
   hasWallpaper: boolean
   /** 当前页面是否处于认证后的主布局。 */
   isAuthenticated: boolean
+  /** 当前浏览器是否需要绕开 Chrome fixed document backdrop 的重合成路径。 */
+  needsStableFixedBackdrop: boolean
   /** 当前玻璃渲染质量。 */
   quality: ThemeCustomizerGlassQuality
   /** Vuetify 当前解析后的主题名。 */
   themeName: string
+}
+
+interface GlassFixedShellBrowserIdentity {
+  /** User-Agent Client Hints 暴露的浏览器品牌。 */
+  userAgentData?: {
+    brands?: readonly {
+      brand: string
+    }[]
+  }
+  /** Client Hints 不可用时使用的传统浏览器标识。 */
+  userAgent: string
 }
 
 const GLASS_FIXED_SHELL_BACKPLATE_KEY: InjectionKey<GlassFixedShellBackplateContext> =
@@ -35,10 +48,19 @@ const EMPTY_FIXED_SHELL_CONTEXT: GlassFixedShellBackplateContext = {
   transitionDurationMs: 0,
 }
 
-/** 只有磨砂标准使用直接壁纸背板；其他材质和 GPU 质量继续走既有呈现路径。 */
+/** Chrome 使用独立 fixed 背板规避 document backdrop 重合成；Safari 保留原生采样路径。 */
+export function isChromeFixedShellBackplateBrowser(browserIdentity: GlassFixedShellBrowserIdentity = navigator) {
+  const brands = browserIdentity.userAgentData?.brands
+  if (brands?.length) return brands.some(({ brand }) => brand === 'Google Chrome')
+
+  return /\bChrome\/\d+/u.test(browserIdentity.userAgent) && !/\b(?:Edg|OPR)\/\d+/u.test(browserIdentity.userAgent)
+}
+
+/** 只有需要稳定 fixed 背板的 Chrome 磨砂标准布局使用直接壁纸采样。 */
 export function shouldUseGlassFixedShellBackplate(options: GlassFixedShellBackplateEligibility) {
   return (
     options.isAuthenticated &&
+    options.needsStableFixedBackdrop &&
     options.themeName === 'glass' &&
     options.appearance === 'frosted' &&
     options.quality === 'css' &&

--- a/src/composables/useGlassFixedShellBackplate.ts
+++ b/src/composables/useGlassFixedShellBackplate.ts
@@ -21,7 +21,7 @@ interface GlassFixedShellBackplateEligibility {
   hasWallpaper: boolean
   /** 当前页面是否处于认证后的主布局。 */
   isAuthenticated: boolean
-  /** 当前浏览器是否需要绕开 Chrome fixed document backdrop 的重合成路径。 */
+  /** 当前浏览器是否需要绕开 Chromium fixed document backdrop 的重合成路径。 */
   needsStableFixedBackdrop: boolean
   /** 当前玻璃渲染质量。 */
   quality: ThemeCustomizerGlassQuality
@@ -48,15 +48,15 @@ const EMPTY_FIXED_SHELL_CONTEXT: GlassFixedShellBackplateContext = {
   transitionDurationMs: 0,
 }
 
-/** Chrome 使用独立 fixed 背板规避 document backdrop 重合成；Safari 保留原生采样路径。 */
-export function isChromeFixedShellBackplateBrowser(browserIdentity: GlassFixedShellBrowserIdentity = navigator) {
+/** Chromium 使用独立 fixed 背板规避 document backdrop 重合成；WebKit 保留原生采样路径。 */
+export function isChromiumFixedShellBackplateBrowser(browserIdentity: GlassFixedShellBrowserIdentity = navigator) {
   const brands = browserIdentity.userAgentData?.brands
-  if (brands?.length) return brands.some(({ brand }) => brand === 'Google Chrome')
+  if (brands?.length) return brands.some(({ brand }) => brand === 'Chromium')
 
-  return /\bChrome\/\d+/u.test(browserIdentity.userAgent) && !/\b(?:Edg|OPR)\/\d+/u.test(browserIdentity.userAgent)
+  return /\b(?:Chrome|Chromium)\/\d+/u.test(browserIdentity.userAgent)
 }
 
-/** 只有需要稳定 fixed 背板的 Chrome 磨砂标准布局使用直接壁纸采样。 */
+/** 只有需要稳定 fixed 背板的 Chromium 磨砂标准布局使用直接壁纸采样。 */
 export function shouldUseGlassFixedShellBackplate(options: GlassFixedShellBackplateEligibility) {
   return (
     options.isAuthenticated &&

--- a/src/styles/__tests__/glassOverlayMaterial.spec.ts
+++ b/src/styles/__tests__/glassOverlayMaterial.spec.ts
@@ -39,7 +39,7 @@ describe('glass overlay material styles', () => {
 
     expect(styles).toContain('--glass-fixed-shell-backplate-filter: blur(min(var(--glass-blur-raised), 60px))')
     expect(styles).toMatch(
-      /&\[data-glass-appearance='frosted'\]\[data-glass-quality='css'\][\s\S]*?\.layout-vertical-nav::before,[\s\S]*?\.layout-navbar,[\s\S]*?backdrop-filter:\s*none\s*!important;/,
+      /&\[data-glass-appearance='frosted'\]\[data-glass-quality='css'\][\s\S]*?\.layout-wrapper\.layout-fixed-shell-backplate-active \.layout-vertical-nav::before,[\s\S]*?\.layout-wrapper\.layout-fixed-shell-backplate-active \.layout-navbar,[\s\S]*?backdrop-filter:\s*none\s*!important;/,
     )
     expect(backplate).toContain('filter: var(--glass-fixed-shell-backplate-filter)')
     expect(backplate).not.toContain('backdrop-filter')

--- a/src/styles/themes/glass.scss
+++ b/src/styles/themes/glass.scss
@@ -462,11 +462,12 @@ html[data-theme='glass'] {
     }
   }
 
-  // 磨砂标准直接渲染稳定壁纸背板，固定功能层不得读取随页面重绘的 document backdrop。
+  // Chrome 磨砂标准直接渲染稳定壁纸背板，固定功能层不得读取随页面重绘的 document backdrop。
   &[data-glass-appearance='frosted'][data-glass-quality='css'] body[data-theme='glass'] {
-    .layout-vertical-nav::before,
-    .layout-navbar,
-    .layout-wrapper.layout-horizontal-nav-active.layout-horizontal-nav-scrolled.layout-navbar-fixed .layout-navbar {
+    .layout-wrapper.layout-fixed-shell-backplate-active .layout-vertical-nav::before,
+    .layout-wrapper.layout-fixed-shell-backplate-active .layout-navbar,
+    .layout-wrapper.layout-fixed-shell-backplate-active.layout-horizontal-nav-active.layout-horizontal-nav-scrolled.layout-navbar-fixed
+      .layout-navbar {
       -webkit-backdrop-filter: none !important;
       backdrop-filter: none !important;
     }

--- a/src/styles/themes/glass.scss
+++ b/src/styles/themes/glass.scss
@@ -462,7 +462,7 @@ html[data-theme='glass'] {
     }
   }
 
-  // Chrome 磨砂标准直接渲染稳定壁纸背板，固定功能层不得读取随页面重绘的 document backdrop。
+  // Chromium 磨砂标准直接渲染稳定壁纸背板，固定功能层不得读取随页面重绘的 document backdrop。
   &[data-glass-appearance='frosted'][data-glass-quality='css'] body[data-theme='glass'] {
     .layout-wrapper.layout-fixed-shell-backplate-active .layout-vertical-nav::before,
     .layout-wrapper.layout-fixed-shell-backplate-active .layout-navbar,


### PR DESCRIPTION
## 问题与背景

PR #602 为磨砂标准 fixed shell 引入了稳定壁纸背板，以避免 Chromium 浏览器中的侧边栏和顶栏在 document backdrop 重合成时闪烁。

Reviewer 指出，当认证后的背景图层暂时没有可显示壁纸时，布局不会挂载固定背板，但原选择器仍会关闭侧边栏和顶栏的 `backdrop-filter`。此时新背板和原生磨砂都不存在，固定功能层会出现材质缺失。

## 原因分析

背板的运行时启用条件包含“存在壁纸”，CSS 条件却只包含主题、材质和质量，二者没有共享“背板已实际挂载”的状态。

该重合成问题在 Chrome 与 Edge 中均可复现，Firefox 与 Safari 未复现，因此 workaround 应按 Chromium engine 启用，而不是按单一浏览器品牌或所有浏览器启用。

## 解决方案

- 仅在固定背板图层真实存在时，为布局添加 `layout-fixed-shell-backplate-active`。
- 只有该激活类存在时才关闭侧边栏和顶栏的原生 `backdrop-filter`；无壁纸时自动保留原材质路径。
- 优先通过 User-Agent Client Hints 的 `Chromium` brand 识别引擎，并以传统 User-Agent 中的 `Chrome/Chromium` token 作为回退。
- Edge、Opera、Vivaldi、Yandex Browser、Samsung Internet 和 Android WebView 等 Chromium 产品进入同一路径；Firefox、Safari 和 iOS Chrome 保持原生实现。
- 增加无壁纸、浏览器范围和 CSS 激活条件的回归测试。

## 影响与风险

改动仅影响认证后玻璃主题的磨砂标准 fixed shell：

- Chromium 浏览器有壁纸时继续使用 #602 的稳定背板。
- Chromium 浏览器无壁纸时保留原生磨砂，不再出现材质缺失。
- Firefox、Safari 和 iOS Chrome 继续使用原生 backdrop。
- 透明、色调、均衡和高质量路径不变。

浏览器识别优先采用 Client Hints；不提供 Client Hints 的环境使用 Chromium UA token 回退。

## 验证

- `yarn test:run`：96 个测试文件、928 项测试通过
- `yarn typecheck`
- `yarn lint`
- `yarn lint:suppressions:prune`
- `yarn format:check`
- `yarn build`
- `git diff --check`
- Chrome 与 Edge 磨砂标准运行态确认：有背板时激活类存在并关闭 fixed shell 的原生 backdrop
- Firefox 与 Safari 确认继续使用原生 backdrop，未复现 fixed-shell 闪烁

## 关联

- Follow-up to #602
- Reviewer discussion: https://github.com/jxxghp/MoviePilot-Frontend/pull/602#discussion_r3683113723
- Chromium scope discussion: https://github.com/jxxghp/MoviePilot-Frontend/pull/603#discussion_r3683525243
