### PR TITLE
[codex] Compact downloading poster cards

### DIFF
--- a/src/components/cards/DownloadingCard.vue
+++ b/src/components/cards/DownloadingCard.vue
@@ -159,13 +159,7 @@ async function deleteDownload() {
           }"
         >
           <div v-if="hasPosterImage" class="downloading-card__poster">
-            <VImg
-              :src="media.image"
-              class="downloading-card__image"
-              cover
-              position="top"
-              @error="imageLoadError = true"
-            >
+            <VImg :src="media.image" class="downloading-card__image" position="center" @error="imageLoadError = true">
               <template #placeholder>
                 <VSkeletonLoader class="downloading-card__image-loader h-full" />
               </template>
@@ -276,7 +270,7 @@ async function deleteDownload() {
 
 .downloading-card {
   display: grid;
-  min-block-size: 13rem;
+  min-block-size: 12rem;
   color: rgb(var(--v-theme-on-surface));
   grid-template-columns: 8.25rem minmax(0, 1fr);
 }
@@ -284,7 +278,7 @@ async function deleteDownload() {
 .downloading-card__poster {
   position: relative;
   overflow: hidden;
-  min-block-size: 13rem;
+  min-block-size: 12rem;
   background: rgba(var(--v-theme-on-surface), 0.06);
 }
 
@@ -292,14 +286,6 @@ async function deleteDownload() {
 .downloading-card__image-loader {
   block-size: 100%;
   inline-size: 100%;
-}
-
-.downloading-card__image :deep(.v-img__img) {
-  transition: transform 0.35s ease;
-}
-
-.downloading-card--hovering .downloading-card__image :deep(.v-img__img) {
-  transform: scale(1.035);
 }
 
 .downloading-card__poster-edge {
@@ -313,8 +299,8 @@ async function deleteDownload() {
   display: flex;
   min-inline-size: 0;
   flex-direction: column;
-  gap: 0.65rem;
-  padding: 1rem !important;
+  gap: 0.55rem;
+  padding: 0.875rem !important;
 }
 
 .downloading-card__chips {
@@ -457,17 +443,17 @@ async function deleteDownload() {
 
 @container (width <= 25rem) {
   .downloading-card {
-    min-block-size: 12rem;
+    min-block-size: 11rem;
     grid-template-columns: 6.75rem minmax(0, 1fr);
   }
 
   .downloading-card__poster {
-    min-block-size: 12rem;
+    min-block-size: 11rem;
   }
 
   .downloading-card__body {
-    gap: 0.5rem;
-    padding: 0.75rem !important;
+    gap: 0.45rem;
+    padding: 0.65rem !important;
   }
 
   .downloading-card__chips {
@@ -517,11 +503,5 @@ async function deleteDownload() {
 .downloading-card.downloading-card--no-image {
   min-block-size: 0;
   grid-template-columns: minmax(0, 1fr);
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .downloading-card__image :deep(.v-img__img) {
-    transition: none;
-  }
 }
 </style>


### PR DESCRIPTION
## What changed

- Reduced poster-card minimum height from 208px to 192px on regular cards and from 192px to 176px on narrow cards.
- Reduced internal vertical padding and gaps while allowing long content to grow naturally.
- Switched posters from cropped `cover` rendering to centered `contain` rendering.
- Removed poster zoom so the complete artwork remains visible.

## Why

Poster cards remained taller than necessary, and common 2:3 artwork lost its left and right edges in narrow card columns. The new dimensions are denser while preserving the complete poster on small screens.

## Validation

- `yarn prettier src/components/cards/DownloadingCard.vue --check`
- `yarn eslint src/components/cards/DownloadingCard.vue --max-warnings=0`
- `yarn test:run src/components/cards/__tests__/DownloadingCard.spec.ts src/views/reorganize/__tests__/DownloadingListView.spec.ts` (12 tests passed)
- `git diff --check`
- Confirmed Vuetify's non-cover `VImg` mode uses `object-fit: contain`.

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 3652689cb1ef63e783c90ec400e0b1d600b4d925

- 紧凑下载海报卡片的高度与内边距
- 海报改为居中完整显示，避免裁切
- 移除悬停缩放及相关动效样式
- 无接口兼容性影响；未新增测试
<!-- pr-agent-summary:end -->
