### PR TITLE
feat: 修复玻璃主题下Chip标签颜色

### DIFF
--- a/src/styles/themes/glass.scss
+++ b/src/styles/themes/glass.scss
@@ -826,6 +826,32 @@ html[data-theme='glass'] {
     background-color: rgba(255, 255, 255, 7%);
   }
 
+  // 有色 Chip 保留语义色相，仅降低不透明度形成有色玻璃，与按钮的色玻璃规则保持一致。
+  .v-chip.bg-primary {
+    border-color: rgba(var(--v-theme-primary), 48%);
+    background-color: rgba(var(--v-theme-primary), 34%) !important;
+  }
+
+  .v-chip.bg-success {
+    border-color: rgba(var(--v-theme-success), 48%);
+    background-color: rgba(var(--v-theme-success), 34%) !important;
+  }
+
+  .v-chip.bg-info {
+    border-color: rgba(var(--v-theme-info), 48%);
+    background-color: rgba(var(--v-theme-info), 34%) !important;
+  }
+
+  .v-chip.bg-warning {
+    border-color: rgba(var(--v-theme-warning), 48%);
+    background-color: rgba(var(--v-theme-warning), 34%) !important;
+  }
+
+  .v-chip.bg-error {
+    border-color: rgba(var(--v-theme-error), 48%);
+    background-color: rgba(var(--v-theme-error), 34%) !important;
+  }
+
   .v-table {
     .v-table__wrapper > table > thead {
       background-color: rgba(255, 255, 255, 6%);


### PR DESCRIPTION
## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 633f821a8db07a75fb94261135762bc9b21e35b2

- 修复玻璃主题有色 Chip 语义色丢失
- 为五种状态色应用半透明玻璃背景与边框
- 仅影响 `glass` 主题下的 `.v-chip`
<!-- pr-agent-summary:end -->
