### PR TITLE
build: enable modern API for indented Sass

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -251,6 +251,10 @@ export default defineConfig(({ command, mode, isPreview }) => ({
   },
   css: {
     preprocessorOptions: {
+      sass: {
+        api: 'modern-compiler',
+        quietDeps: true,
+      },
       scss: {
         api: 'modern-compiler',
         quietDeps: true,


### PR DESCRIPTION
## 问题与背景

Vitest 转换 Vuetify 组件样式时会重复输出 Dart Sass `legacy-js-api` 弃用警告。该警告从 Sass 1.79 起启用，并提示 legacy JavaScript API 将在 Sass 2.0 移除。

## 原因分析

调用栈显示输入来自 `vite-plugin-vuetify` 生成的 `virtual:plugin-vuetify:components/.../*.sass`，随后由 Vite CSS preprocessor 调用 Sass legacy API。

现有 Vite 配置只为 `.scss` 设置了 `api: 'modern-compiler'`。Vite 5 按文件扩展名分别读取 `scss` 和 `sass` 选项，因此 Vuetify 的缩进语法 `.sass` 文件没有命中现有配置，并回落到 legacy API。

## 解决方案

为 `css.preprocessorOptions.sass` 补充与 `scss` 相同的 `modern-compiler` 和 `quietDeps` 配置，使两种 Sass 语法都使用现代编译接口。

没有通过 `silenceDeprecations` 隐藏警告，也不需要升级到尚未发布的 Sass 2.0。

## 影响与风险

改动只影响开发、测试和生产构建阶段的 `.sass` 编译接口，不改变浏览器运行时代码、样式语法、接口、配置或数据。

仓库源码当前使用 `.scss`；新增配置主要覆盖 Vuetify 生成的虚拟 `.sass` 样式。项目没有为该路径配置 legacy importer 或自定义函数，迁移风险较低。

该改动与 #604 的测试日志治理相互独立。

## 验证

- `yarn vitest run`：96 个测试文件、928 个测试通过，Sass legacy API 警告为 0。
- `yarn typecheck`
- `yarn lint`
- `yarn lint:suppressions:prune`
- `yarn format:check`
- `yarn build`：构建通过，Sass legacy API 警告为 0。
- `git diff --check`

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 0481931f93cbffb981e14ac19d6e7b3f3128be73

- 为 `.sass` 启用现代 Sass 编译 API
- 对齐 `.scss` 的依赖警告抑制配置
- 减少 Vuetify 虚拟样式的弃用警告
- 仅影响构建与测试编译流程
<!-- pr-agent-summary:end -->
