### PR TITLE
fix(glass): refine fluid response coverage

### DIFF
--- a/src/composables/__tests__/useGlassOpticalRenderer.spec.ts
+++ b/src/composables/__tests__/useGlassOpticalRenderer.spec.ts
@@ -4149,8 +4149,8 @@ describe('glass optical surface discovery', () => {
     expect(scene.children[0].material.fragmentShader).toContain('uniform float uReflectionStrength')
     expect(scene.children[0].material.fragmentShader).not.toContain('uWakeProgress')
     expect(scene.children[0].material.fragmentShader).not.toContain('temporalEnergy')
-    expect(scene.children[0].material.fragmentShader).toContain('const float dynamicRangeScale = 0.40')
-    expect(scene.children[0].material.fragmentShader).toContain('const float dynamicRangeDensity = 6.250')
+    expect(scene.children[0].material.fragmentShader).toContain('const float dynamicRangeScale = 0.52')
+    expect(scene.children[0].material.fragmentShader).toContain('const float dynamicRangeDensity = 3.698')
     expect(scene.children[0].material.fragmentShader).toContain('float pointerSpread = mix(26.0, 17.0, uQuality)')
     expect(scene.children[0].material.fragmentShader).not.toContain(
       'mix(mix(26.0, 17.0, uQuality), mix(12.0, 8.0, uQuality), frosted)',

--- a/src/rendering/glass/__tests__/glassFluidDynamics.spec.ts
+++ b/src/rendering/glass/__tests__/glassFluidDynamics.spec.ts
@@ -1,5 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { createGlassFluidDynamics, GLASS_FLUID_FIELD_FRAGMENT_SHADER } from '@/rendering/glass/glassFluidDynamics'
+import {
+  createGlassFluidDynamics,
+  GLASS_FLUID_DYNAMIC_RANGE_DENSITY,
+  GLASS_FLUID_DYNAMIC_RANGE_SCALE,
+  GLASS_FLUID_FIELD_FRAGMENT_SHADER,
+  GLASS_FLUID_FRAGMENT_SURFACE_REFRACTION,
+  GLASS_FLUID_FRAGMENT_SURFACE_SHAPE,
+} from '@/rendering/glass/glassFluidDynamics'
 
 class FakeVector2 {
   constructor(
@@ -179,9 +186,26 @@ describe('glass fluid dynamics', () => {
 
   it('keeps the established field injection and decay equations', () => {
     expect(GLASS_FLUID_FIELD_FRAGMENT_SHADER).toContain('previousEnergy * uDecay')
-    expect(GLASS_FLUID_FIELD_FRAGMENT_SHADER).toContain('distanceSquared * 437.500')
-    expect(GLASS_FLUID_FIELD_FRAGMENT_SHADER).toContain('distanceSquared * 262.500')
+    expect(GLASS_FLUID_DYNAMIC_RANGE_SCALE).toBe(0.52)
+    expect(GLASS_FLUID_DYNAMIC_RANGE_DENSITY).toBeCloseTo(3.698, 3)
+    expect(GLASS_FLUID_FIELD_FRAGMENT_SHADER).toContain('distanceSquared * 258.876')
+    expect(GLASS_FLUID_FIELD_FRAGMENT_SHADER).toContain('distanceSquared * 155.325')
     expect(GLASS_FLUID_FIELD_FRAGMENT_SHADER).toContain('injection * 0.44')
     expect(GLASS_FLUID_FIELD_FRAGMENT_SHADER).not.toContain('uImpulse')
+  })
+
+  it('narrows directional material coverage without replacing fluid refraction energy', () => {
+    expect(GLASS_FLUID_FRAGMENT_SURFACE_SHAPE).toContain(
+      'smoothstep(0.001, 0.012, length(uPointerVelocity))',
+    )
+    expect(GLASS_FLUID_FRAGMENT_SURFACE_SHAPE).toContain('directionalCoverageShape')
+    expect(GLASS_FLUID_FRAGMENT_SURFACE_SHAPE).toContain('pointerCoverageEnergy')
+    expect(GLASS_FLUID_FRAGMENT_SURFACE_SHAPE).toContain(
+      'pow(clamp(pointerCoverageShape * uMotion, 0.0, 1.0), 1.15)',
+    )
+    expect(GLASS_FLUID_FRAGMENT_SURFACE_REFRACTION).toContain(
+      'pointerDelta * pointerEnergy * pointerStrength',
+    )
+    expect(GLASS_FLUID_FRAGMENT_SURFACE_REFRACTION).not.toContain('pointerCoverageEnergy')
   })
 })

--- a/src/rendering/glass/glassFluidDynamics.ts
+++ b/src/rendering/glass/glassFluidDynamics.ts
@@ -216,8 +216,9 @@ export const GLASS_FLUID_FRAGMENT_SURFACE_SHAPE = `    vec2 pointerDelta = uPoin
       uDeformationStrength *
       uFlowStrength;
     float wakeEnergy = abs(wakeShape) * wakeEnvelope * uMotion;
+    // 覆盖能量比位移核更快收敛，避免高斯尾部把真实折射扩成整块色调覆盖。
     float liquidEnergy = clamp(max(
-      pointerEnergy,
+      pow(pointerEnergy, 1.15),
       max(min(1.0, trailEnergy) * 0.68, wakeEnergy * 0.82)
     ), 0.0, 1.0);`
 

--- a/src/rendering/glass/glassFluidDynamics.ts
+++ b/src/rendering/glass/glassFluidDynamics.ts
@@ -44,7 +44,7 @@ export interface GlassFluidDynamics {
   step(): Texture
 }
 
-export const GLASS_FLUID_DYNAMIC_RANGE_SCALE = 0.4
+export const GLASS_FLUID_DYNAMIC_RANGE_SCALE = 0.52
 export const GLASS_FLUID_DYNAMIC_RANGE_DENSITY = 1 / GLASS_FLUID_DYNAMIC_RANGE_SCALE ** 2
 const GLASS_FLUID_BUFFER_SCALE = 0.25
 

--- a/src/rendering/glass/glassFluidDynamics.ts
+++ b/src/rendering/glass/glassFluidDynamics.ts
@@ -217,8 +217,24 @@ export const GLASS_FLUID_FRAGMENT_SURFACE_SHAPE = `    vec2 pointerDelta = uPoin
       uFlowStrength;
     float wakeEnergy = abs(wakeShape) * wakeEnvelope * uMotion;
     // 覆盖能量比位移核更快收敛，避免高斯尾部把真实折射扩成整块色调覆盖。
+    float coverageDirectionality = max(
+      sharedDirectionality,
+      smoothstep(0.001, 0.012, length(uPointerVelocity))
+    );
+    float coverageWakeTravel =
+      0.08 * coverageDirectionality * mix(0.86, 1.18, uMotionExpansion);
+    float directionalCoverageShape = exp(-(
+      pow(pointerAlong + coverageWakeTravel * 0.45, 2.0) * pointerSpread * 0.55 +
+      pointerAcross * pointerAcross * pointerSpread * 2.8
+    ));
+    float pointerCoverageShape = mix(
+      radialPointerShape,
+      directionalCoverageShape,
+      coverageDirectionality
+    );
+    float pointerCoverageEnergy = pow(clamp(pointerCoverageShape * uMotion, 0.0, 1.0), 1.15);
     float liquidEnergy = clamp(max(
-      pow(pointerEnergy, 1.15),
+      pointerCoverageEnergy,
       max(min(1.0, trailEnergy) * 0.68, wakeEnergy * 0.82)
     ), 0.0, 1.0);`
 


### PR DESCRIPTION
## 问题与背景

玻璃主题的 `fluid` 动态在部分明暗过渡明显的壁纸区域会形成宽而缺少方向结构的深色覆盖。快速跨卡片滑动时，这块覆盖比真实折射范围更显眼，容易被感知为局部黑影。

## 原因分析

主材质此前直接使用宽范围的 `pointerEnergy` 同时驱动折射和材质覆盖。高斯尾部对折射仍有价值，但用于颜色与 alpha 覆盖时会把低能量区域扩展到方向性 wake 之外，形成面积过大的暗色块。

## 解决方案

- 保留原始 `pointerEnergy` 驱动折射，避免削弱现有流体位移。
- 材质覆盖使用收敛更快的独立能量，并在明显移动时沿 wake 方向形成紧凑椭圆覆盖。
- 将 fluid 动态范围从 `0.40` 调整为 `0.52`，在收紧覆盖后维持足够的跨表面传播范围。
- 同步 shader 派生常量测试，并锁定“覆盖收敛不替换折射能量”的边界。

## 影响与风险

- 仅影响 `fluid` 动态模式；`ripple` 与 `off` 不变。
- 不新增 WebGL context、纹理场、事件监听器或生命周期分支。
- 无配置或数据迁移。
- 快速移动时宽泛暗色覆盖减少；小范围交互的峰值与响应基本保持不变。

## 验证

- `yarn vitest run src/rendering/glass/__tests__/glassFluidDynamics.spec.ts src/composables/__tests__/useGlassOpticalRenderer.spec.ts`：93 项测试通过。
- `yarn typecheck`
- `yarn lint`
- `yarn lint:suppressions:prune`
- `yarn build`
- `git diff --check`
- Chrome 同条件 compositor A/B：小范围交互平均 alpha 差异约 `0.06%`；高速交互平均 alpha 降低约 `12.3%`，明显变暗面积减少，峰值与亮斑面积未增加。

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at d7c83d1538e7670ec49dd78ed4948c59f53b5655

- 收紧 fluid 材质覆盖能量，减少暗色扩散
- 按指针运动方向生成紧凑椭圆覆盖
- 保持原有折射能量与位移响应
- 扩大 fluid 传播范围并更新 shader 测试
<!-- pr-agent-summary:end -->
