### PR TITLE
test: 修复取消请求用例的类型错误

### DIFF
--- a/src/api/__tests__/client.spec.ts
+++ b/src/api/__tests__/client.spec.ts
@@ -182,8 +182,8 @@ describe('MoviePilot API client', () => {
 
   it('取消请求保持原始 CanceledError，且不提示或触发离线探测', async () => {
     const reportConnectionFailure = vi.fn()
-    const adapter: AxiosAdapter = async config => {
-      throw new CanceledError('Request cancelled', config)
+    const adapter: AxiosAdapter = async () => {
+      throw new CanceledError('Request cancelled')
     }
     const { api } = createApiClients({ adapter, hooks: { reportConnectionFailure }, notifier })
 


### PR DESCRIPTION
`v3` 中 API 客户端的取消请求测试将 `InternalAxiosRequestConfig` 作为 `CanceledError` 的第二个参数。Axios 1.9.0 的运行时实现把该位置视为配置，但其 TypeScript 声明未覆盖子类构造函数，类型系统沿用 `AxiosError` 的 `code` 参数，因此 `yarn typecheck` 报错并阻断 `typecheck-and-tests`。

本 PR 将测试夹具收窄为只构造取消错误本身。该用例验证的是取消错误原样透传、不会显示失败提示、不会触发离线探测，并不依赖错误携带请求配置。这样既保持既有测试语义，也避免通过类型断言或运行时参数错位来绕开类型检查。

仅修改 `src/api/__tests__/client.spec.ts`，不涉及生产代码、API 行为或依赖版本。

验证结果：

- `yarn vitest run src/api/__tests__/client.spec.ts`：16 个用例通过
- `yarn typecheck`：通过
- `yarn test:run`：189 个测试文件、1900 个用例通过
- `yarn lint`：通过
- `yarn format:check --base upstream/v3 --head HEAD`：通过
- `yarn build`：通过
- `git diff --check upstream/v3...HEAD`：通过

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 889ec24ac5bc78ea911e9233190074fd6e882e6d

- 修正取消请求测试夹具的构造参数
- 避免 `CanceledError` 构造函数类型不匹配
- 保持取消错误透传测试语义不变
<!-- pr-agent-summary:end -->
