### PR TITLE
feat(setting): 实验室新增目录监控与本地文件操作隔离相关配置

### DIFF
--- a/src/locales/en-US.ts
+++ b/src/locales/en-US.ts
@@ -2246,6 +2246,9 @@ export default {
       tokenizedSearch: 'Tokenized Search',
       tokenizedSearchHint:
         'Improve organization history search precision, but may increase performance overhead and unexpected results',
+      monitorNetworkFastMode: 'Fast Monitoring for Network Storage',
+      monitorNetworkFastModeHint:
+        'Allow kernel-notification (fast) monitoring on network/FUSE mounts. Enable only if the mount reliably delivers file change notifications, otherwise new files will not be detected. Restart required.',
       tmdbLanguage: {
         zhCN: 'Simplified Chinese',
         zhTW: 'Traditional Chinese',

--- a/src/locales/en-US.ts
+++ b/src/locales/en-US.ts
@@ -2252,6 +2252,15 @@ export default {
       transferMaxFailedRetries: 'Transfer Retries on Failure',
       transferMaxFailedRetriesHint:
         'Maximum automatic retries after a failed transfer, so a transient network or recognition glitch cannot permanently skip a file. Once exhausted, transfer it manually or delete the transfer history. Range 1-10; the counter resets on a successful transfer or when the record is deleted. Takes effect immediately after saving.',
+      fsProxyEnabled: 'Isolate Local File Operations',
+      fsProxyEnabledHint:
+        'Run local file reads, copies, moves and deletes in a separate subprocess. When a FUSE mount such as CloudDrive2 stops responding, these calls hang forever and cannot be interrupted, which in turn stalls the transfer queue and directory monitoring. Isolated, they can be force-reclaimed after a timeout and surface as ordinary errors that the existing retry logic handles. Disable to fall back to direct calls, matching the previous behaviour.',
+      fsProxyTimeout: 'File Operation Timeout (seconds)',
+      fsProxyTimeoutHint:
+        'Maximum wait for fast operations such as reading attributes, listing directories, deleting and renaming. On timeout the mount is treated as unresponsive and the subprocess is reclaimed. Only applies when "Isolate Local File Operations" is enabled. Takes effect immediately after saving.',
+      fsProxyStallTimeout: 'File Copy Stall Timeout (seconds)',
+      fsProxyStallTimeoutHint:
+        'How long a copy may make no progress at all. The check is based on whether progress advances rather than total elapsed time, so copying a large file for hours is never misjudged — only a completely stalled transfer is aborted. Only applies when "Isolate Local File Operations" is enabled. Takes effect immediately after saving.',
       tmdbLanguage: {
         zhCN: 'Simplified Chinese',
         zhTW: 'Traditional Chinese',

--- a/src/locales/en-US.ts
+++ b/src/locales/en-US.ts
@@ -2249,6 +2249,9 @@ export default {
       monitorNetworkFastMode: 'Fast Monitoring for Network Storage',
       monitorNetworkFastModeHint:
         'Allow kernel-notification (fast) monitoring on network/FUSE mounts. Enable only if the mount reliably delivers file change notifications, otherwise new files will not be detected. Takes effect immediately after saving (monitors are rebuilt automatically).',
+      transferMaxFailedRetries: 'Transfer Retries on Failure',
+      transferMaxFailedRetriesHint:
+        'Maximum automatic retries after a failed transfer, so a transient network or recognition glitch cannot permanently skip a file. Once exhausted, transfer it manually or delete the transfer history. Range 1-10; the counter resets on a successful transfer or when the record is deleted. Takes effect immediately after saving.',
       tmdbLanguage: {
         zhCN: 'Simplified Chinese',
         zhTW: 'Traditional Chinese',

--- a/src/locales/en-US.ts
+++ b/src/locales/en-US.ts
@@ -2248,7 +2248,7 @@ export default {
         'Improve organization history search precision, but may increase performance overhead and unexpected results',
       monitorNetworkFastMode: 'Fast Monitoring for Network Storage',
       monitorNetworkFastModeHint:
-        'Allow kernel-notification (fast) monitoring on network/FUSE mounts. Enable only if the mount reliably delivers file change notifications, otherwise new files will not be detected. Restart required.',
+        'Allow kernel-notification (fast) monitoring on network/FUSE mounts. Enable only if the mount reliably delivers file change notifications, otherwise new files will not be detected. Takes effect immediately after saving (monitors are rebuilt automatically).',
       tmdbLanguage: {
         zhCN: 'Simplified Chinese',
         zhTW: 'Traditional Chinese',

--- a/src/locales/zh-CN.ts
+++ b/src/locales/zh-CN.ts
@@ -2212,7 +2212,7 @@ export default {
       tokenizedSearchHint: '提升整理历史记录搜索精度，但可能增加性能开销和意外结果',
       monitorNetworkFastMode: '网络存储快速监控',
       monitorNetworkFastModeHint:
-        '允许网络/FUSE 挂载目录使用内核通知的快速监控模式，仅当确认挂载能正常下发文件变更通知时开启，否则新文件将无法被监控发现，修改后重启生效',
+        '允许网络/FUSE 挂载目录使用内核通知的快速监控模式，仅当确认挂载能正常下发文件变更通知时开启，否则新文件将无法被监控发现，保存后将自动重建监控并即时生效',
       tmdbLanguage: {
         zhCN: '简体中文',
         zhTW: '繁体中文',

--- a/src/locales/zh-CN.ts
+++ b/src/locales/zh-CN.ts
@@ -2210,6 +2210,9 @@ export default {
       transferThreadsHint: '多线程整理文件可以提高速度，但可能增加系统资源占用',
       tokenizedSearch: '分词搜索',
       tokenizedSearchHint: '提升整理历史记录搜索精度，但可能增加性能开销和意外结果',
+      monitorNetworkFastMode: '网络存储快速监控',
+      monitorNetworkFastModeHint:
+        '允许网络/FUSE 挂载目录使用内核通知的快速监控模式，仅当确认挂载能正常下发文件变更通知时开启，否则新文件将无法被监控发现，修改后重启生效',
       tmdbLanguage: {
         zhCN: '简体中文',
         zhTW: '繁体中文',

--- a/src/locales/zh-CN.ts
+++ b/src/locales/zh-CN.ts
@@ -2213,6 +2213,9 @@ export default {
       monitorNetworkFastMode: '网络存储快速监控',
       monitorNetworkFastModeHint:
         '允许网络/FUSE 挂载目录使用内核通知的快速监控模式，仅当确认挂载能正常下发文件变更通知时开启，否则新文件将无法被监控发现，保存后将自动重建监控并即时生效',
+      transferMaxFailedRetries: '整理失败重试次数',
+      transferMaxFailedRetriesHint:
+        '自动整理失败后允许重试的最大次数，避免一次网络或识别抖动让文件永久漏整理；次数用尽后需手动整理或删除整理记录。取值 1-10，整理成功或删除记录时计数清零，保存后即时生效',
       tmdbLanguage: {
         zhCN: '简体中文',
         zhTW: '繁体中文',

--- a/src/locales/zh-CN.ts
+++ b/src/locales/zh-CN.ts
@@ -2216,6 +2216,15 @@ export default {
       transferMaxFailedRetries: '整理失败重试次数',
       transferMaxFailedRetriesHint:
         '自动整理失败后允许重试的最大次数，避免一次网络或识别抖动让文件永久漏整理；次数用尽后需手动整理或删除整理记录。取值 1-10，整理成功或删除记录时计数清零，保存后即时生效',
+      fsProxyEnabled: '本地文件操作隔离',
+      fsProxyEnabledHint:
+        '在独立子进程中执行本地文件的读取、复制、移动与删除。CloudDrive2 等 FUSE 挂载失去响应时，这类操作会永久卡住且无法中断，进而拖死整理队列与目录监控；隔离后可在超时后强制回收并转为普通错误，由既有的重试机制接管。关闭后退回直接调用，行为与旧版一致',
+      fsProxyTimeout: '文件操作超时（秒）',
+      fsProxyTimeoutHint:
+        '读取属性、列目录、删除、重命名等快速操作的等待上限，超时即判定挂载无响应并回收子进程。仅在开启「本地文件操作隔离」时生效，保存后即时生效',
+      fsProxyStallTimeout: '文件复制停滞超时（秒）',
+      fsProxyStallTimeoutHint:
+        '复制文件时允许「完全没有进度」的最长时间。判断依据是进度是否推进而不是总耗时，因此复制数小时的大文件不会被误判，只有传输彻底卡死才会中断。仅在开启「本地文件操作隔离」时生效，保存后即时生效',
       tmdbLanguage: {
         zhCN: '简体中文',
         zhTW: '繁体中文',

--- a/src/locales/zh-TW.ts
+++ b/src/locales/zh-TW.ts
@@ -2211,7 +2211,7 @@ export default {
       tokenizedSearchHint: '提升整理歷史記錄搜索精度，但可能增加性能開銷和意外結果',
       monitorNetworkFastMode: '網路儲存快速監控',
       monitorNetworkFastModeHint:
-        '允許網路/FUSE 掛載目錄使用內核通知的快速監控模式，僅當確認掛載能正常下發檔案變更通知時開啟，否則新檔案將無法被監控發現，修改後重啟生效',
+        '允許網路/FUSE 掛載目錄使用內核通知的快速監控模式，僅當確認掛載能正常下發檔案變更通知時開啟，否則新檔案將無法被監控發現，保存後將自動重建監控並即時生效',
       tmdbLanguage: {
         zhCN: '簡體中文',
         zhTW: '繁體中文',

--- a/src/locales/zh-TW.ts
+++ b/src/locales/zh-TW.ts
@@ -2215,6 +2215,15 @@ export default {
       transferMaxFailedRetries: '整理失敗重試次數',
       transferMaxFailedRetriesHint:
         '自動整理失敗後允許重試的最大次數，避免一次網路或辨識抖動讓檔案永久漏整理；次數用盡後需手動整理或刪除整理記錄。取值 1-10，整理成功或刪除記錄時計數歸零，保存後即時生效',
+      fsProxyEnabled: '本機檔案操作隔離',
+      fsProxyEnabledHint:
+        '在獨立子行程中執行本機檔案的讀取、複製、移動與刪除。CloudDrive2 等 FUSE 掛載失去回應時，這類操作會永久卡住且無法中斷，進而拖死整理佇列與目錄監控；隔離後可在逾時後強制回收並轉為一般錯誤，由既有的重試機制接手。關閉後退回直接呼叫，行為與舊版一致',
+      fsProxyTimeout: '檔案操作逾時（秒）',
+      fsProxyTimeoutHint:
+        '讀取屬性、列出目錄、刪除、重新命名等快速操作的等待上限，逾時即判定掛載無回應並回收子行程。僅在開啟「本機檔案操作隔離」時生效，保存後即時生效',
+      fsProxyStallTimeout: '檔案複製停滯逾時（秒）',
+      fsProxyStallTimeoutHint:
+        '複製檔案時允許「完全沒有進度」的最長時間。判斷依據是進度是否推進而不是總耗時，因此複製數小時的大檔案不會被誤判，只有傳輸徹底卡死才會中斷。僅在開啟「本機檔案操作隔離」時生效，保存後即時生效',
       tmdbLanguage: {
         zhCN: '簡體中文',
         zhTW: '繁體中文',

--- a/src/locales/zh-TW.ts
+++ b/src/locales/zh-TW.ts
@@ -2212,6 +2212,9 @@ export default {
       monitorNetworkFastMode: '網路儲存快速監控',
       monitorNetworkFastModeHint:
         '允許網路/FUSE 掛載目錄使用內核通知的快速監控模式，僅當確認掛載能正常下發檔案變更通知時開啟，否則新檔案將無法被監控發現，保存後將自動重建監控並即時生效',
+      transferMaxFailedRetries: '整理失敗重試次數',
+      transferMaxFailedRetriesHint:
+        '自動整理失敗後允許重試的最大次數，避免一次網路或辨識抖動讓檔案永久漏整理；次數用盡後需手動整理或刪除整理記錄。取值 1-10，整理成功或刪除記錄時計數歸零，保存後即時生效',
       tmdbLanguage: {
         zhCN: '簡體中文',
         zhTW: '繁體中文',

--- a/src/locales/zh-TW.ts
+++ b/src/locales/zh-TW.ts
@@ -2209,6 +2209,9 @@ export default {
       transferThreadsHint: '多線程整理文件可以提高速度，但可能增加系統資源佔用',
       tokenizedSearch: '分詞搜索',
       tokenizedSearchHint: '提升整理歷史記錄搜索精度，但可能增加性能開銷和意外結果',
+      monitorNetworkFastMode: '網路儲存快速監控',
+      monitorNetworkFastModeHint:
+        '允許網路/FUSE 掛載目錄使用內核通知的快速監控模式，僅當確認掛載能正常下發檔案變更通知時開啟，否則新檔案將無法被監控發現，修改後重啟生效',
       tmdbLanguage: {
         zhCN: '簡體中文',
         zhTW: '繁體中文',

--- a/src/views/setting/AccountSettingSystem.vue
+++ b/src/views/setting/AccountSettingSystem.vue
@@ -135,6 +135,7 @@ const SystemSettings = ref<any>({
     ENCODING_DETECTION_PERFORMANCE_MODE: true,
     TRANSFER_THREADS: 1,
     MONITOR_NETWORK_FAST_MODE: false,
+    TRANSFER_MAX_FAILED_RETRIES: 3,
   },
 })
 
@@ -2555,6 +2556,18 @@ watch(currentLlmSnapshotKey, (snapshotKey, previousSnapshotKey) => {
                     type="number"
                     min="1"
                     prepend-inner-icon="mdi-swap-horizontal"
+                  />
+                </VCol>
+                <VCol cols="12" md="6">
+                  <VTextField
+                    v-model.number="SystemSettings.Advanced.TRANSFER_MAX_FAILED_RETRIES"
+                    :label="t('setting.system.transferMaxFailedRetries')"
+                    :hint="t('setting.system.transferMaxFailedRetriesHint')"
+                    persistent-hint
+                    type="number"
+                    min="1"
+                    max="10"
+                    prepend-inner-icon="mdi-refresh-alert"
                   />
                 </VCol>
               </VRow>

--- a/src/views/setting/AccountSettingSystem.vue
+++ b/src/views/setting/AccountSettingSystem.vue
@@ -136,6 +136,9 @@ const SystemSettings = ref<any>({
     TRANSFER_THREADS: 1,
     MONITOR_NETWORK_FAST_MODE: false,
     TRANSFER_MAX_FAILED_RETRIES: 3,
+    FS_PROXY_ENABLED: true,
+    FS_PROXY_TIMEOUT: 30,
+    FS_PROXY_STALL_TIMEOUT: 120,
   },
 })
 
@@ -2570,6 +2573,28 @@ watch(currentLlmSnapshotKey, (snapshotKey, previousSnapshotKey) => {
                     prepend-inner-icon="mdi-refresh-alert"
                   />
                 </VCol>
+                <VCol v-if="SystemSettings.Advanced.FS_PROXY_ENABLED" cols="12" md="6">
+                  <VTextField
+                    v-model.number="SystemSettings.Advanced.FS_PROXY_TIMEOUT"
+                    :label="t('setting.system.fsProxyTimeout')"
+                    :hint="t('setting.system.fsProxyTimeoutHint')"
+                    persistent-hint
+                    type="number"
+                    min="5"
+                    prepend-inner-icon="mdi-timer-outline"
+                  />
+                </VCol>
+                <VCol v-if="SystemSettings.Advanced.FS_PROXY_ENABLED" cols="12" md="6">
+                  <VTextField
+                    v-model.number="SystemSettings.Advanced.FS_PROXY_STALL_TIMEOUT"
+                    :label="t('setting.system.fsProxyStallTimeout')"
+                    :hint="t('setting.system.fsProxyStallTimeoutHint')"
+                    persistent-hint
+                    type="number"
+                    min="10"
+                    prepend-inner-icon="mdi-timer-alert-outline"
+                  />
+                </VCol>
               </VRow>
               <VRow>
                 <VCol cols="12" md="6">
@@ -2577,6 +2602,14 @@ watch(currentLlmSnapshotKey, (snapshotKey, previousSnapshotKey) => {
                     v-model="SystemSettings.Advanced.PLUGIN_AUTO_RELOAD"
                     :label="t('setting.system.pluginAutoReload')"
                     :hint="t('setting.system.pluginAutoReloadHint')"
+                    persistent-hint
+                  />
+                </VCol>
+                <VCol cols="12" md="6">
+                  <VSwitch
+                    v-model="SystemSettings.Advanced.FS_PROXY_ENABLED"
+                    :label="t('setting.system.fsProxyEnabled')"
+                    :hint="t('setting.system.fsProxyEnabledHint')"
                     persistent-hint
                   />
                 </VCol>

--- a/src/views/setting/AccountSettingSystem.vue
+++ b/src/views/setting/AccountSettingSystem.vue
@@ -134,6 +134,7 @@ const SystemSettings = ref<any>({
     RUST_ACCEL: false,
     ENCODING_DETECTION_PERFORMANCE_MODE: true,
     TRANSFER_THREADS: 1,
+    MONITOR_NETWORK_FAST_MODE: false,
   },
 })
 
@@ -2580,6 +2581,14 @@ watch(currentLlmSnapshotKey, (snapshotKey, previousSnapshotKey) => {
                     :label="t('setting.system.rustAccel')"
                     :hint="rustAccelHint"
                     :disabled="!rustAccelAvailable"
+                    persistent-hint
+                  />
+                </VCol>
+                <VCol cols="12" md="6">
+                  <VSwitch
+                    v-model="SystemSettings.Advanced.MONITOR_NETWORK_FAST_MODE"
+                    :label="t('setting.system.monitorNetworkFastMode')"
+                    :hint="t('setting.system.monitorNetworkFastModeHint')"
                     persistent-hint
                   />
                 </VCol>


### PR DESCRIPTION
## 说明

配套后端 PR jxxghp/MoviePilot#6276（修复 FUSE 挂载无响应导致的监控冻死、整理链锁死与漏件），为其新增的配置项补充前端入口。

这些配置目前只能改 `.env`，加入实验室后可在界面调整、保存即时生效。

## 新增配置项（设置 → 系统 → 实验室）

| 配置项 | 类型 | 默认 | 说明 |
| --- | --- | --- | --- |
| `MONITOR_NETWORK_FAST_MODE` | 开关 | 关 | 允许网络/FUSE 挂载目录使用内核通知的快速监控模式 |
| `TRANSFER_MAX_FAILED_RETRIES` | 数字 1-10 | 3 | 自动整理失败后的最大重试次数，避免一次抖动让文件永久漏整理 |
| `FS_PROXY_ENABLED` | 开关 | 开 | 本地文件操作是否在可强杀的子进程中执行 |
| `FS_PROXY_TIMEOUT` | 数字（秒） | 30 | 读属性/列目录/删除/重命名等快操作的超时 |
| `FS_PROXY_STALL_TIMEOUT` | 数字（秒） | 120 | 文件复制允许「完全没有进度」的最长时间 |

## 交互细节

- 两个超时项以 `v-if` 绑定隔离开关：关闭隔离时它们不生效，继续显示只会误导
- 复制停滞超时的提示特意说明**判据是「进度是否推进」而非总耗时**，否则用户看到 120 秒会误以为复制大文件会被打断
- 文案面向用户而非开发者，直接点出场景与后果（如「CloudDrive2 等 FUSE 挂载失去响应时会拖死整理队列与目录监控」）

## 兼容性

- 后端 `/system/env` 是 `settings.model_dump()` 全量返回，新字段自动暴露，**无需后端接口改动**
- 若后端未包含对应配置（如仅升级前端），这些项会读到 `undefined` 并回落到组件默认值，不影响其他设置的读写

## 验证

- `npm run typecheck`：通过，零错误
- `npm run test:run`：184 个测试文件 / 1810 个测试全部通过
- 三个语言包（zh-CN / en-US / zh-TW）均已补齐对应文案

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 7d1e68bfa3b7adce0530af5d79993fcef4ea4678

- 实验室开放监控与文件隔离配置
- 支持失败整理重试次数限制
- 增加中英繁三语说明与风险提示
- 隔离关闭时隐藏相关超时项
- 配置依赖后端支持；未新增测试
<!-- pr-agent-summary:end -->
