### PR TITLE
test(subscribe): cover popular media deduplication

### DIFF
--- a/src/views/subscribe/__tests__/SubscribePopularView.spec.ts
+++ b/src/views/subscribe/__tests__/SubscribePopularView.spec.ts
@@ -241,13 +241,49 @@ describe('SubscribePopularView', () => {
     expect(screen.getByText('热门第二页')).toBeInTheDocument()
   })
 
+  it('deduplicates media across pages and stops when an identity set repeats', async () => {
+    const first = createSubscribeMovie({ title: '热门去重第一页', tmdb_id: 810 })
+    const second = createSubscribeMovie({ title: '热门去重第二页', tmdb_id: 820 })
+    const requestedPages: string[] = []
+    server.use(
+      http.get(subscribeApiUrls.popular, ({ request }) => {
+        const page = new URL(request.url).searchParams.get('page') ?? ''
+        requestedPages.push(page)
+        if (page === '1') return HttpResponse.json([first])
+        if (page === '2') {
+          return HttpResponse.json([{ ...first, title: '第一页跨页重复项' }, second])
+        }
+        return HttpResponse.json([
+          { ...second, title: '第二页乱序重复项' },
+          { ...first, title: '第一页乱序重复项' },
+          { ...first, title: '第一页页内重复项' },
+        ])
+      }),
+    )
+    const user = userEvent.setup()
+
+    await renderPopular()
+    expect(await screen.findByText('热门去重第一页')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: '触发热门订阅加载' }))
+    expect(await screen.findByText('热门去重第二页')).toBeInTheDocument()
+    expect(screen.queryByText('第一页跨页重复项')).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: '触发热门订阅加载' }))
+    await waitFor(() => expect(requestedPages).toEqual(['1', '2', '3']))
+    expect(screen.getByRole('status', { name: '热门订阅无限列表状态' })).toHaveTextContent('empty')
+    expect(screen.queryByText('第二页乱序重复项')).not.toBeInTheDocument()
+    expect(screen.queryByText('第一页乱序重复项')).not.toBeInTheDocument()
+    expect(screen.queryByText('第一页页内重复项')).not.toBeInTheDocument()
+  })
+
   it('loads consecutive pages until an underfilled viewport becomes scrollable', async () => {
     const first = createSubscribeMovie({ title: '未满屏第一页' })
     const second = createSubscribeMovie({ title: '未满屏第二页' })
     const requestedPages: string[] = []
-    const scrollHeight = vi.spyOn(document.body, 'scrollHeight', 'get').mockImplementation(() =>
-      requestedPages.length >= 2 ? 900 : 500,
-    )
+    const scrollHeight = vi
+      .spyOn(document.body, 'scrollHeight', 'get')
+      .mockImplementation(() => (requestedPages.length >= 2 ? 900 : 500))
     server.use(
       http.get(subscribeApiUrls.popular, ({ request }) => {
         const page = new URL(request.url).searchParams.get('page') ?? ''
@@ -396,9 +432,20 @@ describe('SubscribePopularView', () => {
     expect(await screen.findByText('同剧第一季')).toBeInTheDocument()
     expect(screen.getByText('同剧第二季')).toBeInTheDocument()
 
-    // 新的 getMediaIdentity 使用 JSON.stringify(dedupFields.map(...))
-    // dedupFields: ['source', 'type', 'season', 'tmdb_id', 'imdb_id', 'tvdb_id', 'douban_id', 'bangumi_id', 'anilist_id', 'mediaid_prefix', 'media_id']
-    const identityFields = ['source', 'type', 'season', 'tmdb_id', 'imdb_id', 'tvdb_id', 'douban_id', 'bangumi_id', 'anilist_id', 'mediaid_prefix', 'media_id'] as const
+    // 渲染键与生产媒体身份字段保持一致，避免不同季条目发生键冲突。
+    const identityFields = [
+      'source',
+      'type',
+      'season',
+      'tmdb_id',
+      'imdb_id',
+      'tvdb_id',
+      'douban_id',
+      'bangumi_id',
+      'anilist_id',
+      'mediaid_prefix',
+      'media_id',
+    ] as const
     const item1 = createSubscribeTv({ season: 1, source: undefined, title: '同剧第一季', tmdb_id: 880 })
     const item2 = createSubscribeTv({ season: 2, source: undefined, title: '同剧第二季', tmdb_id: 880 })
     const expectedKeys = [


### PR DESCRIPTION
## 问题与背景

热门订阅已经使用复合媒体身份处理跨页重复条目，并在后端重复返回相同身份集合时终止分页，但对应回归边界此前没有被视图测试直接覆盖。

## 原因分析

现有测试覆盖了分页追加、空页终止、并发加载、失败重试和筛选换代，但没有模拟跨页重复媒体以及重复页身份集合。相关实现发生回归时，测试无法直接识别列表重复或分页循环。

## 解决方案

为 `SubscribePopularView` 增加一条分页回归用例：

- 第二页包含第一页的同一媒体时，只保留原有条目；
- 后续页面以不同顺序和重复数量返回相同身份集合时，列表进入终止状态；
- 重复响应中的替代标题不会进入渲染结果。

## 影响与风险

本 PR 仅修改热门订阅视图测试，不改变生产请求、分页、去重或渲染逻辑，也不包含长列表渐进挂载改动。

## 验证

- `yarn vitest run src/views/subscribe/__tests__/SubscribePopularView.spec.ts`：12 项通过
- `yarn typecheck`
- `yarn lint`
- `yarn format:check`
- `yarn build`
- `git diff --check`

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 5cfe1ddb72495d4ac54cf814d2852826a38ede50

- 覆盖热门订阅跨页媒体去重
- 验证重复身份集合终止分页
- 确保替代标题不进入渲染
- 对齐测试注释与生产身份字段
<!-- pr-agent-summary:end -->
