### PR TITLE
style: 修复数据库备份面板格式检查

### DIFF
--- a/src/components/system/DatabaseBackupPanel.vue
+++ b/src/components/system/DatabaseBackupPanel.vue
@@ -128,12 +128,7 @@ watch(
         </div>
         <div class="text-body-2 text-medium-emphasis mt-1 d-flex flex-wrap align-center gap-1">
           <span>{{ t('setting.system.dbBackupManagementHint') }}</span>
-          <a
-            :href="databaseBackupGuideUrl"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="text-primary"
-          >
+          <a :href="databaseBackupGuideUrl" target="_blank" rel="noopener noreferrer" class="text-primary">
             {{ t('setting.system.dbBackupRestoreGuide') }}
           </a>
         </div>


### PR DESCRIPTION
PR #717 合并时，`DatabaseBackupPanel.vue` 仍有一处不符合仓库 Prettier 规则的标签换行，导致合并提交上的 `format` 检查失败。

本 PR 仅应用 Prettier 生成的格式结果，不改变数据库备份界面的运行时行为。

验证：

- `yarn prettier --check src/components/system/DatabaseBackupPanel.vue`
- `yarn lint`
- `git diff --check`

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 8df76dceef795eaddccac57d689326ab276e2699

- 格式化备份面板帮助链接标签
- 不改变运行时行为或兼容性
<!-- pr-agent-summary:end -->
