### PR TITLE
feat: 记住资源搜索结果的排序选择

### DIFF
--- a/src/pages/resource.vue
+++ b/src/pages/resource.vue
@@ -283,6 +283,18 @@ const isSubtitleSearch = computed(() => resultType.value === 'subtitle')
 // 视图类型，从localStorage中读取
 const viewType = ref<TorrentViewType>(normalizeTorrentViewType(localStorage.getItem('MPTorrentsViewType')))
 
+// 排序条件与方向，从localStorage中读取，让上次的选择在下次进入结果页时继续生效
+const torrentSortFieldStorageKey = 'MPTorrentsSortField'
+const torrentSortTypeStorageKey = 'MPTorrentsSortType'
+const savedSortField = localStorage.getItem(torrentSortFieldStorageKey)
+if (savedSortField && Object.prototype.hasOwnProperty.call(torrentFilter.sortTitles, savedSortField)) {
+  torrentFilter.sortField.value = savedSortField
+}
+const savedSortType = localStorage.getItem(torrentSortTypeStorageKey)
+if (savedSortType === 'asc' || savedSortType === 'desc') {
+  torrentFilter.sortType.value = savedSortType
+}
+
 // 智能推荐相关
 // 从全局设置中获取 AI_RECOMMEND_ENABLED 状态
 const aiRecommendEnabled = computed(() => {
@@ -433,6 +445,12 @@ watch(
   },
   { deep: true },
 )
+
+// 记住排序选择
+watch([() => torrentFilter.sortField.value, () => torrentFilter.sortType.value], ([field, type]) => {
+  localStorage.setItem(torrentSortFieldStorageKey, field)
+  localStorage.setItem(torrentSortTypeStorageKey, type)
+})
 
 // 应用筛选
 function applyFilter() {


### PR DESCRIPTION
## 动机

资源搜索结果页的排序条件与方向只存在于组件状态里（`useTorrentFilter` 的 `sortField` / `sortType`），每次重新进入结果页都会回到「默认 + 降序」。习惯固定用某种排序找资源的用户（例如按大小降序挑原盘/REMUX），每搜一次就要手点一遍。

同一个页面里的「视图类型」已经通过 `localStorage['MPTorrentsViewType']` 记住了，排序却没有。

## 改动

只动 `src/pages/resource.vue`，18 行：

- 进入结果页时从 `localStorage` 恢复 `MPTorrentsSortField` / `MPTorrentsSortType`
- 排序条件或方向变化时写回

恢复时做了合法性校验：排序条件必须是 `sortTitles` 里已存在的键，方向只接受 `asc` / `desc`，非法或缺失一律回落到原有默认值。所以首次使用、清空存储、以及从旧版本升级上来的行为都和现在完全一致。

没有改 `useTorrentFilter` composable —— 持久化只发生在页面层，composable 的默认值与单测行为均不受影响。

## 验证

- `yarn vitest run src/pages/__tests__/resource.spec.ts src/composables/__tests__/useTorrentFilter.spec.ts` → 47 passed
- `yarn typecheck`（vue-tsc --noEmit）→ 通过
- `npx eslint src/pages/resource.vue --max-warnings=0` → 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 0dd13aac2eff9317bbb2c763a12da6e28d103c69

- 持久化资源搜索页排序字段与方向
- 进入页面时校验并恢复本地排序偏好
- 非法或缺失配置保持原有默认行为
- 未新增测试，需验证浏览器存储可用性
<!-- pr-agent-summary:end -->
