### PR TITLE
fix: 修正下载器卡片属性透传

### DIFF
--- a/src/components/cards/DownloaderCard.vue
+++ b/src/components/cards/DownloaderCard.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+defineOptions({ inheritAttrs: false })
+
 import api from '@/api'
 import { formatFileSize } from '@/@core/utils/formatters'
 import type { DownloaderConf, DownloaderInfo } from '@/api/types'
@@ -122,7 +124,7 @@ onUnmounted(() => {
 <template>
   <VHover v-slot="hover">
     <VCard
-      v-bind="hover.props"
+      v-bind="{ ...$attrs, ...hover.props }"
       variant="tonal"
       class="app-card-shell app-card-colorful"
       :style="{ '--app-card-accent-rgb': accentRgb }"
@@ -146,7 +148,10 @@ onUnmounted(() => {
             />
             <span class="app-card-summary__title text-h6">{{ downloader.name }}</span>
           </div>
-          <div v-if="downloaderDict[downloader.type] && props.downloader.enabled" class="app-card-summary__meta text-sm">
+          <div
+            v-if="downloaderDict[downloader.type] && props.downloader.enabled"
+            class="app-card-summary__meta text-sm"
+          >
             <span class="app-card-summary__meta-item">{{ `↑ ${formatFileSize(upload_rate, 1)}/s` }}</span>
             <span class="app-card-summary__meta-item">{{ `↓ ${formatFileSize(download_rate, 1)}/s` }}</span>
           </div>

--- a/src/components/cards/DownloaderCard.vue
+++ b/src/components/cards/DownloaderCard.vue
@@ -5,6 +5,7 @@ import api from '@/api'
 import { formatFileSize } from '@/@core/utils/formatters'
 import type { DownloaderConf, DownloaderInfo } from '@/api/types'
 import { getLogoUrl } from '@/utils/imageUtils'
+import { mergeProps } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { downloaderDict } from '@/api/constants'
 import { useBackground } from '@/composables/useBackground'
@@ -124,7 +125,7 @@ onUnmounted(() => {
 <template>
   <VHover v-slot="hover">
     <VCard
-      v-bind="{ ...$attrs, ...hover.props }"
+      v-bind="mergeProps($attrs, hover.props)"
       variant="tonal"
       class="app-card-shell app-card-colorful"
       :style="{ '--app-card-accent-rgb': accentRgb }"

--- a/src/components/cards/__tests__/DownloaderCard.spec.ts
+++ b/src/components/cards/__tests__/DownloaderCard.spec.ts
@@ -1,0 +1,107 @@
+import DownloaderCard from '@/components/cards/DownloaderCard.vue'
+import { renderWithProviders } from '@tests/support/render'
+import { defineComponent, h, ref } from 'vue'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/api', () => ({
+  default: {
+    get: vi.fn(),
+  },
+}))
+
+vi.mock('@/composables/useBackground', () => ({
+  useBackground: () => ({
+    useConditionalDataRefresh: () => ({ stop: vi.fn() }),
+  }),
+}))
+
+vi.mock('@/composables/useCardAccentColor', () => ({
+  useCardAccentColor: () => ({
+    accentRgb: ref('141, 81, 249'),
+    imageRef: ref(),
+    updateAccentColor: vi.fn(),
+  }),
+}))
+
+vi.mock('@/utils/imageUtils', () => ({
+  getLogoUrl: () => '/downloader.png',
+}))
+
+const passthroughStub = (name: string, tag = 'div') =>
+  defineComponent({
+    name,
+    inheritAttrs: false,
+    setup(_props, { attrs, slots }) {
+      return () => h(tag, attrs, slots.default?.())
+    },
+  })
+
+const VHoverStub = defineComponent({
+  name: 'VHover',
+  inheritAttrs: false,
+  setup(_props, { slots }) {
+    return () => slots.default?.({ props: {} })
+  },
+})
+
+const VCardStub = passthroughStub('VCard', 'article')
+
+const globalStubs = {
+  IconBtn: passthroughStub('IconBtn', 'button'),
+  VBadge: passthroughStub('VBadge', 'span'),
+  VCard: VCardStub,
+  VCardText: passthroughStub('VCardText'),
+  VDialogCloseBtn: passthroughStub('VDialogCloseBtn', 'button'),
+  VHover: VHoverStub,
+  VIcon: passthroughStub('VIcon', 'span'),
+  VImg: defineComponent({
+    name: 'VImg',
+    props: { src: String },
+    setup(props, { attrs }) {
+      return () => h('img', { ...attrs, src: props.src })
+    },
+  }),
+}
+
+const downloader = {
+  name: 'qb-main',
+  type: 'qbittorrent',
+  default: true,
+  enabled: false,
+  config: {},
+}
+
+describe('DownloaderCard', () => {
+  it('places draggable attributes on the card DOM instead of the hover wrapper', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const Harness = defineComponent({
+      setup() {
+        return () =>
+          h(DownloaderCard, {
+            downloader,
+            downloaders: [downloader],
+            allowRefresh: false,
+            'data-draggable': 'true',
+            'aria-label': 'qb-main-card',
+            class: 'draggable-item',
+          })
+      },
+    })
+
+    const { container } = await renderWithProviders(Harness, {
+      global: { stubs: globalStubs },
+    })
+
+    const card = container.querySelector('article')
+    expect(card).toBeInTheDocument()
+    expect(card).toHaveAttribute('data-draggable', 'true')
+    expect(card).toHaveAttribute('aria-label', 'qb-main-card')
+    expect(card).toHaveClass('draggable-item', 'app-card-shell', 'app-card-colorful')
+    expect(container.querySelectorAll('[data-draggable]')).toHaveLength(1)
+
+    const attributeWarnings = warn.mock.calls.filter(([message]) =>
+      String(message).includes('Extraneous non-props attributes'),
+    )
+    expect(attributeWarnings).toHaveLength(0)
+  })
+})

--- a/src/components/cards/__tests__/DownloaderCard.spec.ts
+++ b/src/components/cards/__tests__/DownloaderCard.spec.ts
@@ -40,9 +40,11 @@ const VHoverStub = defineComponent({
   name: 'VHover',
   inheritAttrs: false,
   setup(_props, { slots }) {
-    return () => slots.default?.({ props: {} })
+    return () => slots.default?.({ props: { onMouseenter: hoverMouseenter } })
   },
 })
+
+const hoverMouseenter = vi.fn()
 
 const VCardStub = passthroughStub('VCard', 'article')
 
@@ -74,6 +76,8 @@ const downloader = {
 describe('DownloaderCard', () => {
   it('places draggable attributes on the card DOM instead of the hover wrapper', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const externalMouseenter = vi.fn()
+    hoverMouseenter.mockClear()
     const Harness = defineComponent({
       setup() {
         return () =>
@@ -84,6 +88,7 @@ describe('DownloaderCard', () => {
             'data-draggable': 'true',
             'aria-label': 'qb-main-card',
             class: 'draggable-item',
+            onMouseenter: externalMouseenter,
           })
       },
     })
@@ -98,6 +103,9 @@ describe('DownloaderCard', () => {
     expect(card).toHaveAttribute('aria-label', 'qb-main-card')
     expect(card).toHaveClass('draggable-item', 'app-card-shell', 'app-card-colorful')
     expect(container.querySelectorAll('[data-draggable]')).toHaveLength(1)
+    card?.dispatchEvent(new MouseEvent('mouseenter'))
+    expect(externalMouseenter).toHaveBeenCalledOnce()
+    expect(hoverMouseenter).toHaveBeenCalledOnce()
 
     const attributeWarnings = warn.mock.calls.filter(([message]) =>
       String(message).includes('Extraneous non-props attributes'),


### PR DESCRIPTION
## 背景

系统设置中的下载器列表由拖拽组件向卡片传递非 prop 属性。`DownloaderCard` 以 `VHover` 为根节点，Vue 无法确定这些属性应落到哪个真实 DOM 节点，打开页面时可能产生属性透传 warning。

## 调整

- 关闭组件的隐式属性继承，将外部属性与 hover 属性显式绑定到真实 `VCard`。
- 增加组件测试，确认拖拽属性、ARIA 属性和 class 只落到卡片 DOM，且不产生同类 warning。

下载器排序、刷新、点击和保存逻辑均未改变，页面视觉无变化。

## 验证

- `yarn vitest run src/components/cards/__tests__/DownloaderCard.spec.ts`
- `yarn typecheck`
- `yarn lint`
- 真实 Chrome 打开系统设置：下载器卡片和拖拽把手正常，控制台无相关 warning/error

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 15d26443d7d52ea5e0af56e5d3ffc6e38c5310f9

- 显式将下载器卡片外部属性转发至 `VCard`
- 合并外部与悬停事件监听，保留交互行为
- 避免 `VHover` 根节点属性透传警告
- 新增拖拽、ARIA、样式与事件透传测试
<!-- pr-agent-summary:end -->
