### PR TITLE
feat: 展示 free-threaded Rust 强制启用状态

### DIFF
--- a/src/locales/en-US.ts
+++ b/src/locales/en-US.ts
@@ -2272,6 +2272,7 @@ export default {
       rustAccel: 'Rust Acceleration',
       rustAccelHint:
         'Use the backend Rust extension to accelerate filtering, RSS, indexer parsing, and recognition hot paths',
+      rustAccelRequiredHint: 'The free-threaded runtime requires Rust acceleration',
       rustAccelUnavailableHint:
         'The backend Rust acceleration extension is not installed or loaded, so this cannot be enabled',
       transferThreads: 'File Transfer Threads',

--- a/src/locales/zh-CN.ts
+++ b/src/locales/zh-CN.ts
@@ -2235,6 +2235,7 @@ export default {
       encodingDetectionPerformanceModeHint: '优先提升探测效率，但可能降低编码探测的准确性',
       rustAccel: 'Rust 加速',
       rustAccelHint: '启用后使用后端 Rust 扩展加速过滤、RSS、索引器和媒体识别等热路径',
+      rustAccelRequiredHint: '当前 free-threaded 运行时固定使用 Rust 加速',
       rustAccelUnavailableHint: '当前后端未安装或未加载 Rust 加速扩展，无法启用',
       transferThreads: '文件整理线程数',
       transferThreadsHint: '多线程整理文件可以提高速度，但可能增加系统资源占用',

--- a/src/locales/zh-TW.ts
+++ b/src/locales/zh-TW.ts
@@ -2234,6 +2234,7 @@ export default {
       encodingDetectionPerformanceModeHint: '優先提升探測效率，但可能降低編碼探測的準確性',
       rustAccel: 'Rust 加速',
       rustAccelHint: '啟用後使用後端 Rust 擴展加速過濾、RSS、索引器和媒體識別等熱路徑',
+      rustAccelRequiredHint: '當前 free-threaded 運行環境固定使用 Rust 加速',
       rustAccelUnavailableHint: '當前後端未安裝或未加載 Rust 加速擴展，無法啟用',
       transferThreads: '文件整理線程數',
       transferThreadsHint: '多線程整理文件可以提高速度，但可能增加系統資源佔用',

--- a/src/views/setting/AccountSettingSystem.vue
+++ b/src/views/setting/AccountSettingSystem.vue
@@ -238,6 +238,7 @@ const advancedDialog = ref(false)
 const savingBasic = ref(false)
 const testingLlm = ref(false)
 const rustAccelAvailable = ref(false)
+const rustAccelRequired = ref(false)
 const agentMcpDialog = ref(false)
 const agentMcpServers = ref<AgentMcpServer[]>([])
 const loadingAgentMcpServers = ref(false)
@@ -544,7 +545,11 @@ const canTestLlm = computed(() => {
 })
 
 const rustAccelHint = computed(() =>
-  rustAccelAvailable.value ? t('setting.system.rustAccelHint') : t('setting.system.rustAccelUnavailableHint'),
+  rustAccelRequired.value
+    ? t('setting.system.rustAccelRequiredHint')
+    : rustAccelAvailable.value
+      ? t('setting.system.rustAccelHint')
+      : t('setting.system.rustAccelUnavailableHint'),
 )
 
 const thinkingLevelItems = computed(() => [
@@ -797,7 +802,9 @@ async function loadSystemSettings() {
     }
     const accelAvailable = Boolean(result.RUST_ACCEL_AVAILABLE ?? result.RUST_ACCEL_ENABLED)
     rustAccelAvailable.value = accelAvailable
-    if (!accelAvailable) SystemSettings.value.Advanced.RUST_ACCEL = false
+    rustAccelRequired.value = Boolean(result.RUST_ACCEL_REQUIRED)
+    if (rustAccelRequired.value) SystemSettings.value.Advanced.RUST_ACCEL = true
+    else if (!accelAvailable) SystemSettings.value.Advanced.RUST_ACCEL = false
     SystemSettings.value.Basic.LLM_THINKING_LEVEL = resolveThinkingLevelValue(result)
     await loadLlmProviders()
   } catch (error) {
@@ -898,7 +905,8 @@ async function testLlmConnection() {
 // 保存高级设置
 async function saveAdvancedSettings() {
   if (!normalizeDbBackupSettings()) return
-  if (!rustAccelAvailable.value) SystemSettings.value.Advanced.RUST_ACCEL = false
+  if (rustAccelRequired.value) SystemSettings.value.Advanced.RUST_ACCEL = true
+  else if (!rustAccelAvailable.value) SystemSettings.value.Advanced.RUST_ACCEL = false
   cleanEmptyFields(SystemSettings.value.Advanced, ['LOG_FILE_FORMAT'])
 
   // 同时保存高级设置和刮削开关设置
@@ -2774,7 +2782,7 @@ watch(currentLlmSnapshotKey, (snapshotKey, previousSnapshotKey) => {
                     v-model="SystemSettings.Advanced.RUST_ACCEL"
                     :label="t('setting.system.rustAccel')"
                     :hint="rustAccelHint"
-                    :disabled="!rustAccelAvailable"
+                    :disabled="!rustAccelAvailable || rustAccelRequired"
                     persistent-hint
                   />
                 </VCol>

--- a/src/views/setting/__tests__/AccountSettingSystem.spec.ts
+++ b/src/views/setting/__tests__/AccountSettingSystem.spec.ts
@@ -1334,6 +1334,22 @@ describe('AccountSettingSystem', () => {
     expect(findPost('system/env')?.[1]).toEqual(expect.objectContaining({ RUST_ACCEL: false }))
   })
 
+  it('keeps Rust acceleration enabled and read-only when required by the runtime', async () => {
+    systemEnv.RUST_ACCEL_AVAILABLE = true
+    systemEnv.RUST_ACCEL_REQUIRED = true
+    systemEnv.RUST_ACCEL = false
+    await renderSettings()
+
+    const dialog = await openAdvancedTab('实验室')
+    const rust = dialog.getByLabelText('Rust 加速')
+    expect(rust).toBeDisabled()
+    expect(rust).toBeChecked()
+    await fireEvent.click(dialog.getByRole('button', { name: '保存' }))
+
+    await waitFor(() => expect(findPost('system/env')).toBeDefined())
+    expect(findPost('system/env')?.[1]).toEqual(expect.objectContaining({ RUST_ACCEL: true }))
+  })
+
   it('suppresses silent refresh while the advanced dialog is open and resumes after save', async () => {
     await renderSettings()
     await waitFor(() => expect(mocks.apiGet).toHaveBeenCalledWith('system/env'))


### PR DESCRIPTION
free-threaded 运行时要求 Rust 加速始终启用，但前端此前只知道扩展是否可用，仍允许用户关闭开关，无法表达 V3t 的固定运行时合同。

本 PR 读取后端 `/system/env` 返回的 `RUST_ACCEL_REQUIRED` 能力位：

- 运行时要求 Rust 时，开关固定为开启并设为只读，保存时继续提交 `RUST_ACCEL=true`；
- 显示明确的 free-threaded 运行时说明；
- 标准运行时保持现有可切换行为，扩展不可用时仍保持禁用；
- 旧后端未返回该字段时按 `false` 处理，因此不要求与后端同步合并。

前端不解析 Python 版本或镜像标签，运行时差异由后端根据 `Py_GIL_DISABLED` 统一映射为能力位，避免在 UI 中复制解释器判断。

验证通过：

- `yarn typecheck`
- `yarn lint`
- focused tests：37 passed
- 桌面宽屏真实页面验证：高级设置可正常打开，Rust 控件布局和只读状态正常，相关接口无失败请求
- `git diff --check`

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at b42dadb6a09e2032d629328bab852771dd91297e

- 支持运行时强制启用 Rust 加速
- 必需时固定开启并禁止修改
- 补充三种语言的状态提示
- 新增强制模式保存行为测试
<!-- pr-agent-summary:end -->
