### PR TITLE
test: 补充插件工作流动作配置保护

### DIFF
--- a/src/components/workflow/__tests__/InvokePluginAction.spec.ts
+++ b/src/components/workflow/__tests__/InvokePluginAction.spec.ts
@@ -1,0 +1,188 @@
+import InvokePluginAction from '@/components/workflow/InvokePluginAction.vue'
+import { fireEvent, screen, waitFor, within } from '@testing-library/vue'
+import { renderWithProviders } from '@tests/support/render'
+import { defineComponent, h, type PropType } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  apiGet: vi.fn(),
+}))
+
+vi.mock('@/api', () => ({
+  default: {
+    get: (...args: unknown[]) => mocks.apiGet(...args),
+  },
+}))
+
+vi.mock('@vue-flow/core', async () => {
+  const { defineComponent: defineVueComponent, h: createElement } = await import('vue')
+  return {
+    Handle: defineVueComponent({ setup: () => () => createElement('span') }),
+    Position: { Left: 'left', Right: 'right' },
+  }
+})
+
+type SelectItem = { title: string; value: string }
+
+const SelectStub = defineComponent({
+  name: 'VSelect',
+  props: {
+    items: { type: Array as PropType<SelectItem[]>, default: () => [] },
+    label: { type: String, default: '' },
+    modelValue: { type: String, default: '' },
+  },
+  emits: ['update:modelValue'],
+  setup:
+    (props, { emit }) =>
+    () =>
+      h('label', [
+        h('span', props.label),
+        h(
+          'select',
+          {
+            'aria-label': props.label,
+            onChange: (event: Event) => emit('update:modelValue', (event.target as HTMLSelectElement).value),
+            value: props.modelValue,
+          },
+          props.items.map(item => h('option', { value: item.value }, item.title)),
+        ),
+      ]),
+})
+
+const TextareaStub = defineComponent({
+  name: 'VTextarea',
+  props: {
+    label: { type: String, default: '' },
+    modelValue: { type: String, default: '' },
+  },
+  emits: ['update:modelValue'],
+  setup:
+    (props, { emit }) =>
+    () =>
+      h('label', [
+        h('span', props.label),
+        h('textarea', {
+          'aria-label': props.label,
+          onInput: (event: Event) => emit('update:modelValue', (event.target as HTMLTextAreaElement).value),
+          value: props.modelValue,
+        }),
+      ]),
+})
+
+const BoxStub = defineComponent({
+  setup:
+    (_, { slots }) =>
+    () =>
+      h('div', slots.default?.()),
+})
+
+function createData(overrides: Record<string, unknown> = {}) {
+  return {
+    action_id: 'refresh',
+    action_params: { force: true },
+    plugin_id: 'plugin-a',
+    ...overrides,
+  }
+}
+
+async function renderAction(data = createData()) {
+  return renderWithProviders(InvokePluginAction, {
+    props: { data, id: 'action-1' },
+    global: {
+      stubs: {
+        VAvatar: BoxStub,
+        VCard: BoxStub,
+        VCardItem: BoxStub,
+        VCardSubtitle: BoxStub,
+        VCardText: BoxStub,
+        VCardTitle: BoxStub,
+        VCol: BoxStub,
+        VDivider: true,
+        VIcon: true,
+        VRow: BoxStub,
+        VSelect: SelectStub,
+        VTextarea: TextareaStub,
+      },
+    },
+  })
+}
+
+describe('InvokePluginAction', () => {
+  beforeEach(() => {
+    mocks.apiGet.mockReset().mockResolvedValue([
+      {
+        actions: [
+          { id: 'refresh', name: '刷新缓存' },
+          { id: 'sync', name: '同步数据' },
+        ],
+        plugin_id: 'plugin-a',
+        plugin_name: '插件 A',
+      },
+      {
+        actions: [{ id: 'cleanup', name: '清理数据' }],
+        plugin_id: 'plugin-b',
+        plugin_name: '插件 B',
+      },
+    ])
+  })
+
+  it('maps the public plugin action id contract to the selected plugin options', async () => {
+    const data = createData()
+    await renderAction(data)
+
+    await waitFor(() => expect(mocks.apiGet).toHaveBeenCalledWith('workflow/plugin/actions'))
+    const pluginSelect = screen.getByLabelText('插件')
+    const actionSelect = screen.getByLabelText('动作ID')
+    expect(
+      within(pluginSelect)
+        .getAllByRole('option')
+        .map(option => option.getAttribute('value')),
+    ).toEqual(['plugin-a', 'plugin-b'])
+    expect(
+      within(actionSelect)
+        .getAllByRole('option')
+        .map(option => option.getAttribute('value')),
+    ).toEqual(['refresh', 'sync'])
+
+    await fireEvent.update(pluginSelect, 'plugin-b')
+    await waitFor(() =>
+      expect(within(screen.getByLabelText('动作ID')).getByRole('option', { name: '清理数据' })).toHaveValue('cleanup'),
+    )
+    await fireEvent.update(actionSelect, 'cleanup')
+    expect(data).toEqual(expect.objectContaining({ action_id: 'cleanup', plugin_id: 'plugin-b' }))
+  })
+
+  it('round-trips object parameters and preserves invalid JSON for correction', async () => {
+    const data = createData()
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    await renderAction(data)
+
+    const params = screen.getByLabelText('动作参数')
+    expect(params).toHaveValue('{\n  "force": true\n}')
+
+    await fireEvent.update(params, '{"force":false,"limit":2}')
+    expect(data.action_params).toEqual({ force: false, limit: 2 })
+
+    await fireEvent.update(params, '{invalid')
+    expect(data.action_params).toBe('{invalid')
+    expect(consoleError).toHaveBeenCalled()
+
+    await fireEvent.update(params, '')
+    expect(data.action_params).toEqual({})
+  })
+
+  it('keeps existing configuration when plugin actions fail to load', async () => {
+    const error = new Error('plugin actions unavailable')
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const data = createData({ action_params: 'raw parameters' })
+    mocks.apiGet.mockRejectedValueOnce(error)
+
+    await renderAction(data)
+
+    await waitFor(() => expect(consoleError).toHaveBeenCalledWith(error))
+    expect(screen.getByLabelText('插件')).toBeEmptyDOMElement()
+    expect(screen.getByLabelText('动作ID')).toBeEmptyDOMElement()
+    expect(screen.getByLabelText('动作参数')).toHaveValue('raw parameters')
+    expect(data).toEqual({ action_id: 'refresh', action_params: 'raw parameters', plugin_id: 'plugin-a' })
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -364,6 +364,7 @@ export default defineConfig(({ command, mode, isPreview }) => ({
         'src/components/dialog/UserAddEditDialog.vue',
         'src/components/dialog/WorkflowAddEditDialog.vue',
         'src/components/dialog/WorkflowActionsDialog.vue',
+        'src/components/workflow/InvokePluginAction.vue',
         'src/components/workflow/WorkflowSidebar.vue',
         'src/components/dialog/OTPAuthDialog.vue',
         'src/components/dialog/PasskeyDialog.vue',
@@ -591,6 +592,12 @@ export default defineConfig(({ command, mode, isPreview }) => ({
         },
         'src/components/dialog/WorkflowActionsDialog.vue': {
           branches: 85,
+          functions: 90,
+          lines: 90,
+          statements: 90,
+        },
+        'src/components/workflow/InvokePluginAction.vue': {
+          branches: 80,
           functions: 90,
           lines: 90,
           statements: 90,


### PR DESCRIPTION
`InvokePluginAction` 同时承担插件/动作联动和 `action_params` JSON 双向转换，但此前没有直接行为测试，字段映射或编辑语义变化只能依赖人工回归发现。

本 PR 增加组件级保护：

- 验证插件公开动作 `id` 映射为动作选项，并在切换插件、动作时写回 `plugin_id` 与 `action_id`；
- 验证对象参数的格式化展示、合法 JSON 转换、非法 JSON 保留和空文本归一；
- 验证动作列表加载失败时保留已有配置；
- 将该组件纳入本地覆盖率分析，并设置与相邻工作流组件一致的文件级门禁。

本 PR 仅修改测试和覆盖率配置，不调整生产代码、接口或用户行为。

验证：

- focused：3 个用例通过；
- 目标覆盖率：Lines 96.7%、Branches 92.59%、Functions 100%；
- `yarn typecheck`；
- `yarn lint`；
- `yarn format:check`；
- `git diff --check`。

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 3224072db23ab0b33df2f4a2c221ad57d0f7ff7c

- 为插件动作工作流组件新增行为测试
- 覆盖动作映射、参数转换与加载失败
- 将组件纳入覆盖率分析及门禁
- 不改变生产代码或接口兼容性
- 风险：仅通过组件桩验证 UI 集成
<!-- pr-agent-summary:end -->
