### PR TITLE
fix(pwa): recover CORS image cache reads

### DIFF
--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -4,6 +4,7 @@ import { CacheFirst, NetworkFirst, StaleWhileRevalidate } from 'workbox-strategi
 import { ExpirationPlugin } from 'workbox-expiration'
 import { CacheableResponsePlugin } from 'workbox-cacheable-response'
 import * as navigationPreload from 'workbox-navigation-preload'
+import { corsSafeCachePlugin } from '@/utils/serviceWorkerCache'
 
 // Service Worker 类型声明
 declare let self: ServiceWorkerGlobalScope & {
@@ -97,6 +98,7 @@ registerRoute(
   new CacheFirst({
     cacheName: `image-cache-${RESOURCE_VERSION}`,
     plugins: [
+      corsSafeCachePlugin,
       new CacheableResponsePlugin({
         statuses: [0, 200],
       }),
@@ -131,6 +133,7 @@ registerRoute(
   new CacheFirst({
     cacheName: `tmdb-image-cache-${RESOURCE_VERSION}`,
     plugins: [
+      corsSafeCachePlugin,
       new CacheableResponsePlugin({
         statuses: [0, 200],
       }),
@@ -157,7 +160,7 @@ registerRoute(
     !url.pathname.includes('/api/v1/mfa/') && // 多因素认证接口
     !url.pathname.includes('/api/v1/auth/') && // 登录认证入口与票据交换
     !url.pathname.includes('/api/v1/dashboard/') && // Dashboard实时监控数据
-    !url.pathname.includes('/api/v1/plugin/')&& // 插件接口
+    !url.pathname.includes('/api/v1/plugin/') && // 插件接口
     !url.pathname.includes('/api/v1/subscribe/'), // 订阅接口
   new NetworkFirst({
     cacheName: `api-cache-${CACHE_VERSION}`,

--- a/src/utils/__tests__/serviceWorkerCache.spec.ts
+++ b/src/utils/__tests__/serviceWorkerCache.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+
+import { corsSafeCachePlugin, selectCorsSafeCachedResponse } from '../serviceWorkerCache'
+
+function createResponse(type: ResponseType) {
+  const response = new Response('image')
+  Object.defineProperty(response, 'type', { value: type })
+  return response
+}
+
+describe('Service Worker cache CORS boundary', () => {
+  it('rejects an opaque cache entry for a CORS image request', () => {
+    const request = new Request('https://image.example/wallpaper.jpg', { mode: 'cors' })
+    const cachedResponse = createResponse('opaque')
+
+    expect(selectCorsSafeCachedResponse(request, cachedResponse)).toBeUndefined()
+  })
+
+  it('keeps a CORS-clean cache entry for a CORS image request', () => {
+    const request = new Request('https://image.example/wallpaper.jpg', { mode: 'cors' })
+    const cachedResponse = createResponse('cors')
+
+    expect(selectCorsSafeCachedResponse(request, cachedResponse)).toBe(cachedResponse)
+  })
+
+  it('keeps an opaque cache entry for an ordinary no-cors image request', () => {
+    const request = new Request('https://image.example/poster.jpg', { mode: 'no-cors' })
+    const cachedResponse = createResponse('opaque')
+
+    expect(selectCorsSafeCachedResponse(request, cachedResponse)).toBe(cachedResponse)
+  })
+
+  it('returns a cache miss unchanged so CacheFirst can use its network and offline policy', () => {
+    const request = new Request('https://image.example/wallpaper.jpg', { mode: 'cors' })
+
+    expect(selectCorsSafeCachedResponse(request, undefined)).toBeUndefined()
+  })
+
+  it('exposes the boundary through the Workbox cached response lifecycle', async () => {
+    const request = new Request('https://image.example/wallpaper.jpg', { mode: 'cors' })
+    const cachedResponse = createResponse('opaque')
+
+    await expect(
+      corsSafeCachePlugin.cachedResponseWillBeUsed?.({
+        cacheName: 'image-cache',
+        cachedResponse,
+        event: new Event('fetch') as ExtendableEvent,
+        matchOptions: {},
+        request,
+      }),
+    ).resolves.toBeUndefined()
+  })
+})

--- a/src/utils/serviceWorkerCache.ts
+++ b/src/utils/serviceWorkerCache.ts
@@ -1,0 +1,21 @@
+import type { WorkboxPlugin } from 'workbox-core'
+
+/**
+ * CORS 请求不得采用 opaque 响应，否则浏览器无法读取其内容。
+ * 普通 no-cors 请求仍保留 opaque 缓存能力；缓存未命中时继续交给策略决定网络或离线回退。
+ */
+export function selectCorsSafeCachedResponse(
+  request: Request,
+  cachedResponse: Response | undefined,
+): Response | undefined {
+  if (request.mode === 'cors' && cachedResponse?.type === 'opaque') return undefined
+
+  return cachedResponse
+}
+
+/** 在 Workbox 采用缓存前执行响应的 CORS 可读性边界。 */
+export const corsSafeCachePlugin: WorkboxPlugin = {
+  async cachedResponseWillBeUsed({ cachedResponse, request }) {
+    return selectCorsSafeCachedResponse(request, cachedResponse)
+  },
+}


### PR DESCRIPTION
## 问题与背景

PWA 受 Service Worker 控制后，同一壁纸 URL 可能先被普通图片请求缓存为 opaque 响应，随后又被玻璃 renderer 以 CORS 模式读取。此时 WebGL 无法使用 opaque 响应，renderer 会进入 fallback，即使图片源站实际支持 CORS。

## 原因分析

图片运行时缓存使用 `CacheFirst`，并允许缓存 status `0` 与 `200`。Cache Storage 对同一 URL 不按请求 mode 隔离，因此先写入的 `no-cors` opaque 响应可能被后续 CORS 请求命中。

## 解决方案

- 增加通用 Workbox 缓存响应筛选器，在 `cachedResponseWillBeUsed` 阶段拒绝让 CORS 请求采用 opaque 响应。
- 将该筛选器接入通用图片缓存与 TMDB 专用图片缓存。
- 保留普通 `no-cors` 图片的 opaque 缓存和离线读取能力；在线时由现有 CORS 预载重试取得可读响应并覆盖旧条目。

该方案不改变缓存键、容量、过期时间或可缓存状态，也不要求清空现有缓存。

## 影响与风险

- 仅影响 CORS 请求命中 opaque 缓存的边界。
- 普通图片的 PWA 离线缓存行为保持不变。
- 离线且只有 opaque 条目时，CORS 请求会按浏览器安全边界失败，而不会把不可读响应交给 canvas 或 WebGL。
- 已有 opaque 条目在恢复联网后可自动替换为 CORS-clean 响应，无配置或数据迁移要求。

## 验证

- `yarn test:run`：131 个测试文件、1207 项测试通过。
- `yarn typecheck`
- `yarn lint`
- `yarn format:check`
- `yarn build`
- `git diff --check`
- 受 Service Worker 控制的 PWA 中验证 opaque 缓存可在线自愈，玻璃 renderer 保持 ready。
- 离线验证普通 `no-cors` 请求仍可读取 opaque 缓存，CORS 请求不会误用该响应；恢复联网后缓存替换为 CORS-clean `200`。

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at d9e69b8f187f4b3d33fb64c818869ff31d379858

- 防止 CORS 请求读取 opaque 图片缓存
- 接入通用及 TMDB 图片缓存策略
- 保留 no-cors 离线 opaque 缓存能力
- 新增 Workbox 缓存生命周期边界测试
<!-- pr-agent-summary:end -->
