### PR TITLE
feat: prefer independent plugin project URLs

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -734,6 +734,8 @@ export interface Plugin {
   plugin_author?: string
   // 作者主页
   author_url?: string
+  // 项目主页
+  project_url?: string
   // 插件配置项ID前缀
   plugin_config_prefix?: string
   // 加载顺序

--- a/src/components/cards/PluginAppCard.vue
+++ b/src/components/cards/PluginAppCard.vue
@@ -90,9 +90,12 @@ const iconPath: Ref<string> = computed(() => {
 // 访问插件页面
 function visitPluginPage() {
   // 将raw.githubusercontent.com转换为项目地址
-  let repoUrl = props.plugin?.repo_url
-  if (props.plugin?.is_local || repoUrl?.startsWith('local://')) {
-    repoUrl = props.plugin?.author_url
+  let repoUrl = props.plugin?.project_url
+  if (!repoUrl) {
+    repoUrl = props.plugin?.repo_url
+    if (props.plugin?.is_local || repoUrl?.startsWith('local://')) {
+      repoUrl = props.plugin?.author_url
+    }
   }
   if (repoUrl?.includes('raw.githubusercontent.com')) {
     try {

--- a/src/components/cards/PluginCard.vue
+++ b/src/components/cards/PluginCard.vue
@@ -327,13 +327,14 @@ function hasRemoteRepoUrl(plugin?: Plugin) {
   return Boolean(plugin?.repo_url && !plugin.repo_url.startsWith('local://'))
 }
 
-/** 优先解析插件仓库地址，本地插件或缺少仓库地址时回退到作者主页。 */
+/** 优先解析项目主页，其次使用远程安装来源，最后回退到作者主页。 */
 function resolvePluginPageUrl(plugin?: Plugin) {
   if (!plugin) return ''
 
+  const projectUrl = normalizePluginRepoUrl(plugin.project_url)
   const repoUrl = hasRemoteRepoUrl(plugin) ? normalizePluginRepoUrl(plugin.repo_url) : plugin.author_url
 
-  return repoUrl || plugin.author_url || ''
+  return projectUrl || repoUrl || plugin.author_url || ''
 }
 
 /** 从插件市场中查找同 ID 插件，补齐已安装插件缺失的 repo_url。 */
@@ -399,6 +400,12 @@ async function showPluginAbout() {
 
 // 访问插件项目主页
 async function visitPluginPage() {
+  const projectUrl = normalizePluginRepoUrl(props.plugin?.project_url)
+  if (projectUrl) {
+    window.open(projectUrl, '_blank')
+    return
+  }
+
   const popup = window.open('about:blank', '_blank')
   let pluginDetail = await fetchInstalledPluginDetail()
 

--- a/src/components/cards/__tests__/PluginAppCardRating.spec.ts
+++ b/src/components/cards/__tests__/PluginAppCardRating.spec.ts
@@ -271,4 +271,22 @@ describe('PluginAppCard rating badge', () => {
     await fireEvent.click(await screen.findByText('项目主页'))
     expect(open).toHaveBeenCalledWith('https://github.com/example-author', '_blank')
   })
+
+  it('prioritizes a declared project page over the installation source', async () => {
+    const open = vi.spyOn(window, 'open').mockReturnValue(null)
+    const { container } = await renderWithProviders(PluginAppCard, {
+      props: {
+        plugin: {
+          ...plugin,
+          project_url: 'https://github.com/example/plugin',
+          repo_url: 'https://github.com/example/plugins',
+        },
+      },
+    })
+
+    await fireEvent.click(container.querySelector<HTMLButtonElement>('.v-card .v-btn')!)
+    await fireEvent.click(await screen.findByText('项目主页'))
+
+    expect(open).toHaveBeenCalledWith('https://github.com/example/plugin', '_blank')
+  })
 })

--- a/src/components/cards/__tests__/PluginCardAbout.spec.ts
+++ b/src/components/cards/__tests__/PluginCardAbout.spec.ts
@@ -133,6 +133,20 @@ describe('PluginCard about menu', () => {
     expect(popup.opener).toBeNull()
   })
 
+  it('opens a declared project page directly without loading remote metadata', async () => {
+    const projectUrl = 'https://github.com/example/plugin'
+    const open = vi.spyOn(window, 'open').mockReturnValue(null)
+    const { container } = await renderWithProviders(PluginCard, {
+      props: { plugin: { ...plugin, project_url: projectUrl } },
+    })
+
+    await fireEvent.click(container.querySelector<HTMLButtonElement>('.v-card .v-btn')!)
+    await fireEvent.click(await screen.findByText('项目主页'))
+
+    expect(open).toHaveBeenCalledWith(projectUrl, '_blank')
+    expect(mocks.apiGet).not.toHaveBeenCalled()
+  })
+
   it('prioritizes the update status over the rating status', async () => {
     await renderWithProviders(PluginCard, {
       props: {

--- a/src/components/dialog/PluginMarketDetailDialog.vue
+++ b/src/components/dialog/PluginMarketDetailDialog.vue
@@ -90,9 +90,12 @@ function pluginIconPath() {
 
 /** 访问插件项目或作者页面。 */
 function visitPluginPage() {
-  let repoUrl = props.plugin?.repo_url
-  if (props.plugin?.is_local || repoUrl?.startsWith('local://')) {
-    repoUrl = props.plugin?.author_url
+  let repoUrl = props.plugin?.project_url
+  if (!repoUrl) {
+    repoUrl = props.plugin?.repo_url
+    if (props.plugin?.is_local || repoUrl?.startsWith('local://')) {
+      repoUrl = props.plugin?.author_url
+    }
   }
   if (repoUrl?.includes('raw.githubusercontent.com')) {
     try {

--- a/src/components/dialog/__tests__/PluginMarketDetailDialog.spec.ts
+++ b/src/components/dialog/__tests__/PluginMarketDetailDialog.spec.ts
@@ -352,6 +352,19 @@ describe('PluginMarketDetailDialog', () => {
     expect(open).toHaveBeenCalledWith('https://github.com/example/plugins', '_blank')
   })
 
+  it('opens the declared project page instead of the installation source', async () => {
+    const open = vi.spyOn(window, 'open').mockReturnValue(null)
+    await renderDialog({
+      ...basePlugin,
+      project_url: 'https://github.com/example/plugin',
+      repo_url: 'https://github.com/example/plugins',
+    })
+
+    await fireEvent.click(await screen.findByText('MoviePilot'))
+
+    expect(open).toHaveBeenCalledWith('https://github.com/example/plugin', '_blank')
+  })
+
   it('reports rating business and HTTP failures with stable feedback', async () => {
     mocks.apiPost.mockResolvedValueOnce({ success: false })
     const businessFailed = await renderDialog({ ...basePlugin, installed: true })


### PR DESCRIPTION
## Summary
- prefer project_url for installed plugin, marketplace card, and marketplace detail homepage actions
- retain repository and author URL fallbacks for older plugin metadata
- open already-known project URLs synchronously to avoid an about:blank tab

## Verification
- 33 targeted Vitest tests passed
- vue-tsc --noEmit passed
- ESLint passed for all changed files
- production Vite/PWA build passed

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at a4d1684be50da442b6efb4a1acc8e4917065411f

- 新增插件 `project_url` 项目主页元数据
- 主页跳转优先使用声明项目地址
- 保留仓库和作者主页回退逻辑
- 补充卡片与市场详情跳转测试
<!-- pr-agent-summary:end -->
