### PR TITLE
fix(glass): restore dashboard media surface dynamics

### DIFF
--- a/src/composables/__tests__/useGlassOpticalRenderer.spec.ts
+++ b/src/composables/__tests__/useGlassOpticalRenderer.spec.ts
@@ -1974,6 +1974,73 @@ describe('glass optical surface discovery', () => {
     scope.stop()
   })
 
+  it('keeps an explicit optical boundary as the interaction clip without allocating nested slots', async () => {
+    vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(1200)
+    vi.spyOn(window, 'innerHeight', 'get').mockReturnValue(800)
+    const three = await import('three')
+    const render = vi.spyOn(three.WebGLRenderer.prototype, 'render')
+    const pageContent = document.createElement('main')
+    pageContent.className = 'layout-page-content'
+    const outerSurface = document.createElement('section')
+    outerSurface.className = 'v-card'
+    outerSurface.dataset.glassOpticalBoundary = ''
+    outerSurface.style.borderTopLeftRadius = '24px'
+    outerSurface.style.borderTopRightRadius = '24px'
+    outerSurface.style.borderBottomRightRadius = '24px'
+    outerSurface.style.borderBottomLeftRadius = '24px'
+    setOpticalSurfaceBounds(outerSurface, { height: 420, width: 900, x: 40, y: 80 })
+    for (const x of [80, 400]) {
+      const nestedCard = document.createElement('article')
+      nestedCard.className = 'app-hover-lift-card'
+      setOpticalSurfaceBounds(nestedCard, { height: 160, width: 280, x, y: 140 })
+      outerSurface.append(nestedCard)
+    }
+    pageContent.append(outerSurface)
+    document.body.append(pageContent)
+    const scope = effectScope()
+    const renderer = scope.run(() =>
+      useGlassOpticalRenderer({
+        active: ref(true),
+        appearance: ref('clear'),
+        canvas: ref(document.createElement('canvas')),
+        quality: ref('balanced'),
+        routeKey: ref('/dashboard'),
+        surfaceSpace: 'scroll',
+        tintColor: ref('#8D51F9'),
+        wallpaperUrl: ref('https://example.com/wallpaper.jpg'),
+      }),
+    )
+
+    await vi.waitFor(() => expect(renderer?.state.value).toBe('ready'))
+    render.mockClear()
+    window.dispatchEvent(new MouseEvent('pointermove', { clientX: 160, clientY: 200 }))
+    await vi.waitFor(() => expect(render).toHaveBeenCalled())
+    const scene = render.mock.calls.at(-1)?.[0] as unknown as {
+      children: Array<{
+        material: {
+          uniforms: {
+            uInteractionRadii: { value: Array<{ toArray: () => number[] }> }
+            uInteractionRectCount: { value: number }
+            uInteractionRects: { value: Array<{ toArray: () => number[] }> }
+            uRectCount: { value: number }
+          }
+        }
+      }>
+    }
+    const material = scene.children[0].material
+
+    expect(material.uniforms.uRectCount.value).toBe(1)
+    expect(material.uniforms.uInteractionRectCount.value).toBe(1)
+    expect(material.uniforms.uInteractionRects.value[0].toArray()).toEqual([
+      40 / 1200,
+      1 - (80 + 420) / 800,
+      900 / 1200,
+      420 / 800,
+    ])
+    expect(material.uniforms.uInteractionRadii.value[0].toArray()).toEqual([24, 24, 24, 24])
+    scope.stop()
+  })
+
   it('keeps the active and nearby visible clips when a long list exceeds the shader budget', async () => {
     vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(1200)
     vi.spyOn(window, 'innerHeight', 'get').mockReturnValue(800)

--- a/src/composables/useGlassOpticalRenderer.ts
+++ b/src/composables/useGlassOpticalRenderer.ts
@@ -405,6 +405,7 @@ const SURFACE_SELECTORS = [
 ] as const
 const SURFACE_SELECTOR_QUERY = SURFACE_SELECTORS.map(({ selector }) => selector).join(',')
 const INTERACTION_CLIP_SELECTOR = '.app-hover-lift-card'
+const OPTICAL_BOUNDARY_SELECTOR = '[data-glass-optical-boundary]'
 const INTERACTION_CLIP_OVERSCAN_PX = 96
 
 /** 登录卡片随文档弹性合成，其余固定表面继续使用 viewport 坐标。 */
@@ -1944,6 +1945,12 @@ export function useGlassOpticalRenderer(options: UseGlassOpticalRendererOptions)
       const mode = surface.mode ?? 'dynamic'
       if (mode === 'static-material') continue
 
+      // 显式 optical boundary 自身定义完整材质边界；嵌套交互卡只承载其内部内容。
+      if (surface.key.matches(OPTICAL_BOUNDARY_SELECTOR)) {
+        append(surface.key, surface.key, mode, surface.rect)
+        continue
+      }
+
       const surfaceIsClip = surface.key.matches(INTERACTION_CLIP_SELECTOR)
       if (surfaceIsClip) append(surface.key, surface.key, mode, surface.rect)
       const nestedClips = [...surface.key.querySelectorAll<HTMLElement>(INTERACTION_CLIP_SELECTOR)]
@@ -3026,7 +3033,7 @@ export function useGlassOpticalRenderer(options: UseGlassOpticalRendererOptions)
 
       observedMutationRoots.add(root)
       surfaceMutationObserver?.observe(root, {
-        attributeFilter: ['data-glass-optical-mode'],
+        attributeFilter: ['data-glass-optical-boundary', 'data-glass-optical-mode'],
         attributes: true,
         childList: true,
         subtree,

--- a/src/views/dashboard/MediaServerLatest.vue
+++ b/src/views/dashboard/MediaServerLatest.vue
@@ -165,7 +165,12 @@ onActivated(() => {
       </template>
     </DashboardMediaState>
 
-    <VCard v-for="(data, name) in latestList" :key="name" class="dashboard-work-card dashboard-media-card">
+    <VCard
+      v-for="(data, name) in latestList"
+      :key="name"
+      class="dashboard-work-card dashboard-media-card"
+      data-glass-optical-boundary
+    >
       <VCardItem class="dashboard-media-header">
         <VCardTitle>{{ t('dashboard.latest') }} - {{ name }}</VCardTitle>
         <template v-if="loadFailed" #append>

--- a/src/views/dashboard/MediaServerLibrary.vue
+++ b/src/views/dashboard/MediaServerLibrary.vue
@@ -136,7 +136,7 @@ onActivated(() => {
     </template>
   </DashboardMediaState>
 
-  <VCard v-else class="dashboard-media-card dashboard-grid-fill">
+  <VCard v-else class="dashboard-media-card dashboard-grid-fill" data-glass-optical-boundary>
     <VCardItem class="dashboard-media-header">
       <VCardTitle>{{ t('dashboard.library') }}</VCardTitle>
       <template v-if="loadFailed" #append>

--- a/src/views/dashboard/MediaServerPlaying.vue
+++ b/src/views/dashboard/MediaServerPlaying.vue
@@ -173,7 +173,7 @@ onActivated(() => {
       </template>
     </DashboardMediaState>
 
-    <VCard v-if="displayedPlayingList.length > 0" class="dashboard-media-card">
+    <VCard v-if="displayedPlayingList.length > 0" class="dashboard-media-card" data-glass-optical-boundary>
       <VCardItem class="dashboard-media-header">
         <VCardTitle>{{ t('dashboard.playing') }}</VCardTitle>
         <template v-if="loadFailed" #append>


### PR DESCRIPTION
## 问题与背景

玻璃主题下，Dashboard 的“继续观看”“最近入库”和“我的媒体库”外层卡片没有可见流体响应，而同页其他卡片可以正常响应。

这些区域是包含标题、留白与媒体子卡的完整玻璃材质面。预期动态效果覆盖整个外层材质边界，内部海报只负责内容展示。

## 原因分析

嵌套 surface 折叠会让外层材质面占用一个 shader slot，并使用内部 `.app-hover-lift-card` 作为 interaction clips。只要存在内部 clips，父级 clip 就会被完全取消。

三类 Dashboard 媒体卡内部的海报大多由不透明图片覆盖，动态只绘制在这些子卡下方；标题和卡片留白不再属于 interaction mask，因此视觉上表现为整个外层卡片没有流体。

## 解决方案

- 增加 `data-glass-optical-boundary` 显式材质边界合同。声明该属性的 surface 使用自身作为唯一 interaction clip，嵌套卡片不再替换父级边界。
- 在三类 Dashboard 复合媒体卡上声明该边界。
- 将边界属性纳入 renderer 的 MutationObserver，保证运行时新增或切换声明后会刷新 interaction registry。
- 保留普通嵌套容器的现有行为：未声明边界时仍按真实子卡圆角裁剪，不会让动态扩散到纯布局间隙。

## 影响与风险

- 三类 Dashboard 卡仍各占一个 material slot，interaction clip 从多个子卡收敛为一个父边界；不增加 WebGL context、纹理、shader slot 或 pointermove DOM 扫描。
- 推荐、探索、订阅、工作流、站点和资源列表没有声明该边界，行为保持不变。
- 不修改 touch、coarse pointer 或动态能力开关，不会启用或停用移动端流体能力。
- 无配置、数据和迁移要求。

## 验证

- `yarn format:check`
- `yarn lint`
- `yarn typecheck`
- `yarn build`
- `yarn vitest run src/composables/__tests__/useGlassOpticalRenderer.spec.ts`：74 个测试通过
- 玻璃主题下验证三类 Dashboard 复合媒体卡恢复整面动态响应，renderer 保持 ready，嵌套卡片数量和 material slot 预算不变。

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at ab418322077f5d7a113bf2f77c438fc9c134aa0a

- 恢复仪表盘媒体卡完整玻璃动态边界
- 显式边界忽略嵌套交互卡裁剪
- 属性变更触发渲染表面重新发现
- 新增边界裁剪与槽位回归测试
<!-- pr-agent-summary:end -->
