### PR TITLE
fix(glass): stabilize fixed shell and initial frosted material

### DIFF
--- a/src/components/theme/GlassFixedShellBackplate.vue
+++ b/src/components/theme/GlassFixedShellBackplate.vue
@@ -81,7 +81,6 @@ const transitionStyle = computed(() => ({
     var(--glass-fixed-shell-nav-inline-size) 100%,
     0 100%
   );
-  transition: clip-path 0.25s ease-in-out;
 }
 
 .layout-wrapper.layout-vertical-nav-collapsed > .glass-fixed-shell-backplate--main {

--- a/src/styles/__tests__/glassOverlayMaterial.spec.ts
+++ b/src/styles/__tests__/glassOverlayMaterial.spec.ts
@@ -94,10 +94,24 @@ describe('glass overlay material styles', () => {
 
   it('keeps the native scroll backplate stable while suspending only GPU dynamics', () => {
     const styles = readFileSync(resolve(cwd(), 'src/styles/themes/glass.scss'), 'utf8')
+    const balancedRuleStart = styles.indexOf("html[data-glass-appearance='frosted'][data-glass-quality='balanced'] {")
+    const balancedRuleEnd = styles.indexOf('\n}', balancedRuleStart)
+    const balancedRule = styles.slice(balancedRuleStart, balancedRuleEnd)
+    const highRuleStart = styles.indexOf("html[data-glass-appearance='frosted'][data-glass-quality='high'] {")
+    const highRuleEnd = styles.indexOf('\n}', highRuleStart)
+    const highRule = styles.slice(highRuleStart, highRuleEnd)
 
     expect(styles).toContain('--glass-native-surface-backdrop-filter')
-    expect(styles).toContain('blur(calc(16px * var(--glass-frost-blur-scale, 1))) saturate(162%)')
-    expect(styles).toContain('blur(calc(10px * var(--glass-frost-blur-scale, 1))) saturate(154%)')
+    expect(balancedRuleStart).toBeGreaterThanOrEqual(0)
+    expect(balancedRuleEnd).toBeGreaterThan(balancedRuleStart)
+    expect(balancedRule).toContain('blur(calc(16px * var(--glass-frost-blur-scale, 1))) saturate(162%)')
+    expect(balancedRule).toContain('--glass-dashboard-backdrop-filter: var(--glass-native-surface-backdrop-filter)')
+    expect(balancedRule).not.toContain('data-glass-renderer-state')
+    expect(highRuleStart).toBeGreaterThanOrEqual(0)
+    expect(highRuleEnd).toBeGreaterThan(highRuleStart)
+    expect(highRule).toContain('blur(calc(10px * var(--glass-frost-blur-scale, 1))) saturate(154%)')
+    expect(highRule).toContain('--glass-dashboard-backdrop-filter: var(--glass-native-surface-backdrop-filter)')
+    expect(highRule).not.toContain('data-glass-renderer-state')
     expect(styles).toMatch(
       /\[data-glass-appearance='frosted'\][\s\S]*?\[data-glass-renderer-state='ready'\]\s*\{[\s\S]*?--glass-surface-backdrop-filter:\s*var\(--glass-native-surface-backdrop-filter\);/,
     )

--- a/src/styles/__tests__/glassOverlayMaterial.spec.ts
+++ b/src/styles/__tests__/glassOverlayMaterial.spec.ts
@@ -46,6 +46,15 @@ describe('glass overlay material styles', () => {
     expect(backplate).toContain('var(--glass-fixed-shell-nav-inline-size) 100%')
     expect(backplate).toContain('.layout-wrapper:is(.layout-horizontal-nav-active, .layout-overlay-nav)')
     expect(backplate).toContain('.glass-fixed-shell-backplate--overlay-nav')
+    const mainBackplateRule = backplate.match(/\.glass-fixed-shell-backplate--main\s*\{(?<declarations>[\s\S]*?)\n\}/u)
+      ?.groups?.declarations
+    const overlayBackplateRule = backplate.match(
+      /\.glass-fixed-shell-backplate--overlay-nav\s*\{(?<declarations>[\s\S]*?)\n\}/u,
+    )?.groups?.declarations
+
+    expect(mainBackplateRule).toBeDefined()
+    expect(mainBackplateRule).not.toMatch(/transition:\s*clip-path/u)
+    expect(overlayBackplateRule).toMatch(/transition:\s*clip-path 0\.25s ease-in-out/u)
     expect(styles).toMatch(/\.layout-vertical-nav \.ps__rail-y\s*\{[\s\S]*?inset-inline-end:\s*0\.5rem !important;/)
   })
 

--- a/src/styles/themes/glass.scss
+++ b/src/styles/themes/glass.scss
@@ -1275,13 +1275,15 @@ html:is([data-glass-quality='balanced'], [data-glass-quality='high'])[data-glass
   }
 }
 
-// 实时档缩小原生磨砂核；通透度继续通过 frost scale 控制纹理保留程度。
-html[data-glass-appearance='frosted'][data-glass-quality='balanced'][data-glass-renderer-state='ready'] {
+// 质量档从首帧起固定原生磨砂核；renderer 就绪只叠加光学层，不再切换静态材质密度。
+html[data-glass-appearance='frosted'][data-glass-quality='balanced'] {
+  --glass-dashboard-backdrop-filter: var(--glass-native-surface-backdrop-filter);
   --glass-native-surface-backdrop-filter: blur(calc(16px * var(--glass-frost-blur-scale, 1))) saturate(162%)
     brightness(var(--glass-transmission-brightness));
 }
 
-html[data-glass-appearance='frosted'][data-glass-quality='high'][data-glass-renderer-state='ready'] {
+html[data-glass-appearance='frosted'][data-glass-quality='high'] {
+  --glass-dashboard-backdrop-filter: var(--glass-native-surface-backdrop-filter);
   --glass-native-surface-backdrop-filter: blur(calc(10px * var(--glass-frost-blur-scale, 1))) saturate(154%)
     brightness(var(--glass-transmission-brightness));
 }


### PR DESCRIPTION
## 问题与背景

磨砂标准材质在 Chromium 中切换 Dashboard 与带动态顶栏的页面时，fixed shell 主背板会随顶栏高度缓慢展开或收缩。磨砂均衡和高质量在刷新后还会先使用标准档模糊核，待光学 renderer 就绪后再切换到各自的最终模糊核，形成一次可见的材质密度变化。

## 原因分析

fixed shell 主背板与移动 overlay 导航共用了 `clip-path` 过渡，但主背板的裁剪范围属于布局几何，路由切换时不应插值。均衡和高质量的 native frosted backplate 此前受 `data-glass-renderer-state='ready'` 条件控制，导致启动阶段和 renderer 就绪后使用不同的 CSS 模糊核。

## 解决方案

- 主 fixed shell 背板取消 `clip-path` transition，使顶栏几何与布局在同一帧提交；移动 overlay 导航继续保留原有过渡。
- 磨砂均衡和高质量从首帧起使用各自最终的 native blur kernel。renderer 就绪后只增加 GPU 光学层，不再替换 CSS 材质核。
- 增加样式边界测试，锁定主背板与 overlay 背板的不同过渡合同，以及三档磨砂材质的首帧模糊规则。

## 影响与风险

改动仅影响玻璃主题 fixed shell 的几何过渡和磨砂均衡/高质量的启动材质。移动 overlay 导航动画、透明与色调材质、用户配置和数据结构不变，无迁移要求。

## 验证

- `yarn vitest run src/components/theme/__tests__/GlassFixedShellBackplate.spec.ts src/composables/__tests__/useGlassFixedShellBackplate.spec.ts src/styles/__tests__/glassOverlayMaterial.spec.ts`
- `yarn typecheck`
- `yarn lint`
- `yarn build`
- `git diff --check`
- Chromium 磨砂标准下反复切换 Dashboard 与推荐页面，主背板不再缓慢展开或收缩。

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at d89ae5acc5607493c59d0a8f5e60cf925868c75c

- 固定壳主背板取消裁剪动画
- 均衡/高质量首帧固定磨砂核
- renderer 就绪仅叠加光学层
- 新增样式边界回归断言
<!-- pr-agent-summary:end -->
