### PR TITLE
fix(layout): align scrollbar and navbar behavior

### DIFF
--- a/src/@core/scss/libs/perfect-scrollbar.scss
+++ b/src/@core/scss/libs/perfect-scrollbar.scss
@@ -33,16 +33,3 @@ $ps-track-size: 0.5rem;
 .ps__rail-y:hover > .ps__thumb-y {
   inline-size: $ps-hover-size;
 }
-
-// 滚动条只反馈实际滚动状态，鼠标经过容器或键盘聚焦不应让轨道常驻。
-.ps:hover > .ps__rail-x,
-.ps:hover > .ps__rail-y,
-.ps--focus > .ps__rail-x,
-.ps--focus > .ps__rail-y {
-  opacity: 0 !important;
-}
-
-.ps.ps--scrolling-x > .ps__rail-x,
-.ps.ps--scrolling-y > .ps__rail-y {
-  opacity: 0.6 !important;
-}

--- a/src/@layouts/components/VerticalNavLayout.vue
+++ b/src/@layouts/components/VerticalNavLayout.vue
@@ -213,7 +213,7 @@ export default defineComponent({
     // 单独提升顶栏图层可避免导航栏短暂上移到安全区下方。
     backface-visibility: hidden;
     block-size: var(--layout-navbar-block-size);
-    inline-size: calc(100vw - variables.$layout-vertical-nav-width - 0.5rem);
+    inline-size: calc(100% - variables.$layout-vertical-nav-width);
     inset-block-start: 0;
     transform: translate3d(0, 0, 0);
 
@@ -277,7 +277,7 @@ export default defineComponent({
   }
 
   &.layout-vertical-nav-collapsed .layout-navbar {
-    inline-size: calc(100vw - variables.$layout-vertical-nav-collapsed-width - 0.5rem);
+    inline-size: calc(100% - variables.$layout-vertical-nav-collapsed-width);
   }
 
   &.layout-vertical-nav-collapsed .layout-vertical-nav:not(.overlay-nav) {

--- a/src/styles/__tests__/glassOverlayMaterial.spec.ts
+++ b/src/styles/__tests__/glassOverlayMaterial.spec.ts
@@ -61,7 +61,6 @@ describe('glass overlay material styles', () => {
     expect(mainBackplateRule).toBeDefined()
     expect(mainBackplateRule).not.toMatch(/transition:\s*clip-path/u)
     expect(overlayBackplateRule).toMatch(/transition:\s*clip-path 0\.25s ease-in-out/u)
-    expect(styles).toMatch(/\.layout-vertical-nav \.ps__rail-y\s*\{[\s\S]*?inset-inline-end:\s*0\.5rem !important;/)
   })
 
   it('shares the same light frost when glass navbars overlap scrolled content', () => {

--- a/src/styles/common.scss
+++ b/src/styles/common.scss
@@ -1420,32 +1420,25 @@ html[data-theme='transparent'].transparent-glass-realtime .v-theme--transparent 
   }
 }
 
-// 滚动条样式
-::-webkit-scrollbar {
-  block-size: 4px;
-  inline-size: 4px;
-  opacity: 0;
-  transition: opacity 0.3s;
-}
-
-::-webkit-scrollbar-thumb {
-  border-radius: 2px;
-  background: rgb(var(--v-theme-perfect-scrollbar-thumb));
-  box-shadow: inset 0 0 10px rgba(0, 0, 0, 20%);
-
-  @media (hover) {
-    &:hover {
-      background: #a1a1a1;
-    }
+// 原生滚动条沿用浏览器的几何与显隐行为，只统一窄宽度和主题色。
+@supports (scrollbar-width: thin) {
+  * {
+    scrollbar-color: rgba(var(--v-theme-perfect-scrollbar-thumb), 60%) transparent;
+    scrollbar-width: thin;
   }
 }
 
-*:hover::-webkit-scrollbar {
-  opacity: 1;
-}
+// 旧版 WebKit 不支持标准滚动条属性，仅保留基础几何与主题色。
+@supports not (scrollbar-width: thin) {
+  ::-webkit-scrollbar {
+    block-size: 4px;
+    inline-size: 4px;
+  }
 
-*:active::-webkit-scrollbar {
-  opacity: 1;
+  ::-webkit-scrollbar-thumb {
+    border-radius: 2px;
+    background: rgb(var(--v-theme-perfect-scrollbar-thumb));
+  }
 }
 
 // 组件样式

--- a/src/styles/themes/glass.scss
+++ b/src/styles/themes/glass.scss
@@ -491,25 +491,6 @@ html[data-theme='glass'] {
     }
   }
 
-  // 滚动条与导航材质边界保持间距，避免窄轨道参与全高背板的合成。
-  .layout-vertical-nav .ps__rail-y {
-    inset-inline-end: 0.5rem !important;
-    transition: opacity 120ms linear;
-  }
-
-  .layout-vertical-nav .ps__thumb-y,
-  .layout-vertical-nav .ps__rail-y:focus > .ps__thumb-y,
-  .layout-vertical-nav .ps__rail-y:hover > .ps__thumb-y,
-  .layout-vertical-nav .ps__rail-y.ps--clicking .ps__thumb-y {
-    background-color: rgba(255, 255, 255, 28%) !important;
-    inline-size: 2px !important;
-    inset-inline-end: 0.1875rem;
-  }
-
-  .layout-vertical-nav .nav-items.ps--scrolling-y > .ps__rail-y {
-    opacity: 0.42;
-  }
-
   .layout-vertical-nav .nav-link > .router-link-exact-active {
     border: var(--glass-nav-active-border);
     background: var(--glass-nav-active-background) !important;

--- a/src/views/dashboard/AnalyticsScheduler.vue
+++ b/src/views/dashboard/AnalyticsScheduler.vue
@@ -183,6 +183,7 @@ useDataRefresh(
   flex: 1 1 auto;
   min-block-size: 0;
   overscroll-behavior: contain;
+  scrollbar-width: none;
 }
 
 .background-task-item {
@@ -242,8 +243,10 @@ useDataRefresh(
   min-block-size: 0;
 }
 
-.card-list::-webkit-scrollbar {
-  display: none;
+@supports not (scrollbar-width: none) {
+  .card-list::-webkit-scrollbar {
+    display: none;
+  }
 }
 
 @keyframes background-task-rotate {

--- a/src/views/dashboard/MediaServerLatest.vue
+++ b/src/views/dashboard/MediaServerLatest.vue
@@ -229,9 +229,12 @@ onActivated(() => {
   flex-direction: column;
   min-block-size: 0;
   overflow: auto;
+  scrollbar-width: none;
 }
 
-.dashboard-media-content::-webkit-scrollbar {
-  display: none;
+@supports not (scrollbar-width: none) {
+  .dashboard-media-content::-webkit-scrollbar {
+    display: none;
+  }
 }
 </style>

--- a/src/views/dashboard/MediaServerLibrary.vue
+++ b/src/views/dashboard/MediaServerLibrary.vue
@@ -185,9 +185,12 @@ onActivated(() => {
   flex-direction: column;
   min-block-size: 0;
   overflow: auto;
+  scrollbar-width: none;
 }
 
-.dashboard-media-content::-webkit-scrollbar {
-  display: none;
+@supports not (scrollbar-width: none) {
+  .dashboard-media-content::-webkit-scrollbar {
+    display: none;
+  }
 }
 </style>

--- a/src/views/dashboard/MediaServerPlaying.vue
+++ b/src/views/dashboard/MediaServerPlaying.vue
@@ -229,9 +229,12 @@ onActivated(() => {
   flex-direction: column;
   min-block-size: 0;
   overflow: auto;
+  scrollbar-width: none;
 }
 
-.dashboard-media-content::-webkit-scrollbar {
-  display: none;
+@supports not (scrollbar-width: none) {
+  .dashboard-media-content::-webkit-scrollbar {
+    display: none;
+  }
 }
 </style>


### PR DESCRIPTION
## 问题与背景

页面原生滚动条使用固定的 WebKit 4px 几何后，Chromium 的 overlay scrollbar 会转为占用布局空间的 classic scrollbar，并失去平台原生的自动隐藏表现。与此同时，桌面垂直导航顶栏仍保留按旧 8px 滚动条计算的固定扣减，滚动条几何变化后会在右侧留下额外材质空隙。

主侧栏还存在两套不同的交互与主题覆盖：基础 PerfectScrollbar 的 hover/focus 状态被抑制，玻璃主题另行缩为 2px，导致主题之间的反馈和几何不一致。

## 原因分析

- `::-webkit-scrollbar` 的固定宽度会改变 Chromium 的 overlay/classic scrollbar 行为，原有 opacity 规则不能恢复系统级自动隐藏。
- 顶栏使用 `100vw` 并固定扣减 `0.5rem`，其宽度与历史滚动条尺寸耦合，无法同时适配 overlay 与 classic gutter。
- 玻璃主题和基础 PerfectScrollbar 分别修改轨道位置、宽度与显隐状态，同一侧栏在不同主题下形成了不同交互契约。

## 解决方案

- 支持标准滚动条属性的浏览器使用 `scrollbar-width: thin`，thumb 复用侧栏主题色并保持透明轨道，让浏览器和系统继续管理 overlay 与自动隐藏。
- 使用 `@supports` 为旧版 WebKit 保留 4px 基础几何和主题色 fallback，不恢复无效的 opacity/hover 伪显隐逻辑。
- Dashboard 的后台任务、正在播放、最近入库和媒体库内部滚动区使用标准 `scrollbar-width: none` 隐藏轨道，并为不支持标准属性的 WebKit 浏览器保留局部隐藏 fallback。
- 恢复 PerfectScrollbar 自带的 hover、focus、scrolling 与 dragging 反馈，所有主题统一使用基础 4px、交互 6px 的侧栏 thumb；删除玻璃主题 2px 专用覆盖。
- 顶栏宽度改为基于布局视口的 `100%` 计算：overlay 模式铺到视口右缘，classic 模式自动止于 scrollbar gutter 前。

## 影响与风险

- 现代浏览器中 `thin` 的实际像素宽度、圆角和交互细节由浏览器、操作系统及用户设置决定，不保证跨平台像素完全一致。
- 旧版 WebKit 仍使用 4px classic fallback，但不会影响支持标准属性的现代浏览器。
- Dashboard 四个卡片内部仍可通过滚轮、触控板和触摸滚动，只隐藏滚动条轨道。
- 移动端原有隐藏页面滚动条的行为保持不变；无配置、接口或数据迁移。

## 验证

- `yarn format:check`
- `yarn lint`
- `yarn lint:suppressions:prune`
- `yarn typecheck`
- `yarn build`
- `git diff --check`
- 真实浏览器验证桌面垂直导航、折叠导航、水平导航和移动 overlay 布局：顶栏边缘与当前 scrollbar gutter 对齐，Dashboard 局部滚动条保持隐藏，页面控制台无 warning/error。
- 临时模拟 4px classic scrollbar gutter，展开、折叠和水平导航均自动止于 gutter 前；恢复 overlay 后顶栏重新铺到视口右缘。

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 0817a3bc6917b4f3b78c46f4d3251d83d0e90c1e

- 修正顶栏宽度与侧栏对齐
- 采用标准属性控制原生滚动条
- 为旧版 WebKit 保留隐藏回退
- 恢复 PerfectScrollbar 默认交互反馈
- 移除过时玻璃主题样式断言
<!-- pr-agent-summary:end -->
