### PR TITLE
feat: 展示 V3t 运行时状态并锁定 Rust 加速

### DIFF
--- a/src/@layouts/components/VerticalNav.vue
+++ b/src/@layouts/components/VerticalNav.vue
@@ -1,7 +1,9 @@
 <script lang="ts" setup>
 import type { Component } from 'vue'
 import { useDisplay } from 'vuetify'
+import { useI18n } from 'vue-i18n'
 import ThemeLogoMark from '@/components/misc/ThemeLogoMark.vue'
+import { useGlobalSettingsStore } from '@/stores'
 
 interface Props {
   tag?: string | Component
@@ -14,6 +16,17 @@ const props = withDefaults(defineProps<Props>(), {
 })
 
 const { mdAndDown } = useDisplay()
+const { t } = useI18n()
+const globalSettingsStore = useGlobalSettingsStore()
+const pythonFreeThreaded = computed(() => globalSettingsStore.get('PYTHON_FREE_THREADED') === true)
+const runtimeVersion = computed(() => (pythonFreeThreaded.value ? 'v3t' : 'v3'))
+const runtimeGilFallback = computed(
+  () => pythonFreeThreaded.value && globalSettingsStore.get('PYTHON_GIL_ENABLED') === true,
+)
+const runtimeStatusIcon = computed(() => (runtimeGilFallback.value ? 'mdi-alert-circle-outline' : 'mdi-flask-outline'))
+const runtimeStatusHint = computed(() =>
+  t(runtimeGilFallback.value ? 'app.freeThreadedGilFallbackWarning' : 'app.freeThreadedExperimentalHint'),
+)
 const refNav = ref()
 const route = useRoute()
 
@@ -54,7 +67,20 @@ function handleNavScroll(evt: Event) {
           <ThemeLogoMark />
 
           <h1 class="leading-normal text-xl">
-            <span class="moviepilot-wordmark">MOVIEPILOT</span> <span class="text-sm text-gray-500">v3</span>
+            <span class="moviepilot-wordmark">MOVIEPILOT</span>
+            <span
+              class="runtime-version text-sm text-gray-500 d-inline-flex align-center"
+              :class="{
+                'runtime-version--free-threaded': pythonFreeThreaded,
+                'runtime-version--degraded': runtimeGilFallback,
+              }"
+            >
+              {{ runtimeVersion }}
+              <VIcon v-if="pythonFreeThreaded" :icon="runtimeStatusIcon" size="13" :aria-label="runtimeStatusHint" />
+              <VTooltip v-if="pythonFreeThreaded" activator="parent" location="bottom">
+                {{ runtimeStatusHint }}
+              </VTooltip>
+            </span>
           </h1>
         </RouterLink>
       </slot>
@@ -92,7 +118,10 @@ function handleNavScroll(evt: Event) {
   inline-size: variables.$layout-vertical-nav-width;
   inset-block-start: 0;
   inset-inline-start: 0;
-  transition: transform 0.25s ease-in-out, inline-size 0.25s ease-in-out, box-shadow 0.25s ease-in-out;
+  transition:
+    transform 0.25s ease-in-out,
+    inline-size 0.25s ease-in-out,
+    box-shadow 0.25s ease-in-out;
   visibility: hidden;
   will-change: transform, inline-size;
 
@@ -111,6 +140,20 @@ function handleNavScroll(evt: Event) {
 
   .app-title-wrapper {
     margin-inline-end: auto;
+  }
+
+  .runtime-version {
+    margin-inline-start: 0.25rem;
+    font-weight: 600;
+    line-height: 1;
+  }
+
+  .runtime-version--free-threaded {
+    gap: 0.2rem;
+  }
+
+  .runtime-version--degraded {
+    color: rgb(var(--v-theme-warning)) !important;
   }
 
   .nav-items {

--- a/src/@layouts/components/__tests__/VerticalNav.spec.ts
+++ b/src/@layouts/components/__tests__/VerticalNav.spec.ts
@@ -1,0 +1,85 @@
+import VerticalNav from '@/@layouts/components/VerticalNav.vue'
+import { shallowMount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  freeThreaded: false,
+  gilEnabled: true,
+}))
+
+vi.mock('@/stores', () => ({
+  useGlobalSettingsStore: () => ({
+    get: (key: string) => {
+      if (key === 'PYTHON_FREE_THREADED') return mocks.freeThreaded
+      if (key === 'PYTHON_GIL_ENABLED') return mocks.gilEnabled
+      return undefined
+    },
+  }),
+}))
+
+vi.mock('vue-i18n', async importOriginal => ({
+  ...(await importOriginal<typeof import('vue-i18n')>()),
+  useI18n: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock('vue-router', async importOriginal => ({
+  ...(await importOriginal<typeof import('vue-router')>()),
+  useRoute: () => ({ path: '/' }),
+}))
+
+vi.mock('vuetify', async importOriginal => ({
+  ...(await importOriginal<typeof import('vuetify')>()),
+  useDisplay: () => ({ mdAndDown: { value: false } }),
+}))
+
+function renderNavigation() {
+  return shallowMount(VerticalNav, {
+    props: {
+      isOverlayNavActive: false,
+      toggleIsOverlayNavActive: vi.fn(),
+    },
+    global: {
+      stubs: {
+        PerfectScrollbar: { template: '<ul><slot /></ul>' },
+        RouterLink: { template: '<a><slot /></a>' },
+        ThemeLogoMark: true,
+        VIcon: { props: ['ariaLabel'], template: '<span>{{ ariaLabel }}</span>' },
+        VTooltip: { template: '<span><slot /></span>' },
+      },
+    },
+  })
+}
+
+describe('VerticalNav runtime version', () => {
+  beforeEach(() => {
+    mocks.freeThreaded = false
+    mocks.gilEnabled = true
+  })
+
+  it('shows v3 for the standard runtime', () => {
+    const navigation = renderNavigation()
+
+    expect(navigation.text()).toContain('MOVIEPILOT')
+    expect(navigation.get('.runtime-version').text()).toBe('v3')
+  })
+
+  it('shows v3t for the free-threaded runtime', () => {
+    mocks.freeThreaded = true
+    mocks.gilEnabled = false
+
+    const navigation = renderNavigation()
+
+    expect(navigation.get('.runtime-version--free-threaded').text()).toContain('v3t')
+    expect(navigation.get('.runtime-version--free-threaded').classes()).not.toContain('runtime-version--degraded')
+    expect(navigation.text()).toContain('app.freeThreadedExperimentalHint')
+  })
+
+  it('marks v3t when the runtime has enabled the GIL', () => {
+    mocks.freeThreaded = true
+
+    const navigation = renderNavigation()
+
+    expect(navigation.get('.runtime-version--degraded').text()).toContain('v3t')
+    expect(navigation.text()).toContain('app.freeThreadedGilFallbackWarning')
+  })
+})

--- a/src/layouts/default/components/DefaultLayout.vue
+++ b/src/layouts/default/components/DefaultLayout.vue
@@ -484,7 +484,10 @@ watch([() => pluginSidebarNavStore.items, userPermissions], () => {
 watch(
   () => pluginRuntimeStore.reconciliation,
   reconciliation => {
-    if (reconciliation > 0) void pluginSidebarNavStore.ensureSidebarNav(true)
+    if (reconciliation <= 0) return
+
+    void pluginSidebarNavStore.ensureSidebarNav(true)
+    void globalSettingsStore.loadUserSettings()
   },
 )
 

--- a/src/layouts/default/components/__tests__/DefaultLayout.spec.ts
+++ b/src/layouts/default/components/__tests__/DefaultLayout.spec.ts
@@ -24,6 +24,7 @@ interface UserStoreMock {
 const mocks = vi.hoisted(() => ({
   emptyComponent: { template: '<div><slot /></div>' },
   ensureSidebarNav: vi.fn(),
+  loadUserSettings: vi.fn(),
   navLink: {
     name: 'VerticalNavLink',
     props: ['item'],
@@ -76,7 +77,10 @@ vi.mock('@/stores', async () => {
   })
 
   return {
-    useGlobalSettingsStore: () => ({ get: vi.fn(() => false) }),
+    useGlobalSettingsStore: () => ({
+      get: vi.fn(() => false),
+      loadUserSettings: mocks.loadUserSettings,
+    }),
     usePluginRuntimeStore: () => mocks.runtimeStore,
     usePluginSidebarNavStore: () => mocks.sidebarStore,
     useUserStore: () => mocks.userStore,
@@ -125,6 +129,8 @@ describe('DefaultLayout', () => {
   beforeEach(() => {
     mocks.ensureSidebarNav.mockReset()
     mocks.ensureSidebarNav.mockResolvedValue(undefined)
+    mocks.loadUserSettings.mockReset()
+    mocks.loadUserSettings.mockResolvedValue(undefined)
     mocks.startPluginRuntime.mockReset()
     mocks.stopPluginRuntime.mockReset()
     mocks.runtimeStore!.reconciliation = 0
@@ -264,11 +270,14 @@ describe('DefaultLayout', () => {
     mocks.runtimeStore!.reconciliation = 1
     await nextTick()
     expect(mocks.ensureSidebarNav).toHaveBeenCalledWith(true)
+    expect(mocks.loadUserSettings).toHaveBeenCalled()
     mocks.ensureSidebarNav.mockClear()
+    mocks.loadUserSettings.mockClear()
 
     mocks.runtimeStore!.reconciliation = 2
     await nextTick()
     expect(mocks.ensureSidebarNav).toHaveBeenCalledWith(true)
+    expect(mocks.loadUserSettings).toHaveBeenCalled()
 
     wrapper.unmount()
     expect(mocks.stopPluginRuntime).toHaveBeenCalledTimes(1)

--- a/src/locales/en-US.ts
+++ b/src/locales/en-US.ts
@@ -2273,6 +2273,8 @@ export default {
       rustAccelHint:
         'Use the backend Rust extension to accelerate filtering, RSS, indexer parsing, and recognition hot paths',
       rustAccelRequiredHint: 'The free-threaded runtime requires Rust acceleration',
+      rustAccelGilFallbackWarning:
+        'The free-threaded runtime has fallen back to GIL mode. Check backend logs for native extension compatibility warnings.',
       rustAccelUnavailableHint:
         'The backend Rust acceleration extension is not installed or loaded, so this cannot be enabled',
       transferThreads: 'File Transfer Threads',

--- a/src/locales/en-US.ts
+++ b/src/locales/en-US.ts
@@ -277,6 +277,9 @@ export default {
     continueBrowsing: 'Continue browsing',
     online: 'Application Online',
     onlineMessage: 'Network connection restored',
+    freeThreadedExperimentalHint: 'Experimental free-threaded runtime',
+    freeThreadedGilFallbackWarning:
+      'The free-threaded runtime has fallen back to GIL mode. Check backend logs for native extension compatibility warnings.',
   },
   pwa: {
     installApp: 'Install MoviePilot App',
@@ -2273,8 +2276,6 @@ export default {
       rustAccelHint:
         'Use the backend Rust extension to accelerate filtering, RSS, indexer parsing, and recognition hot paths',
       rustAccelRequiredHint: 'The free-threaded runtime requires Rust acceleration',
-      rustAccelGilFallbackWarning:
-        'The free-threaded runtime has fallen back to GIL mode. Check backend logs for native extension compatibility warnings.',
       rustAccelUnavailableHint:
         'The backend Rust acceleration extension is not installed or loaded, so this cannot be enabled',
       transferThreads: 'File Transfer Threads',

--- a/src/locales/zh-CN.ts
+++ b/src/locales/zh-CN.ts
@@ -270,6 +270,8 @@ export default {
     continueBrowsing: '继续浏览',
     online: '应用在线',
     onlineMessage: '网络连接已恢复',
+    freeThreadedExperimentalHint: '实验性 free-threaded 运行时',
+    freeThreadedGilFallbackWarning: 'free-threaded 运行时已退化为 GIL 模式，请检查后端日志中的原生扩展兼容告警',
   },
   pwa: {
     installApp: '安装 MoviePilot 应用',
@@ -2236,7 +2238,6 @@ export default {
       rustAccel: 'Rust 加速',
       rustAccelHint: '启用后使用后端 Rust 扩展加速过滤、RSS、索引器和媒体识别等热路径',
       rustAccelRequiredHint: '当前 free-threaded 运行时固定使用 Rust 加速',
-      rustAccelGilFallbackWarning: 'free-threaded 运行时已退化为 GIL 模式，请检查后端日志中的原生扩展兼容告警',
       rustAccelUnavailableHint: '当前后端未安装或未加载 Rust 加速扩展，无法启用',
       transferThreads: '文件整理线程数',
       transferThreadsHint: '多线程整理文件可以提高速度，但可能增加系统资源占用',

--- a/src/locales/zh-CN.ts
+++ b/src/locales/zh-CN.ts
@@ -2236,6 +2236,7 @@ export default {
       rustAccel: 'Rust 加速',
       rustAccelHint: '启用后使用后端 Rust 扩展加速过滤、RSS、索引器和媒体识别等热路径',
       rustAccelRequiredHint: '当前 free-threaded 运行时固定使用 Rust 加速',
+      rustAccelGilFallbackWarning: 'free-threaded 运行时已退化为 GIL 模式，请检查后端日志中的原生扩展兼容告警',
       rustAccelUnavailableHint: '当前后端未安装或未加载 Rust 加速扩展，无法启用',
       transferThreads: '文件整理线程数',
       transferThreadsHint: '多线程整理文件可以提高速度，但可能增加系统资源占用',

--- a/src/locales/zh-TW.ts
+++ b/src/locales/zh-TW.ts
@@ -270,6 +270,8 @@ export default {
     continueBrowsing: '繼續瀏覽',
     online: '應用在線',
     onlineMessage: '網絡連接已恢復',
+    freeThreadedExperimentalHint: '實驗性 free-threaded 運行環境',
+    freeThreadedGilFallbackWarning: 'free-threaded 運行環境已退化為 GIL 模式，請檢查後端日誌中的原生擴展兼容警告',
   },
   pwa: {
     installApp: '安裝 MoviePilot 應用',
@@ -2235,7 +2237,6 @@ export default {
       rustAccel: 'Rust 加速',
       rustAccelHint: '啟用後使用後端 Rust 擴展加速過濾、RSS、索引器和媒體識別等熱路徑',
       rustAccelRequiredHint: '當前 free-threaded 運行環境固定使用 Rust 加速',
-      rustAccelGilFallbackWarning: 'free-threaded 運行環境已退化為 GIL 模式，請檢查後端日誌中的原生擴展兼容警告',
       rustAccelUnavailableHint: '當前後端未安裝或未加載 Rust 加速擴展，無法啟用',
       transferThreads: '文件整理線程數',
       transferThreadsHint: '多線程整理文件可以提高速度，但可能增加系統資源佔用',

--- a/src/locales/zh-TW.ts
+++ b/src/locales/zh-TW.ts
@@ -2235,6 +2235,7 @@ export default {
       rustAccel: 'Rust 加速',
       rustAccelHint: '啟用後使用後端 Rust 擴展加速過濾、RSS、索引器和媒體識別等熱路徑',
       rustAccelRequiredHint: '當前 free-threaded 運行環境固定使用 Rust 加速',
+      rustAccelGilFallbackWarning: 'free-threaded 運行環境已退化為 GIL 模式，請檢查後端日誌中的原生擴展兼容警告',
       rustAccelUnavailableHint: '當前後端未安裝或未加載 Rust 加速擴展，無法啟用',
       transferThreads: '文件整理線程數',
       transferThreadsHint: '多線程整理文件可以提高速度，但可能增加系統資源佔用',

--- a/src/views/setting/AccountSettingSystem.vue
+++ b/src/views/setting/AccountSettingSystem.vue
@@ -239,7 +239,6 @@ const savingBasic = ref(false)
 const testingLlm = ref(false)
 const rustAccelAvailable = ref(false)
 const rustAccelRequired = ref(false)
-const pythonGilEnabled = ref(true)
 const agentMcpDialog = ref(false)
 const agentMcpServers = ref<AgentMcpServer[]>([])
 const loadingAgentMcpServers = ref(false)
@@ -552,8 +551,6 @@ const rustAccelHint = computed(() =>
       ? t('setting.system.rustAccelHint')
       : t('setting.system.rustAccelUnavailableHint'),
 )
-const freeThreadedGilFallback = computed(() => rustAccelRequired.value && pythonGilEnabled.value)
-
 const thinkingLevelItems = computed(() => [
   { title: t('setting.system.llmThinkingLevelOff'), value: 'off' },
   { title: t('setting.system.llmThinkingLevelAuto'), value: 'auto' },
@@ -805,7 +802,6 @@ async function loadSystemSettings() {
     const accelAvailable = Boolean(result.RUST_ACCEL_AVAILABLE ?? result.RUST_ACCEL_ENABLED)
     rustAccelAvailable.value = accelAvailable
     rustAccelRequired.value = Boolean(result.RUST_ACCEL_REQUIRED)
-    pythonGilEnabled.value = Boolean(result.PYTHON_GIL_ENABLED)
     if (rustAccelRequired.value) SystemSettings.value.Advanced.RUST_ACCEL = true
     else if (!accelAvailable) SystemSettings.value.Advanced.RUST_ACCEL = false
     SystemSettings.value.Basic.LLM_THINKING_LEVEL = resolveThinkingLevelValue(result)
@@ -2785,18 +2781,10 @@ watch(currentLlmSnapshotKey, (snapshotKey, previousSnapshotKey) => {
                     v-model="SystemSettings.Advanced.RUST_ACCEL"
                     :label="t('setting.system.rustAccel')"
                     :hint="rustAccelHint"
-                    :disabled="!rustAccelAvailable || rustAccelRequired"
+                    :disabled="!rustAccelAvailable"
+                    :readonly="rustAccelRequired"
                     persistent-hint
                   />
-                  <VAlert
-                    v-if="freeThreadedGilFallback"
-                    type="warning"
-                    variant="tonal"
-                    density="compact"
-                    class="mt-2"
-                  >
-                    {{ t('setting.system.rustAccelGilFallbackWarning') }}
-                  </VAlert>
                 </VCol>
                 <VCol cols="12" md="6">
                   <VSwitch

--- a/src/views/setting/AccountSettingSystem.vue
+++ b/src/views/setting/AccountSettingSystem.vue
@@ -239,6 +239,7 @@ const savingBasic = ref(false)
 const testingLlm = ref(false)
 const rustAccelAvailable = ref(false)
 const rustAccelRequired = ref(false)
+const pythonGilEnabled = ref(true)
 const agentMcpDialog = ref(false)
 const agentMcpServers = ref<AgentMcpServer[]>([])
 const loadingAgentMcpServers = ref(false)
@@ -551,6 +552,7 @@ const rustAccelHint = computed(() =>
       ? t('setting.system.rustAccelHint')
       : t('setting.system.rustAccelUnavailableHint'),
 )
+const freeThreadedGilFallback = computed(() => rustAccelRequired.value && pythonGilEnabled.value)
 
 const thinkingLevelItems = computed(() => [
   { title: t('setting.system.llmThinkingLevelOff'), value: 'off' },
@@ -803,6 +805,7 @@ async function loadSystemSettings() {
     const accelAvailable = Boolean(result.RUST_ACCEL_AVAILABLE ?? result.RUST_ACCEL_ENABLED)
     rustAccelAvailable.value = accelAvailable
     rustAccelRequired.value = Boolean(result.RUST_ACCEL_REQUIRED)
+    pythonGilEnabled.value = Boolean(result.PYTHON_GIL_ENABLED)
     if (rustAccelRequired.value) SystemSettings.value.Advanced.RUST_ACCEL = true
     else if (!accelAvailable) SystemSettings.value.Advanced.RUST_ACCEL = false
     SystemSettings.value.Basic.LLM_THINKING_LEVEL = resolveThinkingLevelValue(result)
@@ -2785,6 +2788,15 @@ watch(currentLlmSnapshotKey, (snapshotKey, previousSnapshotKey) => {
                     :disabled="!rustAccelAvailable || rustAccelRequired"
                     persistent-hint
                   />
+                  <VAlert
+                    v-if="freeThreadedGilFallback"
+                    type="warning"
+                    variant="tonal"
+                    density="compact"
+                    class="mt-2"
+                  >
+                    {{ t('setting.system.rustAccelGilFallbackWarning') }}
+                  </VAlert>
                 </VCol>
                 <VCol cols="12" md="6">
                   <VSwitch

--- a/src/views/setting/__tests__/AccountSettingSystem.spec.ts
+++ b/src/views/setting/__tests__/AccountSettingSystem.spec.ts
@@ -1337,6 +1337,7 @@ describe('AccountSettingSystem', () => {
   it('keeps Rust acceleration enabled and read-only when required by the runtime', async () => {
     systemEnv.RUST_ACCEL_AVAILABLE = true
     systemEnv.RUST_ACCEL_REQUIRED = true
+    systemEnv.PYTHON_GIL_ENABLED = false
     systemEnv.RUST_ACCEL = false
     await renderSettings()
 
@@ -1344,10 +1345,26 @@ describe('AccountSettingSystem', () => {
     const rust = dialog.getByLabelText('Rust 加速')
     expect(rust).toBeDisabled()
     expect(rust).toBeChecked()
+    expect(
+      dialog.queryByText('free-threaded 运行时已退化为 GIL 模式，请检查后端日志中的原生扩展兼容告警'),
+    ).not.toBeInTheDocument()
     await fireEvent.click(dialog.getByRole('button', { name: '保存' }))
 
     await waitFor(() => expect(findPost('system/env')).toBeDefined())
     expect(findPost('system/env')?.[1]).toEqual(expect.objectContaining({ RUST_ACCEL: true }))
+  })
+
+  it('warns when a free-threaded runtime has enabled the GIL', async () => {
+    systemEnv.RUST_ACCEL_AVAILABLE = true
+    systemEnv.RUST_ACCEL_REQUIRED = true
+    systemEnv.PYTHON_GIL_ENABLED = true
+    await renderSettings()
+
+    const dialog = await openAdvancedTab('实验室')
+
+    expect(
+      dialog.getByText('free-threaded 运行时已退化为 GIL 模式，请检查后端日志中的原生扩展兼容告警'),
+    ).toBeVisible()
   })
 
   it('suppresses silent refresh while the advanced dialog is open and resumes after save', async () => {

--- a/src/views/setting/__tests__/AccountSettingSystem.spec.ts
+++ b/src/views/setting/__tests__/AccountSettingSystem.spec.ts
@@ -1337,34 +1337,19 @@ describe('AccountSettingSystem', () => {
   it('keeps Rust acceleration enabled and read-only when required by the runtime', async () => {
     systemEnv.RUST_ACCEL_AVAILABLE = true
     systemEnv.RUST_ACCEL_REQUIRED = true
-    systemEnv.PYTHON_GIL_ENABLED = false
     systemEnv.RUST_ACCEL = false
     await renderSettings()
 
     const dialog = await openAdvancedTab('实验室')
     const rust = dialog.getByLabelText('Rust 加速')
-    expect(rust).toBeDisabled()
+    expect(rust).toHaveAttribute('aria-disabled', 'false')
     expect(rust).toBeChecked()
-    expect(
-      dialog.queryByText('free-threaded 运行时已退化为 GIL 模式，请检查后端日志中的原生扩展兼容告警'),
-    ).not.toBeInTheDocument()
+    await fireEvent.click(rust)
+    expect(rust).toBeChecked()
     await fireEvent.click(dialog.getByRole('button', { name: '保存' }))
 
     await waitFor(() => expect(findPost('system/env')).toBeDefined())
     expect(findPost('system/env')?.[1]).toEqual(expect.objectContaining({ RUST_ACCEL: true }))
-  })
-
-  it('warns when a free-threaded runtime has enabled the GIL', async () => {
-    systemEnv.RUST_ACCEL_AVAILABLE = true
-    systemEnv.RUST_ACCEL_REQUIRED = true
-    systemEnv.PYTHON_GIL_ENABLED = true
-    await renderSettings()
-
-    const dialog = await openAdvancedTab('实验室')
-
-    expect(
-      dialog.getByText('free-threaded 运行时已退化为 GIL 模式，请检查后端日志中的原生扩展兼容告警'),
-    ).toBeVisible()
   })
 
   it('suppresses silent refresh while the advanced dialog is open and resumes after save', async () => {


### PR DESCRIPTION
## 目标

free-threaded 运行时此前在前端仍显示为 `v3`，用户也无法直接感知运行期间是否退化为 GIL 模式。同时，V3t 强制开启 Rust 加速时若使用禁用态，会让已开启的开关在视觉上近似关闭。

## 改动

- 登录后根据后端运行态能力显示 `v3` 或 `v3t`，V3t 使用后置实验标记，并在 GIL 被重新启用时显示告警状态。
- 插件运行态重新协调后刷新全局设置，使原生扩展加载引起的 GIL 状态变化能够及时反映到导航栏。
- V3t 强制启用 Rust 加速时保持正常开启视觉并设为只读，只有 Rust 扩展不可用时才显示禁用态。
- 补充简体中文、繁体中文和英文文案及相关组件测试。

前端依赖后端在用户全局设置中返回 `PYTHON_FREE_THREADED` 与 `PYTHON_GIL_ENABLED`。字段缺失时按标准 V3 展示，不影响现有运行时。

## 验证

- 相关 Vitest：45 passed
- `yarn typecheck`
- `yarn lint`
- `yarn lint:suppressions:prune`
- 桌面视口连接真实 V3t 后端验证：版本标识、提示、Rust 开关只读状态及 GIL 状态刷新均符合预期

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 9b31ba4a53b512d38d790bf448ac672350e64244

- 展示 `v3t` free-threaded 运行时状态
- GIL 回退时显示告警与兼容性提示
- 运行时协调后刷新全局设置状态
- Rust 加速强制启用时保持开启且只读
- 补充运行时标识与设置行为测试
<!-- pr-agent-summary:end -->
