### PR TITLE
fix(dashboard): remeasure async card content

### DIFF
--- a/src/components/misc/ProgressiveCardGrid.vue
+++ b/src/components/misc/ProgressiveCardGrid.vue
@@ -1057,7 +1057,8 @@ watch(
 
 <template>
   <div ref="containerRef" class="progressive-card-grid">
-    <div ref="trackRef" class="progressive-card-grid__track">
+    <!-- 完整高度由虚拟占位与可见网格共同承载，供上层自适应布局观察稳定的尺寸语义。 -->
+    <div ref="trackRef" class="progressive-card-grid__track" data-layout-size-source>
       <div
         v-if="topSpacerHeight > 0"
         class="progressive-card-grid__spacer"

--- a/src/components/misc/__tests__/ProgressiveCardGrid.spec.ts
+++ b/src/components/misc/__tests__/ProgressiveCardGrid.spec.ts
@@ -35,6 +35,20 @@ describe('ProgressiveCardGrid scroll target lifecycle', () => {
       expect(addScrollListener).toHaveBeenCalledWith('scroll', expect.any(Function), { passive: true })
     })
   })
+
+  it('exposes the complete virtual track as a layout size source', () => {
+    const { container } = render(ProgressiveCardGrid, {
+      props: {
+        items: [{ id: 1 }],
+        getItemKey: (item: { id: number }) => item.id,
+      },
+      slots: {
+        default: '<div>item</div>',
+      },
+    })
+
+    expect(container.querySelector('.progressive-card-grid__track')).toHaveAttribute('data-layout-size-source')
+  })
 })
 
 describe('ProgressiveCardGrid mount scheduling', () => {

--- a/src/pages/__tests__/dashboard.spec.ts
+++ b/src/pages/__tests__/dashboard.spec.ts
@@ -67,6 +67,44 @@ class ResizeObserverMock implements ResizeObserver {
   unobserve() {}
 }
 
+class LayoutSourceResizeObserverMock implements ResizeObserver {
+  static readonly instances: LayoutSourceResizeObserverMock[] = []
+
+  readonly observed = new Set<Element>()
+  readonly unobserved = new Set<Element>()
+  private readonly callback: ResizeObserverCallback
+
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback
+    LayoutSourceResizeObserverMock.instances.push(this)
+  }
+
+  disconnect() {
+    this.observed.clear()
+  }
+
+  observe(target: Element) {
+    this.observed.add(target)
+  }
+
+  unobserve(target: Element) {
+    this.observed.delete(target)
+    this.unobserved.add(target)
+  }
+
+  resize(target: Element, height: number) {
+    this.callback([{ contentRect: { height }, target } as ResizeObserverEntry], this)
+  }
+}
+
+async function findLayoutSourceObserver(source: Element) {
+  await waitFor(() => {
+    expect(LayoutSourceResizeObserverMock.instances.some(observer => observer.observed.has(source))).toBe(true)
+  })
+
+  return LayoutSourceResizeObserverMock.instances.find(observer => observer.observed.has(source))!
+}
+
 vi.mock('@/api', () => ({
   default: {
     get: (...args: unknown[]) => mocks.apiGet(...args),
@@ -108,7 +146,7 @@ vi.mock('@/composables/useSharedDialog', () => ({
 }))
 
 vi.mock('@/components/misc/DashboardElement.vue', async () => {
-  const { defineComponent, h, onMounted } = await import('vue')
+  const { defineComponent, h, onMounted, ref } = await import('vue')
 
   return {
     default: defineComponent({
@@ -118,6 +156,7 @@ vi.mock('@/components/misc/DashboardElement.vue', async () => {
       },
       emits: ['loaded'],
       setup(props, { emit }) {
+        const showLayoutSizeSource = ref(false)
         onMounted(() => emit('loaded'))
 
         return () =>
@@ -126,8 +165,16 @@ vi.mock('@/components/misc/DashboardElement.vue', async () => {
             {
               'data-dashboard-id': (props.config as { id: string }).id,
               'data-testid': 'dashboard-item',
+              onClick: () => {
+                showLayoutSizeSource.value = !showLayoutSizeSource.value
+              },
             },
-            (props.config as { name: string }).name,
+            [
+              (props.config as { name: string }).name,
+              showLayoutSizeSource.value
+                ? h('div', { 'data-layout-size-source': '', 'data-testid': 'layout-size-source' }, 'size source')
+                : null,
+            ],
           )
       },
     }),
@@ -158,6 +205,11 @@ const enabledOnlyLibrary = {
   systemInfo: false,
 }
 
+const enabledLibraryAndSystemInfo = {
+  ...enabledOnlySystemInfo,
+  library: true,
+}
+
 function deferred<T>() {
   let resolve!: (value: T) => void
   const promise = new Promise<T>(promiseResolve => {
@@ -181,8 +233,10 @@ async function renderDashboard() {
 
 describe('dashboard page initial layout', () => {
   beforeEach(() => {
+    LayoutSourceResizeObserverMock.instances.length = 0
     mocks.grid.engine.nodes.length = 0
     mocks.gridInit.mockClear()
+    mocks.grid.resizeToContent.mockClear()
     mocks.grid.setAnimation.mockClear()
     mocks.apiGet.mockReset()
     mocks.apiPost.mockReset()
@@ -374,6 +428,135 @@ describe('dashboard page initial layout', () => {
       },
     })
     await waitFor(() => expect(mocks.grid.load).toHaveBeenCalled())
+  })
+
+  it('observes an async size source and remeasures only its automatic card', async () => {
+    vi.stubGlobal('ResizeObserver', LayoutSourceResizeObserverMock)
+    localStorage.setItem(
+      'MP_DASHBOARD_GRID_LAYOUT',
+      JSON.stringify({
+        enabled: enabledLibraryAndSystemInfo,
+        items: { library: { x: 0, y: 0, w: 6 }, systemInfo: { x: 6, y: 0, w: 6 } },
+        updatedAt: 10,
+      }),
+    )
+    mocks.apiGet.mockImplementation((url: string) => {
+      if (url === '/user/config/DashboardOrder') {
+        return {
+          data: {
+            value: [
+              { id: 'library', key: '' },
+              { id: 'systemInfo', key: '' },
+            ],
+          },
+        }
+      }
+      if (url === '/user/config/DashboardGridLayout') {
+        return {
+          data: {
+            value: {
+              enabled: enabledLibraryAndSystemInfo,
+              items: { library: { x: 0, y: 0, w: 6 }, systemInfo: { x: 6, y: 0, w: 6 } },
+            },
+          },
+        }
+      }
+      if (url === '/plugin/dashboard/meta') return []
+      throw new Error('Unexpected GET ' + url)
+    })
+
+    const { container } = await renderDashboard()
+    await waitFor(() => expect(mocks.grid.makeWidget).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(mocks.grid.load).toHaveBeenCalled())
+    await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(() => resolve(undefined))))
+    mocks.grid.resizeToContent.mockClear()
+
+    const libraryDashboard = screen
+      .getAllByTestId('dashboard-item')
+      .find(element => element.getAttribute('data-dashboard-id') === 'library')!
+    await fireEvent.click(libraryDashboard)
+    const sizeSource = libraryDashboard.querySelector('[data-layout-size-source]')!
+    const observer = await findLayoutSourceObserver(sizeSource)
+    const libraryItem = container.querySelector('.dashboard-grid-item[gs-id="library"]')
+    const systemInfoItem = container.querySelector('.dashboard-grid-item[gs-id="systemInfo"]')
+    observer.resize(sizeSource, 480)
+
+    await waitFor(() => expect(mocks.grid.resizeToContent).toHaveBeenCalledWith(libraryItem))
+    expect(mocks.grid.resizeToContent).toHaveBeenCalledTimes(1)
+    expect(mocks.grid.resizeToContent).not.toHaveBeenCalledWith(systemInfoItem)
+
+    mocks.grid.resizeToContent.mockClear()
+    sizeSource.append(document.createElement('span'))
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(mocks.grid.resizeToContent).not.toHaveBeenCalled()
+
+    await fireEvent.click(libraryDashboard)
+    await waitFor(() => expect(observer.unobserved.has(sizeSource)).toBe(true))
+  })
+
+  it('ignores size source changes for manually sized cards', async () => {
+    vi.stubGlobal('ResizeObserver', LayoutSourceResizeObserverMock)
+    localStorage.setItem(
+      'MP_DASHBOARD_GRID_LAYOUT',
+      JSON.stringify({
+        enabled: enabledOnlyLibrary,
+        items: { library: { x: 0, y: 0, w: 12, h: 20 } },
+        updatedAt: 10,
+      }),
+    )
+    mocks.apiGet.mockImplementation((url: string) => {
+      if (url === '/user/config/DashboardOrder') return { data: { value: [{ id: 'library', key: '' }] } }
+      if (url === '/user/config/DashboardGridLayout') {
+        return {
+          data: { value: { enabled: enabledOnlyLibrary, items: { library: { x: 0, y: 0, w: 12, h: 20 } } } },
+        }
+      }
+      if (url === '/plugin/dashboard/meta') return []
+      throw new Error('Unexpected GET ' + url)
+    })
+
+    const { container } = await renderDashboard()
+    await waitFor(() => expect(mocks.grid.makeWidget).toHaveBeenCalledTimes(1))
+    await new Promise(resolve => requestAnimationFrame(() => resolve(undefined)))
+    mocks.grid.resizeToContent.mockClear()
+
+    await fireEvent.click(screen.getByTestId('dashboard-item'))
+    const sizeSource = container.querySelector('[data-layout-size-source]')!
+    const observer = await findLayoutSourceObserver(sizeSource)
+    observer.resize(sizeSource, 480)
+    await new Promise(resolve => requestAnimationFrame(() => resolve(undefined)))
+    expect(mocks.grid.resizeToContent).not.toHaveBeenCalled()
+  })
+
+  it('ignores size source changes while editing an automatic card', async () => {
+    vi.stubGlobal('ResizeObserver', LayoutSourceResizeObserverMock)
+    localStorage.setItem(
+      'MP_DASHBOARD_GRID_LAYOUT',
+      JSON.stringify({ enabled: enabledOnlyLibrary, items: { library: { x: 0, y: 0, w: 12 } }, updatedAt: 10 }),
+    )
+    mocks.apiGet.mockImplementation((url: string) => {
+      if (url === '/user/config/DashboardOrder') return { data: { value: [{ id: 'library', key: '' }] } }
+      if (url === '/user/config/DashboardGridLayout') {
+        return { data: { value: { enabled: enabledOnlyLibrary, items: { library: { x: 0, y: 0, w: 12 } } } } }
+      }
+      if (url === '/plugin/dashboard/meta') return []
+      throw new Error('Unexpected GET ' + url)
+    })
+
+    const { container } = await renderDashboard()
+    await waitFor(() => expect(mocks.grid.makeWidget).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(mocks.grid.resizeToContent).toHaveBeenCalled())
+    mocks.grid.resizeToContent.mockClear()
+
+    await fireEvent.click(screen.getByTestId('dashboard-item'))
+    const sizeSource = container.querySelector('[data-layout-size-source]')!
+    const observer = await findLayoutSourceObserver(sizeSource)
+    await fireEvent.click(document.querySelector('.compact-fab--primary') as HTMLElement)
+    await new Promise(resolve => requestAnimationFrame(() => resolve(undefined)))
+    mocks.grid.resizeToContent.mockClear()
+    observer.resize(sizeSource, 480)
+    await new Promise(resolve => requestAnimationFrame(() => resolve(undefined)))
+    expect(mocks.grid.resizeToContent).not.toHaveBeenCalled()
   })
 
   it('applies a newer remote profile and refreshes the local first-frame cache', async () => {

--- a/src/pages/dashboard.vue
+++ b/src/pages/dashboard.vue
@@ -41,6 +41,7 @@ const DASHBOARD_GRID_CELL_HEIGHT = 16
 const DASHBOARD_GRID_FALLBACK_ROWS = 4
 const DASHBOARD_GRID_MARGIN = 8
 const DASHBOARD_GRID_CONTENT_RESIZE_THRESHOLD = 4
+const DASHBOARD_GRID_SIZE_SOURCE_SELECTOR = '[data-layout-size-source]'
 const DASHBOARD_ENABLE_STORAGE_KEY = 'MP_DASHBOARD'
 const DASHBOARD_ORDER_STORAGE_KEY = 'MP_DASHBOARD_ORDER'
 const DASHBOARD_GRID_LAYOUT_STORAGE_KEY_PREFIX = 'MP_DASHBOARD_GRID_LAYOUT'
@@ -141,8 +142,10 @@ let isLegacyDashboardEnableConfigLoaded = false
 const dashboardGridResizeStartHeights = new Map<string, number | undefined>()
 const dashboardGridPendingContentResize = new Set<GridItemHTMLElement>()
 const dashboardGridObservedContentHeights = new Map<string, number>()
+const dashboardGridObservedSizeSources = new Set<Element>()
 
 let dashboardGridContentObserver: ResizeObserver | null = null
+let dashboardGridContentMutationObserver: MutationObserver | null = null
 let dashboardGridContentResizeFrame: number | null = null
 let dashboardGridResizeRefreshFrame: number | null = null
 let dashboardGridAnimationFrame: number | null = null
@@ -1326,16 +1329,24 @@ function syncDashboardFillContentState(element?: GridItemHTMLElement) {
 // 监听仪表板组件内容尺寸变化，让未手动调高的组件按内容高度自适应。
 function observeDashboardGridContent() {
   const gridElement = dashboardGridRef.value
+  dashboardGridContentMutationObserver?.disconnect()
+  dashboardGridContentMutationObserver = null
+  dashboardGridContentObserver?.disconnect()
+  dashboardGridContentObserver = null
+  dashboardGridPendingContentResize.clear()
+  dashboardGridObservedContentHeights.clear()
+  dashboardGridObservedSizeSources.clear()
   if (!gridElement || typeof ResizeObserver === 'undefined') return
 
   syncDashboardFillContentState()
-  dashboardGridContentObserver?.disconnect()
-  dashboardGridPendingContentResize.clear()
-  dashboardGridObservedContentHeights.clear()
   dashboardGridContentObserver = new ResizeObserver(entries => {
     entries.forEach(entry => {
       const itemElement = entry.target.closest('.dashboard-grid-item') as GridItemHTMLElement | null
-      if (itemElement && shouldScheduleDashboardContentResize(itemElement, entry.contentRect.height)) {
+      const isSizeSource = entry.target.matches(DASHBOARD_GRID_SIZE_SOURCE_SELECTOR)
+      if (
+        itemElement &&
+        (isSizeSource || shouldScheduleDashboardContentResize(itemElement, entry.contentRect.height))
+      ) {
         scheduleDashboardItemContentResize(itemElement)
       }
     })
@@ -1344,6 +1355,46 @@ function observeDashboardGridContent() {
   gridElement.querySelectorAll<HTMLElement>('.dashboard-grid-auto-size').forEach(element => {
     dashboardGridContentObserver?.observe(element)
   })
+  gridElement.querySelectorAll<HTMLElement>(DASHBOARD_GRID_SIZE_SOURCE_SELECTOR).forEach(observeDashboardGridSizeSource)
+
+  if (typeof MutationObserver === 'undefined') return
+
+  dashboardGridContentMutationObserver = new MutationObserver(mutations => {
+    mutations.forEach(mutation => {
+      mutation.removedNodes.forEach(node => {
+        findDashboardGridSizeSources(node).forEach(unobserveDashboardGridSizeSource)
+      })
+      mutation.addedNodes.forEach(node => {
+        findDashboardGridSizeSources(node).forEach(observeDashboardGridSizeSource)
+      })
+    })
+  })
+  dashboardGridContentMutationObserver.observe(gridElement, { childList: true, subtree: true })
+}
+
+// 返回节点自身及后代声明的真实尺寸源，普通子节点变化不进入测高路径。
+function findDashboardGridSizeSources(node: Node) {
+  if (!(node instanceof Element)) return []
+
+  const sources = Array.from(node.querySelectorAll<Element>(DASHBOARD_GRID_SIZE_SOURCE_SELECTOR))
+  if (node.matches(DASHBOARD_GRID_SIZE_SOURCE_SELECTOR)) sources.unshift(node)
+
+  return sources
+}
+
+// 注册异步挂载的尺寸源；ResizeObserver 的首次回调负责触发实际测高。
+function observeDashboardGridSizeSource(element: Element) {
+  if (!dashboardGridContentObserver || dashboardGridObservedSizeSources.has(element)) return
+
+  dashboardGridObservedSizeSources.add(element)
+  dashboardGridContentObserver.observe(element)
+}
+
+// 节点卸载后同步解除观察，避免 KeepAlive 与布局重建保留失效引用。
+function unobserveDashboardGridSizeSource(element: Element) {
+  if (!dashboardGridContentObserver || !dashboardGridObservedSizeSources.delete(element)) return
+
+  dashboardGridContentObserver.unobserve(element)
 }
 
 // 判断内容高度变化是否足够触发 GridStack 行高重算，避免 hover 级微小波动造成布局抖动。
@@ -1648,6 +1699,8 @@ onDeactivated(() => {
 
 onBeforeUnmount(() => {
   Object.keys(refreshTimers.value).forEach(clearPluginDashboardTimer)
+  dashboardGridContentMutationObserver?.disconnect()
+  dashboardGridContentMutationObserver = null
   dashboardGridContentObserver?.disconnect()
   dashboardGridContentObserver = null
   if (dashboardGridContentResizeFrame !== null) {
@@ -1668,6 +1721,7 @@ onBeforeUnmount(() => {
   }
   dashboardGridPendingContentResize.clear()
   dashboardGridObservedContentHeights.clear()
+  dashboardGridObservedSizeSources.clear()
   dashboardGridResizeStartHeights.clear()
   dashboardGrid.value?.destroy(false)
   dashboardGrid.value = null
@@ -1676,11 +1730,7 @@ onBeforeUnmount(() => {
 
 <template>
   <!-- 仪表板 -->
-  <div
-    ref="dashboardGridRef"
-    class="grid-stack dashboard-grid"
-    :class="{ 'is-editing': isLayoutEditing }"
-  >
+  <div ref="dashboardGridRef" class="grid-stack dashboard-grid" :class="{ 'is-editing': isLayoutEditing }">
     <div
       v-for="gridItem in dashboardGridItems"
       :key="gridItem.id"
@@ -1876,5 +1926,4 @@ onBeforeUnmount(() => {
   inset-block-end: -4px;
   inset-inline-end: -4px;
 }
-
 </style>

--- a/src/views/dashboard/DashboardRecentImports.vue
+++ b/src/views/dashboard/DashboardRecentImports.vue
@@ -52,15 +52,20 @@ onActivated(loadRecentImports)
     </VCardItem>
 
     <VCardText class="recent-import-list">
-      <div v-for="item in recentImports" :key="item.id" class="recent-import-item">
-        <VImg :src="getPosterUrl(item)" :alt="item.title" class="recent-import-poster" cover />
-        <div class="recent-import-copy">
-          <div class="recent-import-title">{{ item.title }}<span v-if="item.year"> ({{ item.year }})</span></div>
-          <div class="recent-import-meta">{{ getImportMeta(item) }}</div>
-        </div>
-        <div class="recent-import-time">
-          {{ item.date ? formatDateDifference(item.date) : '' }}
-          <VIcon icon="mdi-check-circle" color="success" size="16" />
+      <!-- 非空列表使用自然内容高度，避免外层填充布局隐藏异步增长。 -->
+      <div v-if="recentImports.length > 0" data-layout-size-source>
+        <div v-for="item in recentImports" :key="item.id" class="recent-import-item">
+          <VImg :src="getPosterUrl(item)" :alt="item.title" class="recent-import-poster" cover />
+          <div class="recent-import-copy">
+            <div class="recent-import-title">
+              {{ item.title }}<span v-if="item.year"> ({{ item.year }})</span>
+            </div>
+            <div class="recent-import-meta">{{ getImportMeta(item) }}</div>
+          </div>
+          <div class="recent-import-time">
+            {{ item.date ? formatDateDifference(item.date) : '' }}
+            <VIcon icon="mdi-check-circle" color="success" size="16" />
+          </div>
         </div>
       </div>
 

--- a/src/views/dashboard/__tests__/DashboardRecentImports.spec.ts
+++ b/src/views/dashboard/__tests__/DashboardRecentImports.spec.ts
@@ -1,0 +1,33 @@
+import DashboardRecentImports from '@/views/dashboard/DashboardRecentImports.vue'
+import { renderWithProviders } from '@tests/support/render'
+import { screen } from '@testing-library/vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  apiGet: vi.fn(),
+}))
+
+vi.mock('@/api', () => ({
+  default: {
+    get: (...args: unknown[]) => mocks.apiGet(...args),
+  },
+}))
+
+describe('dashboard recent imports', () => {
+  beforeEach(() => {
+    mocks.apiGet.mockReset()
+  })
+
+  it('exposes the rendered list as a layout size source', async () => {
+    mocks.apiGet.mockResolvedValue({
+      data: {
+        list: [{ id: 1, title: '异步入库记录' }],
+      },
+    })
+
+    const { container } = await renderWithProviders(DashboardRecentImports)
+
+    const renderedItem = await screen.findByText('异步入库记录')
+    expect(container.querySelector('[data-layout-size-source]')).toContainElement(renderedItem)
+  })
+})


### PR DESCRIPTION
## 问题与背景

清理站点数据后首次登录时，Dashboard 的异步媒体卡片可能在真实列表内容挂载前完成 GridStack 自动测高并缓存较短高度，导致“最近入库”“我的媒体库”等卡片只显示一部分内容；同页刷新后由于首屏数据已就绪，高度恢复正常。

预期首次登录与刷新都应按真实内容高度完成自动测量，同时保留用户手动高度、编辑模式和响应式布局语义。

## 原因分析

现有 Dashboard 只观察 `.dashboard-grid-auto-size` 外层。部分媒体卡片采用填充布局或虚拟列表，异步数据会改变内层真实内容高度，但外层 `contentRect` 可能保持不变，因此不会再次调度 GridStack 的 `resizeToContent()`。刷新时首屏快照先于首次测量恢复，所以不易触发该时序问题。

## 解决方案

- 为通用虚拟列表的完整高度 track 和“最近入库”的真实列表容器声明 `data-layout-size-source`，明确哪个盒子代表真实内容高度。
- Dashboard 的 `ResizeObserver` 统一观察自动测高外层与这些真实尺寸源，仍通过既有 rAF 队列调用 GridStack 官方 `resizeToContent()`。
- 使用窄范围 `MutationObserver` 只负责异步尺寸源的注册与注销，普通子节点变化不会直接触发重测。
- 保留手动高度、编辑模式、响应式档位和自动高度缓存的原有保护，不引入业务卡逐层 `emit + nextTick` 的布局事件链。

## 影响与风险

改动只影响声明真实尺寸源的自动高度卡片，当前覆盖三张媒体服务器列表卡和“最近入库”。固定高度后台任务卡、结构稳定的统计/图表/系统信息卡以及固定比例推荐卡不接入动态测高，避免周期刷新造成 Dashboard 跳高。

不涉及后端接口、配置或数据迁移。顶栏、滚动条及主题材质视觉不在本 PR 范围内。

## 验证

- 4 个专项测试文件共 44 条用例通过，覆盖尺寸源注册/注销、自动卡片重测、手动高度与编辑态保护、媒体卡和最近入库渲染。
- `yarn format:check`
- `yarn typecheck`
- `yarn lint`
- `yarn lint:suppressions:prune`
- `yarn build`
- `git diff --check`
- 真实浏览器清理站点数据后冷登录与刷新对比：播放中、最近添加、媒体库、最近入库四张卡片高度一致，均无内部溢出或控制台运行时错误。
- 390px 移动宽度下启用的“最近入库”卡片无内部溢出。

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 66f9ae7eb285399c213f1dfb3395cb41ea2bf4b4

- 修复异步内容卡片首屏高度截断
- 以 `data-layout-size-source` 标记真实高度容器
- 动态注册尺寸源并触发 GridStack 重测
- 保留手动高度和编辑模式保护
- 覆盖虚拟列表、最近入库及观察器测试
- 风险：依赖浏览器 `ResizeObserver` 与 DOM 标记
<!-- pr-agent-summary:end -->
