### PR TITLE
fix: 补充智能助手输入字段语义

### DIFF
--- a/src/components/agent/AgentAssistantPanel.vue
+++ b/src/components/agent/AgentAssistantPanel.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { useDisplay } from 'vuetify'
 import { useI18n } from 'vue-i18n'
+import { useId } from 'vue'
 import api, { isApiResponse } from '@/api'
 import { useAuthStore, useUserStore } from '@/stores'
 import { getCurrentLocale } from '@/plugins/i18n'
@@ -343,6 +344,9 @@ const drawerStyle = computed(() => ({
   '--agent-assistant-panel-width': drawerWidth.value,
   zIndex: AGENT_ASSISTANT_LAYER_Z_INDEX.panel,
 }))
+const inputGroupId = useId()
+const fileInputId = `agent-assistant-file-input-${inputGroupId}`
+const messageInputId = `agent-assistant-message-input-${inputGroupId}`
 
 // 创建前端展示用的临时 ID。
 function createId(prefix: string) {
@@ -2765,9 +2769,11 @@ onScopeDispose(() => {
         <div class="agent-assistant-input">
           <input
             ref="fileInputRef"
+            :id="fileInputId"
             class="agent-assistant-file-input"
             type="file"
             multiple
+            name="attachments"
             :disabled="isBusy"
             @change="handleFileSelection"
           />
@@ -2776,14 +2782,17 @@ onScopeDispose(() => {
             :disabled="isBusy || recording"
             :title="t('agentAssistant.attachFile')"
             :aria-label="t('agentAssistant.attachFile')"
+            :aria-controls="fileInputId"
             @click="openFilePicker"
           >
             <VIcon icon="mdi-plus" />
           </IconBtn>
           <textarea
             ref="inputRef"
+            :id="messageInputId"
             v-model="inputText"
             class="agent-assistant-textarea"
+            name="message"
             rows="1"
             :disabled="isBusy || recording"
             :placeholder="inputPlaceholder"

--- a/src/components/agent/__tests__/AgentAssistantPanel.spec.ts
+++ b/src/components/agent/__tests__/AgentAssistantPanel.spec.ts
@@ -207,6 +207,22 @@ describe('AgentAssistantPanel stream recovery', () => {
     vi.useRealTimers()
   })
 
+  it('exposes unique semantic controls for file attachments and messages', () => {
+    const wrapper = mountPanel()
+    const fileInput = wrapper.get('input[type="file"]')
+    const messageInput = wrapper.get('textarea')
+    const attachButton = wrapper.get('.agent-assistant-attach')
+
+    expect(fileInput.attributes('id')).toMatch(/^agent-assistant-file-input-/)
+    expect(fileInput.attributes('name')).toBe('attachments')
+    expect(messageInput.attributes('id')).toMatch(/^agent-assistant-message-input-/)
+    expect(messageInput.attributes('name')).toBe('message')
+    expect(fileInput.attributes('id')).not.toBe(messageInput.attributes('id'))
+    expect(attachButton.attributes('aria-controls')).toBe(fileInput.attributes('id'))
+
+    wrapper.unmount()
+  })
+
   it('toggles the desktop assistant between the side panel and fullscreen modes', async () => {
     displayState.mdAndDown.value = false
     vi.stubGlobal(


### PR DESCRIPTION
## 背景

智能助手面板的隐藏附件输入和消息输入缺少稳定字段语义，浏览器自动填充、可访问性工具及测试无法可靠识别控件；附件按钮与实际文件输入之间也没有显式关联。

## 调整

- 使用 Vue 实例级 ID，为附件输入和消息输入生成唯一标识。
- 分别声明稳定的 `attachments`、`message` 字段名称。
- 通过 `aria-controls` 将附件按钮关联到隐藏文件输入。
- 增加 focused 测试保护字段唯一性和关联关系。

上传、消息发送、快捷键、接口 payload 和视觉表现均未改变。

## 验证

- `yarn vitest run src/components/agent/__tests__/AgentAssistantPanel.spec.ts`（34 个用例通过）
- `yarn typecheck`
- `yarn lint`
- 真实 Chrome 打开智能助手：两个字段 ID/name 唯一，附件按钮关联正确，无相关控制台 warning

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 0f70c01c2be9270ec8881e85edff4719f3623a99

- 为附件和消息输入添加唯一语义标识
- 使用 `useId` 防止组件实例 ID 冲突
- 关联附件按钮与隐藏文件输入
- 新增测试覆盖字段名称与可访问性关系
<!-- pr-agent-summary:end -->
