### PR TITLE
fix: 回放插件运行态代际变化

### DIFF
--- a/src/views/plugin/PluginCardListView.vue
+++ b/src/views/plugin/PluginCardListView.vue
@@ -218,6 +218,7 @@ const isMarketRefreshing = ref(false)
 const pluginRuntimeSummary = computed(() => pluginRuntimeStore.summary)
 const installingPluginIds = ref(new Set<string>())
 const isPluginPageActive = ref(false)
+const appliedRuntimeReconciliation = ref(0)
 
 // 每类远程快照独立管理 writer 代际，旧请求只能完成自身 Promise，不能覆盖新状态。
 let installedWriterGeneration = 0
@@ -1038,6 +1039,17 @@ async function fetchInstalledPlugins(context: KeepAliveRefreshContext = {}): Pro
   }
 }
 
+/** 运行态变化在市场页发生时延后应用，回到已安装列表后再补一次快照。 */
+async function reconcileInstalledRuntime(): Promise<void> {
+  const reconciliation = pluginRuntimeStore.reconciliation
+  if (reconciliation <= appliedRuntimeReconciliation.value) return
+
+  const refreshed = await fetchInstalledPlugins({ silent: true })
+  if (refreshed && reconciliation === pluginRuntimeStore.reconciliation) {
+    appliedRuntimeReconciliation.value = reconciliation
+  }
+}
+
 function isPluginRuntimeSettling(pluginId: string) {
   return pluginRuntimeSummary.value?.ready === false || installingPluginIds.value.has(pluginId)
 }
@@ -1448,19 +1460,26 @@ watch(activeTab, (newTab, oldTab) => {
     if (generation !== tabScrollRestoreGeneration) return
     window.scrollTo({ behavior: 'auto', top: tabScrollPositions[newTab] })
   })
+
+  if (newTab === 'installed' && isPluginPageActive.value && !document.hidden) {
+    void reconcileInstalledRuntime()
+  }
 })
 
 watch(
   () => pluginRuntimeStore.reconciliation,
   () => {
     if (isPluginPageActive.value && activeTab.value === 'installed' && !document.hidden) {
-      void fetchInstalledPlugins({ silent: true })
+      void reconcileInstalledRuntime()
     }
   },
 )
 
 onActivated(() => {
   isPluginPageActive.value = true
+  if (activeTab.value === 'installed' && !document.hidden) {
+    void reconcileInstalledRuntime()
+  }
 })
 
 onDeactivated(() => {

--- a/src/views/plugin/__tests__/PluginCardListView.spec.ts
+++ b/src/views/plugin/__tests__/PluginCardListView.spec.ts
@@ -794,6 +794,30 @@ describe('PluginCardListView loading and request ownership', () => {
     await waitForRequestsToFinish()
   })
 
+  it('applies a runtime generation received while the market tab is open', async () => {
+    let installedRequests = 0
+    const { pinia } = await renderList({
+      installed: () => {
+        installedRequests += 1
+        return [createPlugin({ id: 'Installed', installed: true, plugin_name: '已安装插件' })]
+      },
+      market: () => [createPlugin({ id: 'Market', plugin_name: '市场插件' })],
+    })
+    await waitForRequestsToFinish()
+    const initialInstalledRequests = installedRequests
+    const runtimeStore = usePluginRuntimeStore(pinia)
+
+    getHeaderConfig().modelValue.value = 'market'
+    await nextTick()
+    runtimeStore.reconciliation = 1
+    await nextTick()
+    expect(installedRequests).toBe(initialInstalledRequests)
+
+    getHeaderConfig().modelValue.value = 'installed'
+    await waitFor(() => expect(installedRequests).toBe(initialInstalledRequests + 1))
+    await waitForRequestsToFinish()
+  })
+
   it('does not request the superuser runtime summary for an ordinary administrator', async () => {
     server.use(
       http.get(apiUrls.runtime, () => {


### PR DESCRIPTION
## 变更

修复插件运行态代际在市场页变化时被丢弃的问题。后台恢复或依赖收敛期间，用户可能停留在插件市场；原实现会忽略这次协调信号，返回“我的插件”后继续显示旧的运行态和列表。现在保留未应用的代际，重新进入已安装列表时只回放已安装插件快照，不重新请求市场数据。

本 PR 只包含前端 PR #694 合并后的代际回放修复，不重复提交已合并的插件状态和安装交互改动。

## 验证

- 插件页聚焦测试：41 passed
- 前端全量测试：1313 passed
- 格式检查、Lint、生产构建通过

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 6ffc1f09a4395ea564325698163ef878fd72f963

- 修复市场页期间运行态变更丢失
- 返回“我的插件”时补拉已安装快照
- 仅成功且代际一致时标记已应用
- 新增标签切换运行态回放测试
<!-- pr-agent-summary:end -->
