### PR TITLE
fix(agent): 恢复响应分类前的断流请求

### DIFF
--- a/src/components/agent/AgentAssistantPanel.vue
+++ b/src/components/agent/AgentAssistantPanel.vue
@@ -1908,12 +1908,13 @@ async function streamAgentMessage(
     }
 
     if (isRecoverableStreamDisconnect(error)) {
-      if (!assistantMessage) return
       shouldSaveClientSnapshot = false
       invalidateProtectedDeliveries()
       beginStreamRecovery(sessionId.value, streamStartedAt)
-      assistantMessage.status = 'streaming'
-      refreshMessageList()
+      if (assistantMessage) {
+        assistantMessage.status = 'streaming'
+        refreshMessageList()
+      }
       if (document.visibilityState === 'visible') scheduleStreamRecovery(1200)
       return
     }

--- a/src/components/agent/__tests__/AgentAssistantPanel.spec.ts
+++ b/src/components/agent/__tests__/AgentAssistantPanel.spec.ts
@@ -1022,6 +1022,73 @@ describe('AgentAssistantPanel stream recovery', () => {
     wrapper.unmount()
   })
 
+  it('recovers an ordinary request when the connection fails before response classification', async () => {
+    const userText = '检查下载任务'
+    const assistantText = '下载任务检查完成'
+    let requestedSessionId = ''
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.endsWith('/message/agent/stream') && init?.method === 'POST') {
+        requestedSessionId = JSON.parse(String(init.body)).session_id
+        throw new TypeError('Failed to fetch')
+      }
+      if (requestedSessionId && url.includes(`/sessions/${encodeURIComponent(requestedSessionId)}`)) {
+        return createAgentResponse({
+          session_id: 'web-agent:preheader-recovery',
+          client_session_id: requestedSessionId,
+          updated_at: new Date(Date.now() + 1000).toISOString(),
+          is_processing: false,
+          messages: [
+            {
+              id: 'user-preheader-recovery',
+              role: 'user',
+              content: userText,
+              createdAt: Date.now(),
+              status: 'done',
+              attachments: [],
+              choices: [],
+              tools: [],
+            },
+            {
+              id: 'assistant-preheader-recovery',
+              role: 'assistant',
+              content: assistantText,
+              createdAt: Date.now() + 1000,
+              status: 'done',
+              attachments: [],
+              choices: [],
+              tools: [],
+            },
+          ],
+        })
+      }
+
+      return createAgentResponse([])
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const wrapper = mountPanel()
+    await wrapper.find('textarea').setValue(userText)
+    await wrapper.find('textarea').trigger('keydown', { key: 'Enter' })
+    await flushPromises()
+
+    expect(wrapper.find('.agent-assistant-message--user').exists()).toBe(false)
+    expect(localStorage.getItem('moviepilot-agent-assistant-state') || '').not.toContain(userText)
+    expect(JSON.parse(localStorage.getItem('moviepilot-agent-assistant-state') || '{}').streamRecovery).toMatchObject({
+      sessionId: requestedSessionId,
+      attempts: 0,
+    })
+
+    await vi.advanceTimersByTimeAsync(1200)
+    await flushPromises()
+
+    expect(wrapper.text()).toContain(userText)
+    expect(wrapper.text()).toContain(assistantText)
+    expect(JSON.parse(localStorage.getItem('moviepilot-agent-assistant-state') || '{}').streamRecovery).toBeNull()
+
+    wrapper.unmount()
+  })
+
   it('commits ordinary messages in user and assistant order after response classification', async () => {
     const userText = '检查下载任务'
     const assistantText = '检查完成'


### PR DESCRIPTION
前端 PR #672 为了避免敏感确认文本在响应分类前进入历史，将用户消息提交延后到了响应头返回之后。Review 发现：如果初始 `fetch` 在响应头返回前发生可恢复网络错误，助手消息尚未创建，现有分支会直接退出并跳过断流恢复；请求若已到达后端，普通结果可能丢失。

本 PR 收口这一竞态：

- 响应分类前发生可恢复断网时，仍建立既有 stream recovery，并从服务端会话快照恢复最终结果。
- 未分类的用户文本继续不进入 DOM、localStorage、本地历史或 `/display` 快照。
- 已经创建助手占位的断流路径保持原有状态更新；不新增重试协议或消息持久化方式。

验证：

- 前端全量测试：188 files，1860 passed
- Agent 面板组件测试：33 passed
- `yarn typecheck`
- `yarn lint`
- `yarn lint:suppressions:prune`
- `yarn format:check`
- `yarn build`
- `git diff --check`

Follow-up to #672

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at e3c485c44b8c20040f92c3a2f58e3d497f33e89c

- 恢复响应分类前的断线请求
- 未分类文本继续避免本地提交
- 断流后从会话快照恢复结果
- 新增预响应头断线恢复测试
<!-- pr-agent-summary:end -->
