### PR TITLE
fix(router): keep route reveal timeline monotonic

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -6,8 +6,6 @@ declare module 'vue-router' {
     subject?: string
     keepAlive?: boolean
     keepAliveKey?: string
-    /** 来源页面停用成本较高时，分阶段把目标页起始态交给 compositor。 */
-    pagePresentationHandoff?: 'staged'
     layoutWrapperClasses?: string
     navActiveLink?: RouteLocationRaw
     requiresAuth?: boolean

--- a/src/composables/__tests__/usePagePresentationMotion.spec.ts
+++ b/src/composables/__tests__/usePagePresentationMotion.spec.ts
@@ -143,6 +143,38 @@ describe('page presentation motion', () => {
     routeRoot.remove()
   })
 
+  it('ignores a late geometry acknowledgement after reveal has started', () => {
+    const routeRoot = document.createElement('div')
+    Object.defineProperties(routeRoot, {
+      offsetHeight: { configurable: true, get: () => 2096 },
+      offsetWidth: { configurable: true, get: () => 1200 },
+      scrollHeight: { configurable: true, get: () => 2096 },
+      scrollWidth: { configurable: true, get: () => 1200 },
+    })
+    document.body.append(routeRoot)
+
+    expect(motion.start('/dashboard', routeRoot)).toBe(true)
+    const motionEpoch = motion.epoch.value
+    expect(motion.reader.acknowledgeGeometryReady(motionEpoch, 1040)).toBe(true)
+
+    const revealFrame = [...callbacks.values()].at(-1)!
+    revealFrame(1120)
+    const currentFrame = [...callbacks.values()].at(-1)!
+    const currentOpacity = motion.opacity.value
+    const currentProgress = motion.progress.value
+    const currentRevision = motion.revision.value
+    const currentTranslateY = motion.translateY.value
+
+    expect(motion.reader.acknowledgeGeometryReady(motionEpoch, 1160)).toBe(false)
+    expect(motion.opacity.value).toBe(currentOpacity)
+    expect(motion.progress.value).toBe(currentProgress)
+    expect(motion.revision.value).toBe(currentRevision)
+    expect(motion.translateY.value).toBe(currentTranslateY)
+    expect([...callbacks.values()].at(-1)).toBe(currentFrame)
+
+    routeRoot.remove()
+  })
+
   it('keeps frosted material fully composed when the renderer releases its geometry hold', () => {
     document.documentElement.dataset.glassAppearance = 'frosted'
     const routeRoot = document.createElement('div')

--- a/src/composables/__tests__/useRouteEnterMotion.spec.ts
+++ b/src/composables/__tests__/useRouteEnterMotion.spec.ts
@@ -88,17 +88,6 @@ describe('route enter motion', () => {
     expect(motion.phase.value).toBe('running')
   })
 
-  it('commits one paint boundary before a staged handoff', () => {
-    const root = document.createElement('div')
-    const stub = createAnimationStub()
-    root.animate = vi.fn(() => stub.animation)
-    const motion = createMotion()
-
-    motion.start(root, { stagedHandoff: true })
-    runNextFrame()
-    expect(stub.play).toHaveBeenCalledOnce()
-  })
-
   it('cancels the previous animation and pending frame on rapid navigation', () => {
     const root = document.createElement('div')
     const first = createAnimationStub()

--- a/src/composables/usePagePresentationMotion.ts
+++ b/src/composables/usePagePresentationMotion.ts
@@ -29,6 +29,7 @@ const revision = ref(0)
 const routeKey = ref('')
 const translateY = ref(0)
 let animationFrame: number | null = null
+let layoutHoldActive = false
 let layoutHoldStartedAt = 0
 let layoutStableSince = 0
 let layoutSignature = ''
@@ -105,6 +106,7 @@ function getLayoutSignature(root: HTMLElement) {
 function beginReveal(timestamp: number, motionEpoch: number) {
   if (!active.value || epoch.value !== motionEpoch) return
 
+  layoutHoldActive = false
   startedAt = timestamp
   applyMotionFrame(0)
   animationFrame = window.requestAnimationFrame(nextTimestamp => renderFrame(nextTimestamp, motionEpoch))
@@ -112,7 +114,7 @@ function beginReveal(timestamp: number, motionEpoch: number) {
 
 /** GPU surface 比整页高度更早稳定时，直接结束布局等待。 */
 function acknowledgeGeometryReady(motionEpoch: number, timestamp = performance.now()) {
-  if (!active.value || epoch.value !== motionEpoch) return false
+  if (!active.value || epoch.value !== motionEpoch || !layoutHoldActive) return false
 
   if (animationFrame !== null) window.cancelAnimationFrame(animationFrame)
   animationFrame = null
@@ -144,6 +146,7 @@ function sampleLayoutHold(timestamp: number, motionEpoch: number, root: HTMLElem
 }
 
 function settleMotion() {
+  layoutHoldActive = false
   active.value = false
   opacity.value = 1
   progress.value = 1
@@ -191,6 +194,7 @@ function start(nextRouteKey: string, layoutRoot?: HTMLElement | null) {
 
   if (animationFrame !== null) window.cancelAnimationFrame(animationFrame)
   animationFrame = null
+  layoutHoldActive = false
   epoch.value += 1
   const motionEpoch = epoch.value
   routeKey.value = nextRouteKey
@@ -222,6 +226,7 @@ function start(nextRouteKey: string, layoutRoot?: HTMLElement | null) {
   active.value = true
   const timestamp = performance.now()
   if (layoutRoot && !usesCssQuality) {
+    layoutHoldActive = true
     layoutHoldStartedAt = timestamp
     layoutStableSince = timestamp
     layoutSignature = getLayoutSignature(layoutRoot)

--- a/src/composables/useRouteEnterMotion.ts
+++ b/src/composables/useRouteEnterMotion.ts
@@ -2,14 +2,8 @@ import { onScopeDispose, readonly, ref } from 'vue'
 
 export const ROUTE_ENTER_MOTION_DURATION_MS = 180
 export const ROUTE_ENTER_MOTION_EASING = 'cubic-bezier(0.2, 0.8, 0.2, 1)'
-export const ROUTE_ENTER_STAGED_PAINT_BOUNDARIES = 1
 
 export type RouteEnterMotionPhase = 'idle' | 'armed' | 'running'
-
-export interface RouteEnterMotionOptions {
-  /** 重页面离场时多保留一个绘制边界，确保目标页起始态已交给 compositor。 */
-  stagedHandoff?: boolean
-}
 
 function shouldSkipRouteEnterMotion() {
   const launchScreenActive =
@@ -39,22 +33,18 @@ export function useRouteEnterMotion() {
     phase.value = 'idle'
   }
 
-  function playAfterPaints(animation: Animation, remainingPaints: number, motionEpoch: number) {
+  function playAfterPaint(animation: Animation, motionEpoch: number) {
     if (motionEpoch !== epoch || animation !== activeAnimation) return
-
-    if (remainingPaints <= 0) {
-      phase.value = 'running'
-      animation.play()
-      return
-    }
 
     animationFrame = window.requestAnimationFrame(() => {
       animationFrame = null
-      playAfterPaints(animation, remainingPaints - 1, motionEpoch)
+      if (motionEpoch !== epoch || animation !== activeAnimation) return
+      phase.value = 'running'
+      animation.play()
     })
   }
 
-  function start(root: HTMLElement | null | undefined, options: RouteEnterMotionOptions = {}) {
+  function start(root: HTMLElement | null | undefined) {
     cancel()
     if (!root || shouldSkipRouteEnterMotion() || typeof root.animate !== 'function') return false
 
@@ -94,7 +84,7 @@ export function useRouteEnterMotion() {
         // cancel() 会拒绝 finished；epoch 已负责丢弃过期事务。
       })
 
-    playAfterPaints(animation, options.stagedHandoff ? ROUTE_ENTER_STAGED_PAINT_BOUNDARIES : 1, motionEpoch)
+    playAfterPaint(animation, motionEpoch)
     return true
   }
 

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -19,26 +19,17 @@ const routeCacheKey = computed(() => {
 
 // 页面过渡按实际页面身份触发；keep-alive 页面避免 query 变化时反复入场。
 const routeTransitionKey = computed(() => (route.meta.keepAlive ? routeCacheKey.value : route.fullPath))
-const routePresentationState = computed(() => ({
-  handoff: route.meta.pagePresentationHandoff,
-  key: routeTransitionKey.value,
-}))
 const pageRouteRef = ref<HTMLElement | null>(null)
 
 // 默认布局只编排路由事务；普通页面与玻璃材质分别由各自 driver 执行动画。
-function playPageEnterMotion(
-  nextPresentation = routePresentationState.value,
-  previousPresentation?: typeof routePresentationState.value,
-) {
+function playPageEnterMotion() {
   routeEnterMotion.cancel()
-  if (pagePresentationMotion.start(nextPresentation.key, pageRouteRef.value)) return
+  if (pagePresentationMotion.start(routeTransitionKey.value, pageRouteRef.value)) return
 
-  routeEnterMotion.start(pageRouteRef.value, {
-    stagedHandoff: previousPresentation?.handoff === 'staged',
-  })
+  routeEnterMotion.start(pageRouteRef.value)
 }
 
-watch(routePresentationState, playPageEnterMotion, { flush: 'post' })
+watch(routeTransitionKey, playPageEnterMotion, { flush: 'post' })
 
 onMounted(playPageEnterMotion)
 

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -50,7 +50,6 @@ const router = createRouter({
           component: () => import('../pages/recommend.vue'),
           meta: {
             keepAlive: true,
-            pagePresentationHandoff: 'staged',
             requiresAuth: true,
             permission: 'discovery',
             feature: PERMISSION_FEATURE.DISCOVERY_RECOMMEND,


### PR DESCRIPTION
## 问题与背景

PR #611 合并后的 Review 指出两项有效问题：

1. renderer 的 geometry acknowledgement 在 reveal 已开始后仍可能取消当前动画帧并重新启动时间线，导致进度回退。
2. 推荐页的 staged handoff 与默认路径都只等待一次 paint boundary，相关 route meta 和 options 已成为无效合同。

## 原因分析

`acknowledgeGeometryReady` 只校验事务是否 active 以及 epoch 是否匹配，没有区分 layout hold 和 reveal 阶段。相同 epoch 的延迟 acknowledgement 因此会重新写入 `startedAt` 和初始帧。

staged handoff 此前已从两个 paint boundary 缩短为一个，但条件分支和上层元数据仍被保留，两个分支的运行行为完全相同。

## 解决方案

- 显式记录 layout hold 是否仍有效；geometry acknowledgement 仅能释放当前 hold 一次。
- reveal 开始、事务完成、取消或新事务启动时统一清理 hold 状态。
- 增加回归测试，确认 late acknowledgement 不改变 progress、opacity、translateY、revision 或当前动画帧。
- 删除无效的 staged handoff options、route meta、类型声明和专用测试，将普通路由动画明确收敛为一次 paint boundary 后播放。

geometry gate 期间的 GPU surface 权重保持不变。静态磨砂材质仍由 native backplate 持有，提前恢复旧 GPU surface 会重新引入过期矩形或 mask 的风险。

## 影响与风险

改动只影响路由呈现事务的 acknowledgement 时序和已经无效的 staged handoff 配置，不改变动画曲线、时长、磨砂材质密度或 renderer 的几何稳定门。

无需配置迁移或数据迁移。

## 验证

- `yarn test:run src/composables/__tests__/usePagePresentationMotion.spec.ts src/composables/__tests__/useRouteEnterMotion.spec.ts`
- `yarn test:run src/composables/__tests__/useGlassOpticalRenderer.spec.ts`
- `yarn typecheck`
- `yarn lint:suppressions:prune`
- `yarn lint`
- `yarn format:check`
- `yarn build`
- `git diff --check`

共 91 项关联测试通过，类型检查、代码检查、格式检查和生产构建通过。

## 关联

Follow-up to #611.

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 80366b5e003faa1b85e09419dbdeed8a259a4e16

- 防止延迟几何回执重启动效时间线
- 路由入场统一为单次绘制后播放
- 移除无效的 staged handoff 元数据
- 新增回归测试保护动画进度稳定性
- 不涉及接口、配置或数据迁移
- 风险：依赖浏览器绘制与 WAAPI 时序
<!-- pr-agent-summary:end -->
