### PR TITLE
fix(agent): 延后敏感确认控制消息入历史

### DIFF
--- a/src/components/agent/AgentAssistantPanel.vue
+++ b/src/components/agent/AgentAssistantPanel.vue
@@ -1830,11 +1830,6 @@ async function streamAgentMessage(
   const displayContent = (displayText ?? content).trim()
   if (!content && !images.length && !files.length && !audioRefs.length) return
 
-  const userMessage = echoUser
-    ? addMessage('user', displayContent || content, 'done', userAttachments, choiceSelection)
-    : null
-  const assistantMessage = addMessage('assistant', '', 'streaming')
-
   abortController = new AbortController()
   userAbortRequested = false
   streamRecoveryAbortRequested = false
@@ -1843,6 +1838,7 @@ async function streamAgentMessage(
   activeStreamStartedAt = streamStartedAt
   let shouldFollowBottomAfterStream = true
   let shouldSaveClientSnapshot = true
+  let assistantMessage: AgentChatMessage | null = null
 
   try {
     const response = await fetch(resolveApiUrl('message/agent/stream'), {
@@ -1867,13 +1863,13 @@ async function streamAgentMessage(
       signal: abortController.signal,
     })
 
+    const isSecretConfirmation = response.headers.get('X-MoviePilot-Agent-Control') === 'secret-confirmation'
+    if (!isSecretConfirmation && echoUser) {
+      addMessage('user', displayContent || content, 'done', userAttachments, choiceSelection)
+    }
+    assistantMessage = addMessage('assistant', '', 'streaming')
     if (!response.ok) {
       throw new Error(await resolveAgentResponseErrorMessage(response))
-    }
-    if (response.headers.get('X-MoviePilot-Agent-Control') === 'secret-confirmation' && userMessage) {
-      messages.value = messages.value.filter(message => message.id !== userMessage.id)
-      refreshMessageList()
-      persistState()
     }
 
     const streamResult = await readAgentStream(response, assistantMessage, streamProtectedDeliveryGeneration)
@@ -1890,7 +1886,8 @@ async function streamAgentMessage(
     pendingStreamRecovery.value = null
     clearStreamRecoveryTimer()
     if (isEmptyAssistantMessage(assistantMessage)) {
-      messages.value = messages.value.filter(message => message.id !== assistantMessage.id)
+      const emptyAssistantMessageId = assistantMessage.id
+      messages.value = messages.value.filter(message => message.id !== emptyAssistantMessageId)
       refreshMessageList()
       return
     }
@@ -1903,6 +1900,7 @@ async function streamAgentMessage(
     if (error?.name === 'AbortError' && streamRecoveryAbortRequested) return
 
     if (error?.name === 'AbortError' && userAbortRequested) {
+      if (!assistantMessage) return
       assistantMessage.status = 'done'
       markToolsDone(assistantMessage)
       refreshMessageList()
@@ -1910,6 +1908,7 @@ async function streamAgentMessage(
     }
 
     if (isRecoverableStreamDisconnect(error)) {
+      if (!assistantMessage) return
       shouldSaveClientSnapshot = false
       invalidateProtectedDeliveries()
       beginStreamRecovery(sessionId.value, streamStartedAt)
@@ -1919,6 +1918,7 @@ async function streamAgentMessage(
       return
     }
 
+    assistantMessage ||= addMessage('assistant', '', 'streaming')
     assistantMessage.status = 'error'
     replaceAssistantTextSegments(assistantMessage, error?.message || t('agentAssistant.error'))
     markToolsDone(assistantMessage)

--- a/src/components/agent/__tests__/AgentAssistantPanel.spec.ts
+++ b/src/components/agent/__tests__/AgentAssistantPanel.spec.ts
@@ -152,6 +152,15 @@ function createControllableAgentStream() {
   }
 }
 
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  const promise = new Promise<T>(resolvePromise => {
+    resolve = resolvePromise
+  })
+
+  return { promise, resolve }
+}
+
 const slotContainerStub = { template: '<div><slot /></div>' }
 const menuStub = defineComponent({
   setup(_props, { slots }) {
@@ -745,18 +754,14 @@ describe('AgentAssistantPanel stream recovery', () => {
     await flushPromises()
 
     stream.emit(legacySseFrame({ type: 'start', session_id: 'web-agent:late-protected' }))
-    stream.emit(
-      protectedSseFrame({ content: protectedMarker }),
-    )
+    stream.emit(protectedSseFrame({ content: protectedMarker }))
     await flushPromises()
     expect(wrapper.text()).toContain(protectedMarker)
 
     await wrapper.setProps({ modelValue: false })
     expect(wrapper.text()).not.toContain(protectedMarker)
 
-    stream.emit(
-      protectedSseFrame({ content: protectedMarker }),
-    )
+    stream.emit(protectedSseFrame({ content: protectedMarker }))
     await wrapper.setProps({ modelValue: true })
     await flushPromises()
     expect(wrapper.text()).not.toContain(protectedMarker)
@@ -781,9 +786,7 @@ describe('AgentAssistantPanel stream recovery', () => {
     await wrapper.find('textarea').trigger('keydown', { key: 'Enter' })
     await flushPromises()
 
-    stream.emit(
-      protectedSseFrame({ content: protectedMarker }),
-    )
+    stream.emit(protectedSseFrame({ content: protectedMarker }))
     await flushPromises()
     expect(wrapper.text()).toContain(protectedMarker)
 
@@ -817,9 +820,7 @@ describe('AgentAssistantPanel stream recovery', () => {
     await wrapper.find('textarea').trigger('keydown', { key: 'Enter' })
     await flushPromises()
 
-    stream.emit(
-      protectedSseFrame({ content: protectedMarker }),
-    )
+    stream.emit(protectedSseFrame({ content: protectedMarker }))
     await flushPromises()
     expect(wrapper.text()).toContain(protectedMarker)
 
@@ -954,7 +955,9 @@ describe('AgentAssistantPanel stream recovery', () => {
     expect(wrapper.find('.agent-assistant-message--user').exists()).toBe(false)
     const localState = JSON.parse(localStorage.getItem('moviepilot-agent-assistant-state') || '{}')
     const localHistory = JSON.parse(localStorage.getItem('moviepilot-agent-assistant-history') || '[]')
-    expect(localState.messages || []).not.toContainEqual(expect.objectContaining({ role: 'user', content: controlText }))
+    expect(localState.messages || []).not.toContainEqual(
+      expect.objectContaining({ role: 'user', content: controlText }),
+    )
     expect(localHistory).not.toContainEqual(expect.objectContaining({ role: 'user', content: controlText }))
     fetchMock.mock.calls
       .filter(([input]) => String(input).includes('/display'))
@@ -964,6 +967,95 @@ describe('AgentAssistantPanel stream recovery', () => {
           expect.objectContaining({ role: 'user', content: controlText }),
         )
       })
+
+    wrapper.unmount()
+  })
+
+  it('does not commit confirmation controls before the response header classifies the request', async () => {
+    const controlText = '确认'
+    const backendFeedback = '确认请求已处理'
+    const deferredStreamResponse = createDeferred<Response>()
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input).endsWith('/message/agent/stream') && init?.method === 'POST') {
+        return deferredStreamResponse.promise
+      }
+
+      return Promise.resolve(createAgentResponse([]))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const wrapper = mountPanel()
+    await wrapper.find('textarea').setValue(controlText)
+    await wrapper.find('textarea').trigger('keydown', { key: 'Enter' })
+    await flushPromises()
+
+    expect(wrapper.find('.agent-assistant-message--user').exists()).toBe(false)
+    expect(localStorage.getItem('moviepilot-agent-assistant-state') || '').not.toContain(controlText)
+    expect(localStorage.getItem('moviepilot-agent-assistant-history') || '').not.toContain(controlText)
+    expect(fetchMock.mock.calls.some(([input]) => String(input).includes('/display'))).toBe(false)
+
+    deferredStreamResponse.resolve(
+      createAgentStreamResponse(
+        [legacySseFrame({ type: 'delta', content: backendFeedback }), legacySseFrame({ type: 'done' })],
+        { 'X-MoviePilot-Agent-Control': 'secret-confirmation' },
+      ),
+    )
+    await flushPromises()
+
+    expect(wrapper.text()).toContain(backendFeedback)
+    expect(wrapper.find('.agent-assistant-message--user').exists()).toBe(false)
+    const localState = JSON.parse(localStorage.getItem('moviepilot-agent-assistant-state') || '{}')
+    const localHistory = JSON.parse(localStorage.getItem('moviepilot-agent-assistant-history') || '[]')
+    expect(localState.messages || []).not.toContainEqual(
+      expect.objectContaining({ role: 'user', content: controlText }),
+    )
+    expect(localHistory).not.toContainEqual(expect.objectContaining({ role: 'user', content: controlText }))
+    fetchMock.mock.calls
+      .filter(([input]) => String(input).includes('/display'))
+      .forEach(([, init]) => {
+        const displayBody = JSON.parse(String(init?.body || '{}'))
+        expect(displayBody.messages || []).not.toContainEqual(
+          expect.objectContaining({ role: 'user', content: controlText }),
+        )
+      })
+
+    wrapper.unmount()
+  })
+
+  it('commits ordinary messages in user and assistant order after response classification', async () => {
+    const userText = '检查下载任务'
+    const assistantText = '检查完成'
+    const deferredStreamResponse = createDeferred<Response>()
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input).endsWith('/message/agent/stream') && init?.method === 'POST') {
+        return deferredStreamResponse.promise
+      }
+
+      return Promise.resolve(createAgentResponse([]))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const wrapper = mountPanel()
+    await wrapper.find('textarea').setValue(userText)
+    await wrapper.find('textarea').trigger('keydown', { key: 'Enter' })
+    await flushPromises()
+
+    expect(wrapper.findAll('.agent-assistant-message')).toHaveLength(0)
+
+    deferredStreamResponse.resolve(
+      createAgentStreamResponse([
+        legacySseFrame({ type: 'delta', content: assistantText }),
+        legacySseFrame({ type: 'done' }),
+      ]),
+    )
+    await flushPromises()
+
+    const messages = wrapper.findAll('.agent-assistant-message')
+    expect(messages).toHaveLength(2)
+    expect(messages[0].classes()).toContain('agent-assistant-message--user')
+    expect(messages[0].text()).toContain(userText)
+    expect(messages[1].classes()).toContain('agent-assistant-message--assistant')
+    expect(messages[1].text()).toContain(assistantText)
 
     wrapper.unmount()
   })


### PR DESCRIPTION
已合并的 #671 依赖后端响应头识别敏感确认控制轮次，但前端会在响应头返回前先把用户输入加入普通消息。慢响应、断线或网络错误时，“确认”可能短暂进入 DOM、本地存储或展示同步路径。

本 PR 将消息提交延后到响应分类之后：

- fetch 返回并读取 `X-MoviePilot-Agent-Control` 后，只有普通请求才写入用户消息。
- 敏感确认控制文本从请求发出到响应完成都不进入 DOM、localStorage、历史索引或 `/display` 快照。
- 普通消息仍按“用户消息、助手消息”的顺序展示，错误与断线处理保持原有语义。

后端配套已由 https://github.com/jxxghp/MoviePilot/pull/6285 合并，用于收口私聊纯文本投递、策略复验和断线结果真实性。

响应分类前的可恢复断流问题由后续 PR #673 独立修复。

验证：

- Agent 面板组件测试：32 passed
- 前端全量测试断言：1859 passed；未触及的音乐页面测试在环境销毁后仍有一条既有计时器异常
- `yarn lint`
- `yarn lint:suppressions:prune`
- `yarn build`
- 真实同源 Web 验收：确认响应头返回前控制文本不进入 DOM 或 localStorage；受保护结果仅在当前面板显示，关闭后清除
- `git diff --check`

`yarn typecheck` 仍受当时未触及的 Axios 测试类型基线问题影响，错误位于 `src/api/__tests__/client.spec.ts`。

Refs #671

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 707b18cb34af7ef31c5acc786836d3949117cf9f

- 延后消息提交至响应分类后
- 敏感确认文本不进入界面或存储
- 保持普通消息用户、助手展示顺序
- 新增慢响应分类边界测试
<!-- pr-agent-summary:end -->
