### PR TITLE
test(download): restore downloading card coverage

### DIFF
--- a/src/components/cards/__tests__/DownloadingCard.spec.ts
+++ b/src/components/cards/__tests__/DownloadingCard.spec.ts
@@ -5,8 +5,14 @@ import { renderWithProviders } from '@tests/support/render'
 import { deleteDownloadHandler, downloadActionHandler } from '@tests/support/msw/handlers/download'
 import { server } from '@tests/support/msw/server'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, h } from 'vue'
 
-function downloading(overrides: Partial<DownloadingInfo> = {}): DownloadingInfo {
+type DownloadingCardInfo = DownloadingInfo & {
+  site_name?: string
+  trackers?: string[]
+}
+
+function downloading(overrides: Partial<DownloadingCardInfo> = {}): DownloadingCardInfo {
   return {
     dlspeed: '2 MiB',
     hash: 'hash-1',
@@ -95,6 +101,96 @@ describe('DownloadingCard display and pause state', () => {
 
     await fireEvent.mouseLeave(hoverArea)
     await waitFor(() => expect(shell).not.toHaveClass('app-hover-lift-card--hovering'))
+  })
+
+  it('normalizes media type, source host, speeds and missing time without exposing tracker details', async () => {
+    await renderCard(
+      downloading({
+        dlspeed: '2 MiB/s',
+        left_time: ' ',
+        media: {
+          poster: 'https://images.example.com/movie.jpg',
+          season: 'S01',
+          title: '测试电影',
+          type: 'movie',
+        },
+        trackers: ['', 'invalid tracker', 'https://www.tracker.example/announce?passkey=private'],
+        upspeed: '',
+        year: ' 2026 ',
+      }),
+    )
+
+    expect(screen.getByText('电影')).toBeInTheDocument()
+    expect(screen.getByText('tracker.example')).toBeInTheDocument()
+    expect(screen.queryByText(/passkey|private/)).not.toBeInTheDocument()
+    expect(screen.getByText(/2026/)).toBeInTheDocument()
+    expect(screen.getByText('2 MiB/s')).toBeInTheDocument()
+    expect(screen.getByText('0 B/s')).toBeInTheDocument()
+    expect(screen.getByText(/--/)).toBeInTheDocument()
+  })
+
+  it('uses explicit site and TV metadata before inferred fallbacks', async () => {
+    await renderCard(
+      downloading({
+        media: {
+          poster: '',
+          title: '测试剧集',
+          type: '电视剧',
+        },
+        season_episode: '',
+        site_name: '主站点',
+        trackers: ['https://tracker.example/announce'],
+      }),
+    )
+
+    expect(screen.getByText('电视剧')).toBeInTheDocument()
+    expect(screen.getByText('主站点')).toBeInTheDocument()
+    expect(screen.queryByText('tracker.example')).not.toBeInTheDocument()
+  })
+
+  it('clamps finite progress and hides invalid or non-positive progress', async () => {
+    const { container, rerender } = await renderCard(downloading({ progress: Number.NaN }))
+
+    expect(container.querySelector('.v-card-text .v-progress-linear')).not.toBeInTheDocument()
+
+    await rerender({ downloaderName: 'qb-main', info: downloading({ progress: 150 }) })
+    expect(screen.getByText('100%')).toBeInTheDocument()
+
+    await rerender({ downloaderName: 'qb-main', info: downloading({ progress: -10 }) })
+    expect(container.querySelector('.v-card-text .v-progress-linear')).not.toBeInTheDocument()
+  })
+
+  it('hides a failed poster and restores image rendering when the media poster changes', async () => {
+    const ImageStub = defineComponent({
+      name: 'VImg',
+      emits: ['error'],
+      setup(_, { attrs, emit }) {
+        return () =>
+          h('img', {
+            ...attrs,
+            'data-testid': 'poster-image',
+            onError: () => emit('error'),
+          })
+      },
+    })
+    const { container, rerender } = await renderWithProviders(DownloadingCard, {
+      global: { stubs: { VImg: ImageStub } },
+      props: { downloaderName: 'qb-main', info: downloading() },
+    })
+
+    await fireEvent.error(screen.getByTestId('poster-image'))
+    await waitFor(() => expect(container.querySelector('.downloading-card__poster')).not.toBeInTheDocument())
+
+    await rerender({
+      downloaderName: 'qb-main',
+      info: downloading({
+        media: {
+          poster: 'https://images.example.com/replacement.jpg',
+          title: '替换海报',
+        },
+      }),
+    })
+    await waitFor(() => expect(container.querySelector('.downloading-card__poster')).toBeInTheDocument())
   })
 
   it('uses the current operation and downloader name, changing state only on business success', async () => {


### PR DESCRIPTION
## 问题与背景

近期下载卡片展示逻辑扩展后，现有测试全部通过，但 `DownloadingCard.vue` 的文件级 Functions/Branches 覆盖率降至 `71.42% / 67.53%`，无法满足仓库已有的 `90% / 85%` 门禁。

## 原因分析

现有用例主要覆盖下载操作和基础悬停行为，未覆盖媒体信息归一化、来源站点选择、进度边界以及海报加载失败后的恢复路径。因此生产行为本身可运行，但文件级分支和函数门禁缺少对应的行为测试证据。

## 解决方案

仅扩展 `src/components/cards/__tests__/DownloadingCard.spec.ts`，通过用户可观察行为补齐以下场景：

- 显式媒体类型优先级，以及电影、电视剧文案归一化；
- 站点名称优先于 Tracker，Tracker 只展示 hostname，不泄露路径、查询参数或 passkey；
- 下载/上传速度、剩余时间和进度的空值、非法值及上下界；
- 海报加载失败后隐藏，媒体海报变化时恢复渲染。

未修改生产代码，也未调整或降低覆盖率阈值。

## 影响与风险

本 PR 仅增加单元测试，不改变下载列表、接口契约、页面交互、构建产物或运行时性能，也不涉及配置和数据迁移。

## 验证

- `yarn vitest run src/components/cards/__tests__/DownloadingCard.spec.ts`：`13 passed`
- `yarn test:coverage`：`143 files / 1307 tests` 全部通过
- 全局 Statements/Branches/Functions/Lines：`95.51% / 85.23% / 92.55% / 95.51%`
- `DownloadingCard.vue` Statements/Branches/Functions/Lines：`100% / 88.11% / 100% / 100%`
- `yarn typecheck`
- `yarn lint`
- `yarn format:check`
- `yarn build`
- `git diff --check`

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 3d10162a081d3c1d8a51f792390ac2a834c48318

- 补充下载卡片边界行为测试
- 覆盖媒体、站点与速度归一化
- 验证进度边界及海报恢复
- 不修改生产代码与接口契约
<!-- pr-agent-summary:end -->
