### PR TITLE
fix(glass): align frosted fixed and scroll materials

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1141,35 +1141,35 @@ onUnmounted(() => {
       <!-- 全局磨砂层 -->
       <div v-if="shouldRenderGlobalBlurLayer" class="global-blur-layer"></div>
     </div>
-    <GlassOpticalLayer
-      v-if="shouldRenderGlassOpticalLayer"
-      :appearance="effectiveGlassSettings.glassAppearance"
-      :deformation-strength="opticalDeformationStrength"
-      :flow-strength="opticalFlowStrength"
-      :quality="opticalQuality === 'high' ? 'high' : 'balanced'"
-      :reflection-strength="opticalReflectionStrength"
-      :transparency-strength="opticalTransparencyStrength"
-      :transmission-strength="opticalTransmissionStrength"
-      :translation-strength="opticalTranslationStrength"
-      :route-key="route.fullPath"
-      :tint-color="globalTheme.current.value.colors.primary"
-      :transition-duration="BACKGROUND_CROSSFADE_DURATION_MS"
-      :transition-started-at="backgroundCrossfadeStartedAt"
-      :wallpaper-url="activeOpticalBackgroundImage"
-      :previous-wallpaper-url="previousOpticalBackgroundImage"
-      :pending-wallpaper-url="pendingOpticalBackgroundImage"
-      :pending-wallpaper-revision="pendingOpticalWallpaperRevision"
-      :activate-wallpaper-revision="activateOpticalWallpaperRevision"
-      @wallpaper-activation-failed="handleOpticalWallpaperActivationFailed"
-      @wallpaper-activated="handleOpticalWallpaperActivated"
-      @wallpaper-preparation-failed="handleOpticalWallpaperPreparationFailed"
-      @wallpaper-prepared="handleOpticalWallpaperPrepared"
-    />
     <!-- 页面内容 -->
     <VApp
       :class="{ 'app-shell--login-wallpaper': isLoginWallpaperRoute }"
       :data-login-visual-profile="isLoginWallpaperRoute ? loginVisualProfile : undefined"
     >
+      <GlassOpticalLayer
+        v-if="shouldRenderGlassOpticalLayer"
+        :appearance="effectiveGlassSettings.glassAppearance"
+        :deformation-strength="opticalDeformationStrength"
+        :flow-strength="opticalFlowStrength"
+        :quality="opticalQuality === 'high' ? 'high' : 'balanced'"
+        :reflection-strength="opticalReflectionStrength"
+        :transparency-strength="opticalTransparencyStrength"
+        :transmission-strength="opticalTransmissionStrength"
+        :translation-strength="opticalTranslationStrength"
+        :route-key="route.fullPath"
+        :tint-color="globalTheme.current.value.colors.primary"
+        :transition-duration="BACKGROUND_CROSSFADE_DURATION_MS"
+        :transition-started-at="backgroundCrossfadeStartedAt"
+        :wallpaper-url="activeOpticalBackgroundImage"
+        :previous-wallpaper-url="previousOpticalBackgroundImage"
+        :pending-wallpaper-url="pendingOpticalBackgroundImage"
+        :pending-wallpaper-revision="pendingOpticalWallpaperRevision"
+        :activate-wallpaper-revision="activateOpticalWallpaperRevision"
+        @wallpaper-activation-failed="handleOpticalWallpaperActivationFailed"
+        @wallpaper-activated="handleOpticalWallpaperActivated"
+        @wallpaper-preparation-failed="handleOpticalWallpaperPreparationFailed"
+        @wallpaper-prepared="handleOpticalWallpaperPrepared"
+      />
       <RouterView />
       <!-- 全局共享弹窗入口，列表与卡片按需在这里挂载业务弹窗。 -->
       <SharedDialogHost />

--- a/src/composables/__tests__/useGlassFixedShellBackplate.spec.ts
+++ b/src/composables/__tests__/useGlassFixedShellBackplate.spec.ts
@@ -14,13 +14,13 @@ describe('shouldUseGlassFixedShellBackplate', () => {
     themeName: 'glass',
   }
 
-  it('enables the direct wallpaper backplate only for affected authenticated Chromium rendering', () => {
+  it('enables the direct wallpaper backplate for every frosted Chromium quality', () => {
     expect(shouldUseGlassFixedShellBackplate(eligible)).toBe(true)
+    expect(shouldUseGlassFixedShellBackplate({ ...eligible, quality: 'balanced' })).toBe(true)
+    expect(shouldUseGlassFixedShellBackplate({ ...eligible, quality: 'high' })).toBe(true)
     expect(shouldUseGlassFixedShellBackplate({ ...eligible, needsStableFixedBackdrop: false })).toBe(false)
     expect(shouldUseGlassFixedShellBackplate({ ...eligible, appearance: 'clear' })).toBe(false)
     expect(shouldUseGlassFixedShellBackplate({ ...eligible, appearance: 'tinted' })).toBe(false)
-    expect(shouldUseGlassFixedShellBackplate({ ...eligible, quality: 'balanced' })).toBe(false)
-    expect(shouldUseGlassFixedShellBackplate({ ...eligible, quality: 'high' })).toBe(false)
     expect(shouldUseGlassFixedShellBackplate({ ...eligible, themeName: 'transparent' })).toBe(false)
     expect(shouldUseGlassFixedShellBackplate({ ...eligible, isAuthenticated: false })).toBe(false)
     expect(shouldUseGlassFixedShellBackplate({ ...eligible, hasWallpaper: false })).toBe(false)

--- a/src/composables/__tests__/useGlassOpticalRenderer.spec.ts
+++ b/src/composables/__tests__/useGlassOpticalRenderer.spec.ts
@@ -456,6 +456,47 @@ describe('glass optical surface discovery', () => {
     ])
   })
 
+  it('keeps frosted fixed surfaces on dynamics-only GPU composition', async () => {
+    const three = await import('three')
+    const render = vi.spyOn(three.WebGLRenderer.prototype, 'render')
+    const canvas = document.createElement('canvas')
+    const appearance = ref<'clear' | 'frosted' | 'tinted'>('clear')
+    appendOpticalSurface('layout-vertical-nav', { height: 800, width: 260, x: 0, y: 0 })
+    const scope = effectScope()
+    const renderer = scope.run(() =>
+      useGlassOpticalRenderer({
+        active: ref(true),
+        appearance,
+        canvas: ref(canvas),
+        quality: ref('balanced'),
+        routeKey: ref('/dashboard'),
+        surfaceSpace: 'fixed',
+        tintColor: ref('#8D51F9'),
+        wallpaperUrl: ref('https://example.com/wallpaper.jpg'),
+      }),
+    )
+
+    await vi.waitFor(() => expect(renderer?.state.value).toBe('ready'))
+    const scene = render.mock.calls.at(-1)?.[0] as unknown as {
+      children: Array<{
+        material: {
+          uniforms: {
+            uDynamicsOnly: { value: number }
+          }
+        }
+      }>
+    }
+    const dynamicsOnly = scene.children[0].material.uniforms.uDynamicsOnly
+    expect(dynamicsOnly.value).toBe(0)
+
+    appearance.value = 'frosted'
+    await vi.waitFor(() => expect(dynamicsOnly.value).toBe(1))
+
+    appearance.value = 'tinted'
+    await vi.waitFor(() => expect(dynamicsOnly.value).toBe(0))
+    scope.stop()
+  })
+
   it('re-samples scroll surfaces and material weight on a shared page motion revision', async () => {
     vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(1200)
     vi.spyOn(window, 'innerHeight', 'get').mockReturnValue(800)

--- a/src/composables/useGlassFixedShellBackplate.ts
+++ b/src/composables/useGlassFixedShellBackplate.ts
@@ -56,14 +56,13 @@ export function isChromiumFixedShellBackplateBrowser(browserIdentity: GlassFixed
   return /\b(?:Chrome|Chromium)\/\d+/u.test(browserIdentity.userAgent)
 }
 
-/** 只有需要稳定 fixed 背板的 Chromium 磨砂标准布局使用直接壁纸采样。 */
+/** Chromium 磨砂 fixed 层使用稳定壁纸背板，避免读取随页面重绘的 document backdrop。 */
 export function shouldUseGlassFixedShellBackplate(options: GlassFixedShellBackplateEligibility) {
   return (
     options.isAuthenticated &&
     options.needsStableFixedBackdrop &&
     options.themeName === 'glass' &&
     options.appearance === 'frosted' &&
-    options.quality === 'css' &&
     options.hasWallpaper
   )
 }

--- a/src/composables/useGlassOpticalRenderer.ts
+++ b/src/composables/useGlassOpticalRenderer.ts
@@ -1399,6 +1399,8 @@ export function useGlassOpticalRenderer(options: UseGlassOpticalRendererOptions)
   let resumePromise: Promise<void> | null = null
   let resumeVersion = 0
   const presentationSpace = options.surfaceSpace ?? 'fixed'
+  const usesDynamicsOnly = () =>
+    presentationSpace === 'scroll' || (presentationSpace === 'fixed' && toValue(options.appearance) === 'frosted')
   const wallpaperSourceCache = options.wallpaperSourceCache ?? createGlassWallpaperSourceCache()
 
   /** 滚动期间由原生 backdrop 接管壁纸；稳定态恢复完整纹理折射与流体反馈。 */
@@ -3664,7 +3666,7 @@ export function useGlassOpticalRenderer(options: UseGlassOpticalRendererOptions)
         uBackgroundVisibility: { value: materialResponse.backgroundVisibility },
         uCoverScale: { value: new three.Vector2(1, 1) },
         uDeformationStrength: { value: getDeformationStrengthScale() },
-        uDynamicsOnly: { value: presentationSpace === 'scroll' ? 1 : 0 },
+        uDynamicsOnly: { value: usesDynamicsOnly() ? 1 : 0 },
         uFlowTexture: { value: null },
         uFlowStrength: { value: getFlowStrengthScale() },
         uHasFlowTexture: { value: 0 },
@@ -3818,6 +3820,7 @@ export function useGlassOpticalRenderer(options: UseGlassOpticalRendererOptions)
         )
         resources.uniforms.uAppearance.value = getGlassAppearanceUniformValue(appearance)
         resources.uniforms.uBackgroundVisibility.value = materialResponse.backgroundVisibility
+        resources.uniforms.uDynamicsOnly.value = usesDynamicsOnly() ? 1 : 0
         resources.uniforms.uFrostDetailLevel.value = materialResponse.frostDetailLevel
         resources.uniforms.uSurfaceDensity.value = materialResponse.surfaceDensity
         resources.uniforms.uTintDensity.value = materialResponse.tintDensity

--- a/src/styles/__tests__/glassOverlayMaterial.spec.ts
+++ b/src/styles/__tests__/glassOverlayMaterial.spec.ts
@@ -33,13 +33,19 @@ describe('glass overlay material styles', () => {
     )
   })
 
-  it('keeps frosted CSS fixed shells on the stable wallpaper backplate', () => {
+  it('keeps Chromium frosted fixed shells on the stable wallpaper backplate', () => {
     const styles = readFileSync(resolve(cwd(), 'src/styles/themes/glass.scss'), 'utf8')
     const backplate = readFileSync(resolve(cwd(), 'src/components/theme/GlassFixedShellBackplate.vue'), 'utf8')
 
     expect(styles).toContain('--glass-fixed-shell-backplate-filter: blur(min(var(--glass-blur-raised), 60px))')
     expect(styles).toMatch(
       /&\[data-glass-appearance='frosted'\]\[data-glass-quality='css'\][\s\S]*?\.layout-wrapper\.layout-fixed-shell-backplate-active \.layout-vertical-nav::before,[\s\S]*?\.layout-wrapper\.layout-fixed-shell-backplate-active \.layout-navbar,[\s\S]*?backdrop-filter:\s*none\s*!important;/,
+    )
+    expect(styles).toMatch(
+      /\[data-glass-appearance='frosted'\]\[data-glass-quality='balanced'\]\s*\{[\s\S]*?--glass-fixed-shell-backplate-filter:\s*var\(--glass-native-surface-backdrop-filter\);/,
+    )
+    expect(styles).toMatch(
+      /\[data-glass-appearance='frosted'\]\[data-glass-quality='high'\]\s*\{[\s\S]*?--glass-fixed-shell-backplate-filter:\s*var\(--glass-native-surface-backdrop-filter\);/,
     )
     expect(backplate).toContain('filter: var(--glass-fixed-shell-backplate-filter)')
     expect(backplate).not.toContain('backdrop-filter')
@@ -120,6 +126,9 @@ describe('glass overlay material styles', () => {
     )
     expect(styles).toMatch(
       /\[data-glass-renderer-state='ready'\][\s\S]*?\.app-hover-lift-card:not\(\.media-card--image-loaded\)[\s\S]*?backdrop-filter:\s*var\(--glass-native-surface-backdrop-filter\)\s*!important;/,
+    )
+    expect(styles).toMatch(
+      /\.layout-wrapper:not\(\.layout-fixed-shell-backplate-active\) \.layout-vertical-nav::before,[\s\S]*?backdrop-filter:\s*var\(--glass-native-surface-backdrop-filter\)\s*!important;/,
     )
     expect(styles).toMatch(
       /\.settings-section-card\.app-grouped-list\s*\{[\s\S]*?backdrop-filter:\s*var\(--glass-native-surface-backdrop-filter\)\s*!important;/,

--- a/src/styles/themes/glass.scss
+++ b/src/styles/themes/glass.scss
@@ -1,6 +1,8 @@
 /* stylelint-disable no-descending-specificity */
 /* stylelint-disable scss/at-rule-no-unknown */
 
+@use '@configured-variables' as variables;
+
 // 材质只覆盖统一表面 token；质量档只替换光学层，不改变业务组件契约。
 html[data-theme='glass'] {
   --glass-surface: rgba(11, 19, 34, calc(0.02 + var(--glass-surface-density, 0.62) * 0.3));
@@ -462,7 +464,7 @@ html[data-theme='glass'] {
     }
   }
 
-  // Chromium 磨砂标准直接渲染稳定壁纸背板，固定功能层不得读取随页面重绘的 document backdrop。
+  // Chromium 磨砂 fixed 层直接渲染稳定壁纸背板，固定功能层不得读取随页面重绘的 document backdrop。
   &[data-glass-appearance='frosted'][data-glass-quality='css'] body[data-theme='glass'] {
     .layout-wrapper.layout-fixed-shell-backplate-active .layout-vertical-nav::before,
     .layout-wrapper.layout-fixed-shell-backplate-active .layout-navbar,
@@ -1193,6 +1195,7 @@ html[data-theme='glass'] {
 
 .glass-optical-layer--fixed {
   position: fixed;
+  z-index: variables.$layout-vertical-nav-layout-navbar-z-index;
 }
 
 // 文档表面与该呈现层共享滚动坐标，canvas backing buffer 仍由 renderer 的质量预算约束。
@@ -1256,6 +1259,12 @@ html[data-glass-appearance='frosted']:is(
     backdrop-filter: none !important;
   }
 
+  .layout-wrapper:not(.layout-fixed-shell-backplate-active) .layout-vertical-nav::before,
+  .layout-wrapper:not(.layout-fixed-shell-backplate-active) .layout-navbar {
+    -webkit-backdrop-filter: var(--glass-native-surface-backdrop-filter) !important;
+    backdrop-filter: var(--glass-native-surface-backdrop-filter) !important;
+  }
+
   .layout-wrapper.window-scrolled.layout-navbar-fixed .layout-navbar,
   .layout-wrapper.layout-horizontal-nav-active.layout-horizontal-nav-scrolled.layout-navbar-fixed .layout-navbar {
     -webkit-backdrop-filter: var(--glass-navbar-scrolled-backdrop-filter) !important;
@@ -1280,12 +1289,14 @@ html[data-glass-appearance='frosted'][data-glass-quality='balanced'] {
   --glass-dashboard-backdrop-filter: var(--glass-native-surface-backdrop-filter);
   --glass-native-surface-backdrop-filter: blur(calc(16px * var(--glass-frost-blur-scale, 1))) saturate(162%)
     brightness(var(--glass-transmission-brightness));
+  --glass-fixed-shell-backplate-filter: var(--glass-native-surface-backdrop-filter);
 }
 
 html[data-glass-appearance='frosted'][data-glass-quality='high'] {
   --glass-dashboard-backdrop-filter: var(--glass-native-surface-backdrop-filter);
   --glass-native-surface-backdrop-filter: blur(calc(10px * var(--glass-frost-blur-scale, 1))) saturate(154%)
     brightness(var(--glass-transmission-brightness));
+  --glass-fixed-shell-backplate-filter: var(--glass-native-surface-backdrop-filter);
 }
 
 // 异步滚动期间只暂停 GPU 动态层；原生壁纸基底不发生材质切换。


### PR DESCRIPTION
## 问题与背景

磨砂均衡、高质量下，fixed 侧边栏和顶栏比 Dashboard、搜索结果等 scroll 卡片更通透。同一质量档的功能层与内容层因此呈现出不同的材质密度。

## 原因分析

scroll 卡片在滚动稳定性调整后始终由原生 backplate 提供静态磨砂，GPU renderer 只输出动态光学效果；fixed 功能层则主要依赖 GPU renderer 同时输出静态材质和动态效果。两类表面使用了不同的静态散射与壁纸采样路径，导致模糊、饱和度和通透度不一致。

这不是刷新或路由切换造成的随机状态泄漏，而是 fixed 与 scroll 的材质职责不同。

## 解决方案

- Chromium 磨砂三档统一启用裁剪到 fixed shell 的稳定壁纸背板，避免读取随页面重绘的 document backdrop。
- 均衡、高质量 fixed 背板复用 scroll 卡片相同的原生磨砂核。
- 磨砂 fixed renderer 收敛为 dynamics-only，只保留流体、焦散和高光，不再重复输出静态材质。
- Safari、Firefox 继续使用原生 fixed backdrop，并复用与 scroll 卡片相同的材质参数。
- 调整 fixed 光学层级，使动态效果位于侧栏和顶栏之上，同时仍由 Vuetify overlay 覆盖。

## 影响与风险

Chromium 会增加一个裁剪到 fixed shell 的稳定合成背板，同时 fixed GPU renderer 从完整静态材质降为 dynamics-only。实现不增加 WebGL context、逐卡 surface 或滚动坐标采样。

现有路由切换和长滚动回归未发现主线程异常、材质切换或弹层遮挡回归。该变更未进行同设备 GPU 百分比 A/B，因此不宣称严格零 GPU 差异。

无需配置迁移或数据迁移。

## 验证

- `yarn test:run src/composables/__tests__/useGlassFixedShellBackplate.spec.ts src/components/theme/__tests__/GlassFixedShellBackplate.spec.ts src/composables/__tests__/useGlassOpticalRenderer.spec.ts src/styles/__tests__/glassOverlayMaterial.spec.ts`
- `yarn typecheck`
- `yarn lint:suppressions:prune`
- `yarn lint`
- `yarn format:check`
- `yarn build`
- `git diff --check`

95 项关联测试通过，类型检查、代码检查、格式检查和生产构建通过。

Chrome 磨砂均衡、高质量下，Dashboard、推荐及长滚动前后的 fixed 与 scroll filter 保持一致，fixed dynamics 仍有指针响应，弹层覆盖正常。Safari 均衡、高质量使用相同磨砂核。维护者已完成对照视觉验收。

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at e8f1fec788898da09a53ec9b07af44236112ea6c

- 统一 Chromium 磨砂固定层材质
  - 所有质量档启用稳定壁纸背板
  - 均衡和高质量复用原生磨砂核
- 固定层 GPU 渲染改为动态效果
  - 磨砂模式不再重复绘制静态材质
  - 外观切换时同步更新渲染 uniform
- 调整光学层层级与回退滤镜
  - 光学层位于导航和顶栏之上
  - 非背板场景保留原生滤镜
- 补充背板、渲染及样式回归测试
  - 无配置或数据迁移需求
  - 风险为 Chromium 合成与 GPU 开销变化
<!-- pr-agent-summary:end -->
