### PR TITLE
fix(glass): define signed coverage square

### DIFF
--- a/src/rendering/glass/__tests__/glassFluidDynamics.spec.ts
+++ b/src/rendering/glass/__tests__/glassFluidDynamics.spec.ts
@@ -195,17 +195,21 @@ describe('glass fluid dynamics', () => {
   })
 
   it('narrows directional material coverage without replacing fluid refraction energy', () => {
-    expect(GLASS_FLUID_FRAGMENT_SURFACE_SHAPE).toContain(
-      'smoothstep(0.001, 0.012, length(uPointerVelocity))',
-    )
+    expect(GLASS_FLUID_FRAGMENT_SURFACE_SHAPE).toContain('smoothstep(0.001, 0.012, length(uPointerVelocity))')
     expect(GLASS_FLUID_FRAGMENT_SURFACE_SHAPE).toContain('directionalCoverageShape')
     expect(GLASS_FLUID_FRAGMENT_SURFACE_SHAPE).toContain('pointerCoverageEnergy')
-    expect(GLASS_FLUID_FRAGMENT_SURFACE_SHAPE).toContain(
-      'pow(clamp(pointerCoverageShape * uMotion, 0.0, 1.0), 1.15)',
-    )
-    expect(GLASS_FLUID_FRAGMENT_SURFACE_REFRACTION).toContain(
-      'pointerDelta * pointerEnergy * pointerStrength',
-    )
+    expect(GLASS_FLUID_FRAGMENT_SURFACE_SHAPE).toContain('pow(clamp(pointerCoverageShape * uMotion, 0.0, 1.0), 1.15)')
+    expect(GLASS_FLUID_FRAGMENT_SURFACE_REFRACTION).toContain('pointerDelta * pointerEnergy * pointerStrength')
     expect(GLASS_FLUID_FRAGMENT_SURFACE_REFRACTION).not.toContain('pointerCoverageEnergy')
+  })
+
+  it('squares the signed coverage offset without GLSL pow', () => {
+    expect(GLASS_FLUID_FRAGMENT_SURFACE_SHAPE).toContain(
+      'float directionalCoverageAlong = pointerAlong + coverageWakeTravel * 0.45;',
+    )
+    expect(GLASS_FLUID_FRAGMENT_SURFACE_SHAPE).toContain(
+      'directionalCoverageAlong * directionalCoverageAlong * pointerSpread * 0.55',
+    )
+    expect(GLASS_FLUID_FRAGMENT_SURFACE_SHAPE).not.toContain('pow(pointerAlong + coverageWakeTravel * 0.45, 2.0)')
   })
 })

--- a/src/rendering/glass/glassFluidDynamics.ts
+++ b/src/rendering/glass/glassFluidDynamics.ts
@@ -223,8 +223,9 @@ export const GLASS_FLUID_FRAGMENT_SURFACE_SHAPE = `    vec2 pointerDelta = uPoin
     );
     float coverageWakeTravel =
       0.08 * coverageDirectionality * mix(0.86, 1.18, uMotionExpansion);
+    float directionalCoverageAlong = pointerAlong + coverageWakeTravel * 0.45;
     float directionalCoverageShape = exp(-(
-      pow(pointerAlong + coverageWakeTravel * 0.45, 2.0) * pointerSpread * 0.55 +
+      directionalCoverageAlong * directionalCoverageAlong * pointerSpread * 0.55 +
       pointerAcross * pointerAcross * pointerSpread * 2.8
     ));
     float pointerCoverageShape = mix(


### PR DESCRIPTION
## 问题与背景

PR #641 调整了玻璃流体动态的覆盖范围。合并后的 reviewer 反馈指出，方向性覆盖公式对可能为负的有符号投影调用了 `pow(..., 2.0)`，在部分 WebGL 驱动上可能产生未定义结果。

## 原因分析

`pointerAlong` 来自方向点积，叠加 wake 偏移后仍可能为负。GLSL ES 不保证负底数调用 `pow` 的结果，即使指数写为 `2.0`，相关片元仍可能得到 NaN 并污染后续覆盖能量计算。

## 解决方案

- 先保存方向性覆盖的有符号投影值，再使用显式自乘计算平方。
- 保持原有偏移、密度、覆盖系数和流体视觉公式不变。
- 增加聚焦回归测试，锁定显式平方并禁止该覆盖路径恢复为有符号 `pow`。

## 影响与风险

该替换在实数数学上与平方运算等价，只消除不同 WebGL/GLSL 驱动间的未定义行为，不调整可见流体强度、范围或方向响应。无需配置或数据迁移。

## 验证

- `yarn vitest run src/rendering/glass/__tests__/glassFluidDynamics.spec.ts`：5 个测试通过
- `yarn format:check`
- `yarn typecheck`
- `yarn lint`
- `yarn build`
- `git diff --check`

## 关联

Follow-up to #641

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 6f0e7b1e3ed62733e4d3e0bcaa2d2c2f58d22147

- 修复有符号投影的 GLSL 平方计算
- 以显式自乘替代潜在未定义的 `pow`
- 增加回归测试锁定覆盖与折射边界
- 仅影响 fluid 覆盖的跨驱动稳定性
<!-- pr-agent-summary:end -->
