### PR TITLE
feat: 添加 AList 存储选项

### DIFF
--- a/src/api/constants.ts
+++ b/src/api/constants.ts
@@ -27,6 +27,11 @@ export const storageAttributes = [
     remote: true,
   },
   {
+    type: 'alistgo',
+    icon: 'mdi-server-network-outline',
+    remote: true,
+  },
+  {
     type: 'smb',
     icon: 'mdi-folder-network-outline',
     remote: true,

--- a/src/components/cards/DirectoryCard.vue
+++ b/src/components/cards/DirectoryCard.vue
@@ -12,6 +12,7 @@ const STORAGE_ACCENT_COLOR_MAP = {
   u115: '#17B26A',
   rclone: '#6675FF',
   alist: '#12B8D7',
+  alistgo: '#1BA0D8',
   smb: '#3B82F6',
 }
 

--- a/src/components/cards/StorageCard.vue
+++ b/src/components/cards/StorageCard.vue
@@ -6,6 +6,7 @@ import alipan_png from '@images/misc/alipan.webp'
 import u115_png from '@images/misc/u115.png'
 import rclone_png from '@images/misc/rclone.png'
 import alist_png from '@images/misc/openlist.svg'
+import alistgo_png from '@images/misc/alist.svg'
 import custom_png from '@images/misc/database.png'
 import smb_png from '@images/misc/smb.png'
 import api from '@/api'
@@ -58,6 +59,7 @@ function openStorageDialog() {
     u115: U115AuthDialog,
     rclone: RcloneConfigDialog,
     alist: AlistConfigDialog,
+    alistgo: AlistConfigDialog,
     smb: SmbConfigDialog,
   }
 
@@ -69,7 +71,9 @@ function openStorageDialog() {
   const dialog = dialogMap[props.storage.type] || StorageCustomConfigDialog
   const dialogProps = dialog === StorageCustomConfigDialog
     ? { storage: props.storage }
-    : { conf: props.storage.config || {} }
+    : dialog === AlistConfigDialog
+      ? { conf: props.storage.config || {}, type: props.storage.type }
+      : { conf: props.storage.config || {} }
 
   openSharedDialog(
     dialog,
@@ -94,6 +98,8 @@ const getIcon = computed(() => {
       return rclone_png
     case 'alist':
       return alist_png
+    case 'alistgo':
+      return alistgo_png
     case 'smb':
       return smb_png
     default:

--- a/src/components/dialog/AlistConfigDialog.vue
+++ b/src/components/dialog/AlistConfigDialog.vue
@@ -15,6 +15,10 @@ const props = defineProps({
     type: Object as PropType<{ [key: string]: any }>,
     required: true,
   },
+  type: {
+    type: String,
+    default: 'alist',
+  },
 })
 
 // 定义事件
@@ -29,7 +33,7 @@ async function handleDone() {
 // 重置配置
 async function handleReset() {
   try {
-    const result: { [key: string]: any } = await api.get('/storage/reset/alist')
+    const result: { [key: string]: any } = await api.get(`/storage/reset/${props.type}`)
     if (result.success) {
       // 重置成功
       handleDone()
@@ -62,7 +66,7 @@ const sourceItems = [
 // 保存alist设置
 async function savaAlistConfig() {
   try {
-    await api.post(`storage/save/alist`, props.conf)
+    await api.post(`storage/save/${props.type}`, props.conf)
   } catch (e) {
     console.error(e)
   }
@@ -78,7 +82,7 @@ async function savaAlistConfig() {
           <VIcon icon="mdi-cog-outline" class="me-2" />
         </template>
         <VCardTitle>
-          {{ t('dialog.alistConfig.title') }}
+          {{ t(`dialog.${props.type}Config.title`) }}
         </VCardTitle>
       </VCardItem>
       <VDivider />
@@ -87,8 +91,8 @@ async function savaAlistConfig() {
           <VCol cols="12">
             <VTextField
               v-model="props.conf.url"
-              :hint="t('dialog.alistConfig.serverUrl')"
-              :label="t('dialog.alistConfig.serverUrl')"
+              :hint="t(`dialog.${props.type}Config.serverUrl`)"
+              :label="t(`dialog.${props.type}Config.serverUrl`)"
               persistent-hint
               prepend-inner-icon="mdi-server"
             />

--- a/src/locales/en-US.ts
+++ b/src/locales/en-US.ts
@@ -1401,6 +1401,7 @@ export default {
     u115: '115 Cloud',
     rclone: 'RClone',
     alist: 'OpenList',
+    alistgo: 'AList',
     smb: 'SMB Network Share',
     custom: 'Custom',
   },
@@ -2915,6 +2916,10 @@ export default {
       },
       complete: 'Complete',
       reset: 'Reset',
+    },
+    alistgoConfig: {
+      title: 'AList Configuration',
+      serverUrl: 'AList server address',
     },
     smbConfig: {
       title: 'SMB Network Share Configuration',

--- a/src/locales/zh-CN.ts
+++ b/src/locales/zh-CN.ts
@@ -1391,6 +1391,7 @@ export default {
     u115: '115网盘',
     rclone: 'RClone',
     alist: 'OpenList',
+    alistgo: 'AList',
     smb: 'SMB网络共享',
     custom: '自定义',
   },
@@ -2860,6 +2861,10 @@ export default {
       },
       complete: '完成',
       reset: '重置',
+    },
+    alistgoConfig: {
+      title: 'AList配置',
+      serverUrl: 'AList服务地址',
     },
     smbConfig: {
       title: 'SMB网络共享配置',

--- a/src/locales/zh-TW.ts
+++ b/src/locales/zh-TW.ts
@@ -1389,6 +1389,7 @@ export default {
     u115: '115網盤',
     rclone: 'RClone',
     alist: 'OpenList',
+    alistgo: 'AList',
     smb: 'SMB網路共享',
     custom: '自定義',
   },
@@ -2859,6 +2860,10 @@ export default {
       },
       complete: '完成',
       reset: '重置',
+    },
+    alistgoConfig: {
+      title: 'AList配置',
+      serverUrl: 'AList服務地址',
     },
     smbConfig: {
       title: 'SMB網路共享配置',


### PR DESCRIPTION
配合后端新增的 `alistgo` 存储类型（jxxghp/MoviePilot#6245），在存储设置的添加存储列表中恢复 AList 选项，与 OpenList 并存。

- 复用 `AlistConfigDialog`，新增 `type` prop 区分保存/重置接口路径及标题、服务地址文案
- 图标使用仓库内保留的 `alist.svg`，新增 `alistgo` 存储显示名与配置文案（zh-CN/zh-TW/en-US）
- vue-tsc、eslint、vitest 全部通过

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at de053f1368f142c7f860ac804b0fa48ab91d4586

- 新增 `alistgo` AList 远程存储选项
- 复用配置弹窗并按类型调用接口
- 补充图标、卡片颜色及多语言文案
- 依赖后端支持 `/storage/*/alistgo` 接口
<!-- pr-agent-summary:end -->
