### PR TITLE
fix(history): 桌面端媒体整理表格显示海报缩略图

### DIFF
--- a/src/views/reorganize/TransferHistoryView.vue
+++ b/src/views/reorganize/TransferHistoryView.vue
@@ -1492,7 +1492,22 @@ onUnmounted(() => {
       </template>
       <template #item.title="{ item }">
         <div class="d-flex align-center">
-          <VAvatar>
+          <VImg
+            v-if="getHistoryPosterUrl(item)"
+            :src="getHistoryPosterUrl(item)"
+            :alt="item.title"
+            cover
+            width="44"
+            height="66"
+            class="rounded-sm flex-shrink-0"
+          >
+            <template #error>
+              <VAvatar>
+                <VIcon :icon="getIcon(item.type || '')" />
+              </VAvatar>
+            </template>
+          </VImg>
+          <VAvatar v-else>
             <VIcon :icon="getIcon(item.type || '')" />
           </VAvatar>
           <div class="d-flex flex-column ms-1">
@@ -1576,7 +1591,22 @@ onUnmounted(() => {
     >
       <template #item.title="{ item }">
         <div class="d-flex align-center">
-          <VAvatar>
+          <VImg
+            v-if="getHistoryPosterUrl(item)"
+            :src="getHistoryPosterUrl(item)"
+            :alt="item.title"
+            cover
+            width="44"
+            height="66"
+            class="rounded-sm flex-shrink-0"
+          >
+            <template #error>
+              <VAvatar>
+                <VIcon :icon="getIcon(item.type || '')" />
+              </VAvatar>
+            </template>
+          </VImg>
+          <VAvatar v-else>
             <VIcon :icon="getIcon(item.type || '')" />
           </VAvatar>
           <div class="d-flex flex-column ms-1">


### PR DESCRIPTION
## 问题

桌面端「媒体整理」历史记录表格（`TransferHistoryView.vue`）的标题列只渲染按类型区分的通用图标（`getIcon()`，mdi-movie / mdi-television-classic 等），即使历史记录带有有效的 `image` 数据也从不显示真实海报。

移动端卡片视图已经通过 `getHistoryPosterUrl(item)`（内部走 `getDisplayImageUrl`，开启全局图片缓存时经 `/api/v1/system/cache/image` 代理）正确显示海报，但这套逻辑没有回填到桌面端的两套 `VDataTableVirtual`（列表模式和分组模式）。结果是同一条记录在仪表盘「最近入库」和移动端都有海报，在桌面表格里只有占位图标。

## 修复

两处桌面 `#item.title` 分支复用移动端已有的 `getHistoryPosterUrl` helper：

- 有海报 URL 时渲染 44×66 的 `VImg` 缩略图（`cover`、`rounded-sm flex-shrink-0`）；
- `VImg` 加载失败时通过 `#error` slot 回退到原有的 `VAvatar` + `VIcon`；
- 无海报 URL 时（`v-else`）保持原有图标渲染，行为与之前完全一致。

不引入新依赖、不改动任何逻辑代码，仅模板层复用现有 helper；两处修改结构一致。

## 验证

- `eslint`（单文件与全仓库 `--max-warnings=0`）、`prettier --check`、`vue-tsc --noEmit`、`vite build` 全部通过；
- 等效补丁已在 v3.0.0 生产实例（Emby + 全局图片缓存开启）上实际运行验证：桌面表格海报正常显示，无图/加载失败记录正确回退类型图标，移动端与分组模式行为不受影响。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 442df59db2a1a9a8aae9163c0cc8ba54bdcd8b79

- 桌面历史表格展示真实海报缩略图
- 复用 `getHistoryPosterUrl` 支持缓存地址
- 图片缺失或加载失败回退类型图标
- 覆盖分组与列表两种表格模式
<!-- pr-agent-summary:end -->
