### PR TITLE
fix: 限定快捷工具关闭事件

### DIFF
--- a/src/components/dialog/ShortcutToolDialog.vue
+++ b/src/components/dialog/ShortcutToolDialog.vue
@@ -14,6 +14,8 @@ const props = withDefaults(
     icon?: string
     maxWidth?: string
     modelValue?: boolean
+    /** 动态视图是否声明并可能触发 close 事件。 */
+    supportsClose?: boolean
     subtitle?: string
     title: string
     view: Component
@@ -25,6 +27,7 @@ const props = withDefaults(
     icon: 'mdi-cog',
     maxWidth: '35rem',
     modelValue: true,
+    supportsClose: false,
     viewProps: () => ({}),
   },
 )
@@ -81,7 +84,7 @@ function closeDialog() {
       </VCardItem>
       <VDivider />
       <VCardText :class="bodyClasses">
-        <Component :is="props.view" v-bind="props.viewProps" @close="closeDialog" />
+        <Component :is="props.view" v-bind="props.viewProps" v-on="props.supportsClose ? { close: closeDialog } : {}" />
       </VCardText>
     </VCard>
   </VDialog>

--- a/src/components/dialog/__tests__/ShortcutToolDialog.spec.ts
+++ b/src/components/dialog/__tests__/ShortcutToolDialog.spec.ts
@@ -2,12 +2,21 @@ import ShortcutToolDialog from '@/components/dialog/ShortcutToolDialog.vue'
 import { screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { renderWithProviders } from '@tests/support/render'
-import { defineComponent, markRaw } from 'vue'
-import { describe, expect, it } from 'vitest'
+import { defineComponent, h, markRaw } from 'vue'
+import { describe, expect, it, vi } from 'vitest'
 
 const ToolView = defineComponent({
   emits: ['close'],
   template: '<button type="button" @click="$emit(\'close\')">关闭工具</button>',
+})
+
+const FragmentToolView = defineComponent({
+  setup(_, { attrs }) {
+    return () => [
+      h('span', { 'data-testid': 'close-listener-state' }, attrs.onClose ? '已绑定' : '未绑定'),
+      h('span', '普通工具内容'),
+    ]
+  },
 })
 
 describe('ShortcutToolDialog', () => {
@@ -16,6 +25,7 @@ describe('ShortcutToolDialog', () => {
     const result = await renderWithProviders(ShortcutToolDialog, {
       props: {
         modelValue: true,
+        supportsClose: true,
         title: '测试工具',
         view: markRaw(ToolView),
       },
@@ -30,5 +40,27 @@ describe('ShortcutToolDialog', () => {
 
     expect(result.emitted()['update:modelValue']).toEqual([[false]])
     expect(result.emitted().close).toEqual([[]])
+  })
+
+  it('does not pass a close listener to an ordinary fragment view', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    await renderWithProviders(ShortcutToolDialog, {
+      props: {
+        modelValue: true,
+        title: '普通工具',
+        view: markRaw(FragmentToolView),
+      },
+      global: {
+        stubs: {
+          VDialogCloseBtn: true,
+        },
+      },
+    })
+
+    expect(screen.getByTestId('close-listener-state')).toHaveTextContent('未绑定')
+    expect(warn.mock.calls.some(([message]) => String(message).includes('Extraneous non-emits event listeners'))).toBe(
+      false,
+    )
   })
 })

--- a/src/composables/useShortcutTools.ts
+++ b/src/composables/useShortcutTools.ts
@@ -31,6 +31,8 @@ export type ShortcutToolItem = PermissionProtectedItem & {
   dialogSubtitle?: string
   icon: string
   maxWidth?: string
+  /** 动态视图是否声明并可能触发 close 事件。 */
+  supportsClose?: boolean
   subtitle: string
   title: string
   titleText?: string
@@ -50,6 +52,7 @@ export function useShortcutTools() {
       dialog: 'nameTest',
       component: NameTestView,
       maxWidth: '65rem',
+      supportsClose: true,
       titleText: t('shortcut.recognition.title'),
     },
     {
@@ -143,6 +146,7 @@ export function useShortcutTools() {
         icon: item.icon,
         maxWidth: item.maxWidth ?? '35rem',
         subtitle: item.dialogSubtitle,
+        supportsClose: item.supportsClose,
         title: item.titleText ?? item.title,
         view: item.component,
       },


### PR DESCRIPTION
## 背景

快捷工具弹窗此前向所有动态视图统一绑定 `close` listener。定时服务等普通视图既不声明该事件，部分还使用 fragment 根节点，打开弹窗时会持续产生 `Extraneous non-emits event listeners (close)` warning。

## 调整

- 在快捷工具定义中增加显式关闭能力，仅名称识别视图声明支持主动关闭。
- 普通动态视图不再接收无语义的 `close` listener。
- 增加测试，同时保护可关闭视图的外层关闭行为，以及普通 fragment 视图无 listener/warning 的行为。

共享弹窗关闭按钮、各快捷工具业务逻辑和页面视觉均未改变。

## 验证

- `yarn vitest run src/components/dialog/__tests__/ShortcutToolDialog.spec.ts`
- `yarn typecheck`
- `yarn lint`
- 真实 Chrome 打开定时服务快捷弹窗：内容正常渲染，无未声明 `close` listener warning

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at b93a699b00abc2c0d29c6f10ce4ccbb50e51988d

- 按工具能力条件绑定动态 `close` 事件
- 为名称识别工具声明关闭支持
- 避免 Fragment 视图产生 Vue 警告
- 增加可关闭与普通视图测试
<!-- pr-agent-summary:end -->
