### PR TITLE
fix(a11y): label dialog close buttons

### DIFF
--- a/src/@core/components/DialogCloseBtn.vue
+++ b/src/@core/components/DialogCloseBtn.vue
@@ -1,12 +1,13 @@
 <script lang="ts" setup>
-// 定义输入参数
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
 const props = defineProps({
-  // 是否显示
+  /** 覆盖关闭按钮默认的右上角定位 class。 */
   innerClass: String,
 })
-// 定义触发的自定义事件
 const emit = defineEmits(['click', 'update:modelValue'])
-// 按钮点击
+
 function onClick() {
   emit('update:modelValue', false)
   emit('click')
@@ -15,6 +16,7 @@ function onClick() {
 
 <template>
   <IconBtn
+    :aria-label="t('common.close')"
     :class="props.innerClass ? props.innerClass : 'absolute right-3 top-3 z-10'"
     @click.stop="onClick"
   >

--- a/src/@core/components/__tests__/DialogCloseBtn.spec.ts
+++ b/src/@core/components/__tests__/DialogCloseBtn.spec.ts
@@ -1,0 +1,40 @@
+import DialogCloseBtn from '@/@core/components/DialogCloseBtn.vue'
+import i18n from '@/plugins/i18n'
+import { screen, waitFor } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { renderWithProviders } from '@tests/support/render'
+import { afterEach, describe, expect, it } from 'vitest'
+
+afterEach(() => {
+  i18n.global.locale.value = 'zh-CN'
+})
+
+describe('DialogCloseBtn', () => {
+  it('keeps its visual and event contracts while exposing a localized name', async () => {
+    const user = userEvent.setup()
+    const { container, emitted, rerender } = await renderWithProviders(DialogCloseBtn)
+    const button = screen.getByRole('button', { name: '关闭' })
+
+    expect(button).toHaveClass('absolute', 'right-3', 'top-3', 'z-10')
+    const icon = container.querySelector('svg.v-icon')
+    expect(icon).not.toBeNull()
+    expect(icon).toHaveAttribute('aria-hidden', 'true')
+    await waitFor(() =>
+      expect(icon?.querySelector('path')).toHaveAttribute(
+        'd',
+        'M19 6.41L17.59 5L12 10.59L6.41 5L5 6.41L10.59 12L5 17.59L6.41 19L12 13.41L17.59 19L19 17.59L13.41 12z',
+      ),
+    )
+
+    i18n.global.locale.value = 'en-US'
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Close' })).toBe(button))
+
+    await user.click(button)
+    expect(emitted()['update:modelValue']).toEqual([[false]])
+    expect(emitted().click).toEqual([[]])
+
+    await rerender({ innerClass: 'dialog-close-custom' })
+    expect(button).toHaveClass('dialog-close-custom')
+    expect(button).not.toHaveClass('absolute', 'right-3', 'top-3', 'z-10')
+  })
+})

--- a/src/components/dialog/__tests__/SiteImportDialog.spec.ts
+++ b/src/components/dialog/__tests__/SiteImportDialog.spec.ts
@@ -220,7 +220,9 @@ describe('SiteImportDialog', () => {
     await fireEvent.click(await screen.findByRole('button', { name: '开始导入' }))
     expect(await screen.findByText('导入过程中出现 1 个错误')).toBeInTheDocument()
 
-    await fireEvent.click(screen.getByRole('button', { name: '关闭' }))
+    const resultCloseButton = screen.getByText('关闭').closest('button')
+    expect(resultCloseButton).not.toBeNull()
+    await fireEvent.click(resultCloseButton!)
     expect(events.update).toHaveBeenCalledWith(false)
     expect(events.importSuccess).not.toHaveBeenCalled()
   })


### PR DESCRIPTION
## 问题与背景

全局 `DialogCloseBtn` 是只显示关闭图标的按钮，但此前没有可访问名称。图标本身按装饰内容隐藏后，屏幕阅读器只能识别到一个未命名按钮，使用语义查询时也无法稳定区分关闭操作。

## 原因分析

组件只渲染 `mdi-close` 图标，没有可见文本、`aria-label` 或其他命名来源；图标的 `aria-hidden` 行为是正确的，但按钮因此缺少 accessible name。

## 解决方案

- 复用现有 `common.close` 翻译，为根 `IconBtn` 增加随语言切换的 `aria-label`。
- 保持原图标、默认及自定义定位 class、点击阻止冒泡，以及 `update:modelValue(false)` / `click` 事件合同不变。
- 增加中英文 accessible name、图标、事件和自定义 class 回归测试，并让调用方测试明确选择结果页中的可见关闭按钮。

## 影响与风险

所有复用 `DialogCloseBtn` 的弹层都会获得本地化可访问名称。该改动不改变视觉样式、按钮尺寸、布局、交互事件或 locale 数据，不涉及配置与迁移。

## 验证

- 聚焦测试：2 个测试文件、12 项测试通过
- 全量测试：155 个测试文件、1443 项测试通过
- `yarn typecheck`
- `yarn lint`
- `yarn lint:suppressions:prune`
- `yarn format:check`
- `yarn build`
- `git diff --check`

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at ba758502ec439c2123b1321eb41e64c7d2192e99

- 为弹窗关闭按钮添加本地化无障碍名称
- 复用 `common.close`，支持中英文动态切换
- 保持定位样式与点击事件合同不变
- 新增组件回归测试并明确结果页关闭按钮
<!-- pr-agent-summary:end -->
