### PR TITLE
fix(auth): reset account state on logout

### DIFF
--- a/src/router/__tests__/auth-guard.spec.ts
+++ b/src/router/__tests__/auth-guard.spec.ts
@@ -1,0 +1,150 @@
+import '@/router'
+import { useAuthStore } from '@/stores/auth'
+import { useUserStore } from '@/stores/user'
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+interface RouteLike {
+  fullPath: string
+  meta: Record<string, unknown>
+  name?: string
+  params?: Record<string, unknown>
+  path: string
+}
+
+type NavigationGuard = (to: RouteLike, from: RouteLike, next: ReturnType<typeof vi.fn>) => Promise<void>
+type AfterEachHook = () => void
+type Redirect = () => string
+
+const routerMocks = vi.hoisted(() => ({
+  afterEach: undefined as AfterEachHook | undefined,
+  guard: undefined as NavigationGuard | undefined,
+  next: vi.fn(),
+  routes: [] as Array<{ path: string; redirect?: Redirect }>,
+  setRequestNavigatingState: vi.fn(),
+}))
+
+vi.mock('vue-router', () => ({
+  createRouter: (options: { routes: Array<{ path: string; redirect?: Redirect }> }) => {
+    routerMocks.routes = options.routes
+    return {
+      afterEach: (hook: AfterEachHook) => {
+        routerMocks.afterEach = hook
+      },
+      beforeEach: (guard: NavigationGuard) => {
+        routerMocks.guard = guard
+      },
+    }
+  },
+  createWebHashHistory: vi.fn(),
+}))
+
+vi.mock('@/api/nprogress', () => ({
+  configureNProgress: vi.fn(),
+}))
+
+vi.mock('@/utils/requestOptimizer', () => ({
+  abortAllRequests: vi.fn(),
+  initializeRequestOptimizer: vi.fn(),
+  setNavigatingState: routerMocks.setRequestNavigatingState,
+}))
+
+function route(overrides: Partial<RouteLike> = {}): RouteLike {
+  return {
+    fullPath: '/apps',
+    meta: {},
+    path: '/apps',
+    ...overrides,
+  }
+}
+
+async function runGuard(to: RouteLike) {
+  await routerMocks.guard?.(to, route({ fullPath: '/', path: '/' }), routerMocks.next)
+}
+
+describe('authentication route guard', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    routerMocks.next.mockReset()
+    routerMocks.setRequestNavigatingState.mockReset()
+  })
+
+  it('routes the root according to the current session role', () => {
+    const rootRedirect = routerMocks.routes.find(item => item.path === '/' && item.redirect)?.redirect
+    expect(rootRedirect).toBeTypeOf('function')
+
+    expect(rootRedirect?.()).toBe('/login')
+
+    useAuthStore().setToken('token')
+    expect(rootRedirect?.()).toBe('/apps')
+
+    useUserStore().setSuperUser(true)
+    expect(rootRedirect?.()).toBe('/dashboard')
+  })
+
+  it('records an unauthenticated protected target before redirecting to login', async () => {
+    await runGuard(
+      route({
+        fullPath: '/subscribe/tv?tab=active',
+        meta: { requiresAuth: true },
+        path: '/subscribe/tv',
+      }),
+    )
+
+    expect(useAuthStore().originalPath).toBe('/subscribe/tv?tab=active')
+    expect(routerMocks.setRequestNavigatingState.mock.calls).toEqual([[true], [false]])
+    expect(routerMocks.next).toHaveBeenCalledOnce()
+    expect(routerMocks.next).toHaveBeenCalledWith('/login')
+  })
+
+  it('does not replace the saved business target while entering the login page', async () => {
+    useAuthStore().setOriginalPath('/resource?keyword=test')
+
+    await runGuard(route({ fullPath: '/login?lab=motion', path: '/login' }))
+
+    expect(useAuthStore().originalPath).toBe('/resource?keyword=test')
+    expect(routerMocks.next).toHaveBeenCalledWith()
+  })
+
+  it('allows ordinary protected routes and enforces declared permissions', async () => {
+    const authStore = useAuthStore()
+    const userStore = useUserStore()
+    authStore.setToken('token')
+
+    await runGuard(route({ meta: { requiresAuth: true } }))
+    expect(routerMocks.next).toHaveBeenLastCalledWith()
+
+    routerMocks.next.mockClear()
+    userStore.setPermissions({ discovery: true, features: { 'discovery.recommend': false } })
+    await runGuard(
+      route({
+        fullPath: '/recommend',
+        meta: { feature: 'discovery.recommend', permission: 'discovery', requiresAuth: true },
+        path: '/recommend',
+      }),
+    )
+    expect(routerMocks.next).toHaveBeenLastCalledWith('/apps')
+    expect(routerMocks.setRequestNavigatingState).toHaveBeenLastCalledWith(false)
+
+    routerMocks.next.mockClear()
+    userStore.setSuperUser(true)
+    await runGuard(
+      route({
+        fullPath: '/recommend',
+        meta: { feature: 'discovery.recommend', permission: 'discovery', requiresAuth: true },
+        path: '/recommend',
+      }),
+    )
+    expect(routerMocks.next).toHaveBeenLastCalledWith()
+  })
+
+  it('clears the navigation state after a completed route', () => {
+    vi.useFakeTimers()
+
+    routerMocks.afterEach?.()
+    expect(routerMocks.setRequestNavigatingState).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(100)
+    expect(routerMocks.setRequestNavigatingState).toHaveBeenCalledWith(false)
+  })
+})

--- a/src/stores/__tests__/auth.spec.ts
+++ b/src/stores/__tests__/auth.spec.ts
@@ -1,5 +1,6 @@
 import { useAuthStore } from '@/stores/auth'
 import { usePluginSidebarNavStore } from '@/stores/pluginSidebarNav'
+import { useUserStore } from '@/stores/user'
 import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it } from 'vitest'
 
@@ -33,13 +34,23 @@ describe('auth store', () => {
     expect(authStore.getToken).toBeNull()
   })
 
-  it('logs out and clears plugin navigation state', () => {
+  it('logs out and clears all account-scoped state', () => {
     const authStore = useAuthStore()
     const pluginNavStore = usePluginSidebarNavStore()
+    const userStore = useUserStore()
     const pendingRequest = Promise.resolve()
 
     authStore.login({ token: 'test-token', remember: true })
     authStore.setOriginalPath('/plugins')
+    userStore.loginUser({
+      avatar: '/avatar.png',
+      level: 3,
+      permissions: { admin: true, discovery: true },
+      superUser: true,
+      userID: 42,
+      userName: 'previous-user',
+      wizard: true,
+    })
     pluginNavStore.$patch({
       inflight: pendingRequest,
       items: [
@@ -63,5 +74,14 @@ describe('auth store', () => {
     expect(pluginNavStore.items).toEqual([])
     expect(pluginNavStore.loaded).toBe(false)
     expect(pluginNavStore.inflight).toBeNull()
+    expect(userStore.$state).toEqual({
+      avatar: '',
+      level: 1,
+      permissions: expect.objectContaining({ admin: false }),
+      superUser: false,
+      userID: -1,
+      userName: '',
+      wizard: false,
+    })
   })
 })

--- a/src/stores/__tests__/user.spec.ts
+++ b/src/stores/__tests__/user.spec.ts
@@ -1,0 +1,89 @@
+import { useUserStore } from '@/stores/user'
+import { DEFAULT_PERMISSIONS } from '@/utils/permission'
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+describe('user store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('starts with an anonymous user and matching getters', () => {
+    const store = useUserStore()
+
+    expect(store.$state).toEqual({
+      avatar: '',
+      level: 1,
+      permissions: DEFAULT_PERMISSIONS,
+      superUser: false,
+      userID: -1,
+      userName: '',
+      wizard: false,
+    })
+    expect(store.getSuperUser).toBe(false)
+    expect(store.getUserID).toBe(-1)
+    expect(store.getUserName).toBe('')
+    expect(store.getAvatar).toBe('')
+    expect(store.getLevel).toBe(1)
+    expect(store.getPermissions).toEqual(DEFAULT_PERMISSIONS)
+    expect(store.getWizard).toBe(false)
+  })
+
+  it('stores a login response and fills omitted permission categories', () => {
+    const store = useUserStore()
+
+    store.loginUser({
+      avatar: '/avatar.png',
+      level: 2,
+      permissions: {
+        discovery: false,
+        features: { 'discovery.recommend': false },
+      },
+      superUser: false,
+      userID: 7,
+      userName: 'viewer',
+      wizard: true,
+    })
+
+    expect(store.$state).toEqual({
+      avatar: '/avatar.png',
+      level: 2,
+      permissions: {
+        ...DEFAULT_PERMISSIONS,
+        discovery: false,
+        features: { 'discovery.recommend': false },
+      },
+      superUser: false,
+      userID: 7,
+      userName: 'viewer',
+      wizard: true,
+    })
+  })
+
+  it('creates isolated default permissions for each store instance', () => {
+    const firstStore = useUserStore()
+
+    setActivePinia(createPinia())
+    expect(useUserStore().permissions.features).not.toBe(firstStore.permissions.features)
+  })
+
+  it('resets every account field without sharing permission mutations', () => {
+    const firstStore = useUserStore()
+    firstStore.setPermissions({ admin: true })
+    firstStore.permissions.features!['discovery.recommend'] = false
+    firstStore.reset()
+
+    expect(firstStore.$state).toEqual({
+      avatar: '',
+      level: 1,
+      permissions: DEFAULT_PERMISSIONS,
+      superUser: false,
+      userID: -1,
+      userName: '',
+      wizard: false,
+    })
+
+    setActivePinia(createPinia())
+    expect(useUserStore().permissions.features).toEqual({})
+  })
+})

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia'
 import type { authState } from '@/stores/types'
 import { usePluginSidebarNavStore } from '@/stores/pluginSidebarNav'
+import { useUserStore } from '@/stores/user'
 import { clearCachedMediaSubscribeStatuses } from '@/utils/mediaStatusCache'
 
 export const useAuthStore = defineStore('auth', {
@@ -33,6 +34,8 @@ export const useAuthStore = defineStore('auth', {
     logout() {
       this.clearToken()
       this.setOriginalPath(null)
+      // 身份和权限属于登录会话；退出后不得被同一浏览器中的下一个账号继承。
+      useUserStore().reset()
       clearCachedMediaSubscribeStatuses()
       usePluginSidebarNavStore().reset()
     },

--- a/src/stores/user.ts
+++ b/src/stores/user.ts
@@ -9,7 +9,10 @@ export const useUserStore = defineStore('user', {
     userName: '',
     avatar: '',
     level: 1,
-    permissions: DEFAULT_PERMISSIONS,
+    permissions: {
+      ...DEFAULT_PERMISSIONS,
+      features: { ...DEFAULT_PERMISSIONS.features },
+    },
     wizard: false,
   }),
 
@@ -33,7 +36,11 @@ export const useUserStore = defineStore('user', {
       this.level = level
     },
     setPermissions(permissions: object) {
-      this.permissions = { ...DEFAULT_PERMISSIONS, ...permissions }
+      const mergedPermissions = { ...DEFAULT_PERMISSIONS, ...permissions }
+      this.permissions = {
+        ...mergedPermissions,
+        features: { ...mergedPermissions.features },
+      }
     },
     setWizard(wizard: boolean) {
       this.wizard = wizard

--- a/src/views/subscribe/__tests__/FullCalendarView.spec.ts
+++ b/src/views/subscribe/__tests__/FullCalendarView.spec.ts
@@ -387,6 +387,8 @@ describe('FullCalendarView', () => {
   })
 
   it('resets a stale mobile title filter after keep-alive refresh replaces the data', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] })
+    vi.setSystemTime(new Date('2026-08-10T12:00:00+08:00'))
     setViewport(480)
     const first = movieSubscribe(3601, '第一轮电影')
     const second = movieSubscribe(3602, '第二轮电影')

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -312,6 +312,7 @@ export default defineConfig(({ command, mode, isPreview }) => ({
         'src/utils/federationLoader.ts',
         'src/utils/federationRuntime.ts',
         'src/stores/auth.ts',
+        'src/stores/user.ts',
         'src/stores/pluginSidebarNav.ts',
         'src/pages/appcenter.vue',
         'src/pages/recommend.vue',
@@ -621,10 +622,16 @@ export default defineConfig(({ command, mode, isPreview }) => ({
           statements: 80,
         },
         'src/stores/auth.ts': {
-          branches: 75,
-          functions: 80,
-          lines: 80,
-          statements: 80,
+          branches: 85,
+          functions: 90,
+          lines: 90,
+          statements: 90,
+        },
+        'src/stores/user.ts': {
+          branches: 85,
+          functions: 90,
+          lines: 90,
+          statements: 90,
         },
         'src/stores/pluginSidebarNav.ts': {
           branches: 85,


### PR DESCRIPTION
## 问题与背景

认证状态和当前用户状态分别由 `auth`、`user` Store 持久化。现有退出流程会清除 Token、订阅状态缓存和插件导航，但不会统一清理当前用户身份与权限，导致同一浏览器后续登录其他账号时可能短暂继承前一个账号的 `superUser`、用户 ID 和权限状态。

同时，用户 Store 的默认权限与 `features` 嵌套对象存在跨 Store 实例共享引用的可能。一个实例对功能权限的修改可能污染后续实例的默认值。

## 原因分析

- `authStore.logout()` 没有调用 `userStore.reset()`，会话级状态的清理边界不完整。
- `state()` 和 `setPermissions()` 只对权限对象做浅复制，嵌套的 `features` 仍可能复用 `DEFAULT_PERMISSIONS.features`。
- 路由守卫的现有实现已经具备根路径分流、登录前目标保存和分类/功能权限判定，但此前缺少集中回归测试保护。

## 解决方案

- 在统一 logout action 中重置用户 Store，确保 Token、身份和权限在同一会话边界内一起清理。
- 在用户 Store 初始化和权限写入时复制 `features`，隔离不同 Store 实例的可变嵌套状态，同时保持现有权限默认补齐语义。
- 增加 auth/user Store 与生产路由守卫测试，覆盖根路径分流、完整原目标、保护路由、分类/功能权限拒绝、超级管理员放行和导航状态收口；路由生产实现没有改动。
- 将 `user.ts` 纳入显式 coverage include，并为 auth/user Store 设置文件级覆盖率门槛。
- 为一个依赖当前日期的既有日历用例固定测试时钟，避免 fixture 随日期过期；日历生产逻辑没有改动。

## 影响与风险

- 影响范围仅限登录会话退出、用户权限对象初始化/写入和相关测试配置。
- 不修改后端接口、HTTP 语义、权限判定规则、路由兼容语义或持久化字段结构，无需数据迁移。
- logout 中的用户状态重置以及小型权限对象复制只发生在 Store 创建、权限写入和退出时；没有新增请求、watcher、timer、轮询或渲染热路径，性能影响可忽略。
- 真实浏览器回归使用合成会话，并阻断账号相关写请求，没有修改真实用户、OTP 或 Passkey 状态。

## 验证

- `yarn format:check`
- `yarn lint:suppressions:prune`
- `yarn lint`
- `yarn typecheck`
- `yarn test:run`：169 个测试文件、1604 个测试全部通过
- `yarn test:coverage`：Statements 95.78%、Branches 85.47%、Functions 92.51%、Lines 95.78%；`auth.ts` 与 `user.ts` 均为 100%
- `yarn build`
- `git diff --check`
- 独立 Final Review：通过
- Chrome：未登录深链、普通用户/超级管理员根路径分流、权限拒绝和 UI 退出后的完整状态清理均通过；干净页面无控制台错误或警告

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 06075c4146f72b44288b3c989c1284c7b1b2a157

- 登出时重置用户身份与权限状态
- 隔离嵌套功能权限对象引用
- 覆盖认证路由守卫和 Store 行为
- 提升 Store 覆盖率并稳定日期测试
<!-- pr-agent-summary:end -->
