### PR TITLE
fix(resource): group LunaTV quality variants

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -872,6 +872,8 @@ export interface TorrentInfo {
   site_order: number
   // 站点下载器
   site_downloader?: string
+  // 插件声明的目标下载目录，仅用于确认弹窗展示，不作为宿主保存目录
+  download_path?: string
   // 种子名称
   title?: string
   // 种子副标题

--- a/src/components/dialog/AddDownloadDialog.vue
+++ b/src/components/dialog/AddDownloadDialog.vue
@@ -101,10 +101,12 @@ const lunaTVDownloadPath = computed(() => {
   if (props.torrent?.site_downloader !== LUNA_TV_DOWNLOADER) {
     return null
   }
-  return props.torrent.download_path?.trim() || null
+  return props.torrent.download_path?.trim() || ''
 })
 
-const isLunaTVResource = computed(() => lunaTVDownloadPath.value !== null)
+const isLunaTVResource = computed(
+  () => props.torrent?.site_downloader === LUNA_TV_DOWNLOADER,
+)
 
 // 加载目录设置
 async function loadDirectories() {

--- a/src/components/dialog/AddDownloadDialog.vue
+++ b/src/components/dialog/AddDownloadDialog.vue
@@ -38,6 +38,8 @@ const props = defineProps({
   torrent: Object as PropType<TorrentInfo>,
 })
 
+const LUNA_TV_DOWNLOADER = 'LunaTVSource'
+
 // 定义成功和失败事件
 const emit = defineEmits(['done', 'error', 'close'])
 
@@ -94,6 +96,15 @@ const dialogSubtitle = computed(() => {
 
   return [siteName, displayTitle].filter(Boolean).join(' - ')
 })
+
+const lunaTVDownloadPath = computed(() => {
+  if (props.torrent?.site_downloader !== LUNA_TV_DOWNLOADER) {
+    return null
+  }
+  return props.torrent.download_path?.trim() || null
+})
+
+const isLunaTVResource = computed(() => lunaTVDownloadPath.value !== null)
 
 // 加载目录设置
 async function loadDirectories() {
@@ -162,8 +173,9 @@ async function addDownload() {
       torrent_in: TorrentInfo | undefined
     } = {
       torrent_in: props.torrent,
-      downloader: selectedDownloader.value,
-      save_path: selectedDirectory.value,
+      downloader: isLunaTVResource.value ? LUNA_TV_DOWNLOADER : selectedDownloader.value,
+      // LunaTV 的目录由插件自行处理，不能作为宿主保存目录提交。
+      save_path: isLunaTVResource.value ? null : selectedDirectory.value,
     }
 
     if (props.media) {
@@ -258,7 +270,17 @@ onMounted(() => {
         </VList>
         <VRow class="px-5">
           <VCol cols="12" md="6">
+            <VTextField
+              v-if="isLunaTVResource"
+              :model-value="LUNA_TV_DOWNLOADER"
+              :label="t('dialog.addDownload.downloader')"
+              variant="underlined"
+              density="comfortable"
+              prepend-inner-icon="mdi-download"
+              readonly
+            />
             <VSelect
+              v-else
               v-model="selectedDownloader"
               :items="downloaderOptions"
               :label="t('dialog.addDownload.downloader')"
@@ -269,7 +291,17 @@ onMounted(() => {
             />
           </VCol>
           <VCol cols="12" md="6">
+            <VTextField
+              v-if="isLunaTVResource"
+              :model-value="lunaTVDownloadPath ?? ''"
+              :label="t('dialog.addDownload.saveDirectory')"
+              variant="underlined"
+              density="comfortable"
+              prepend-inner-icon="mdi-folder"
+              readonly
+            />
             <VCombobox
+              v-else
               v-model="selectedDirectory"
               :items="targetDirectories"
               :label="t('dialog.addDownload.saveDirectory')"

--- a/src/components/dialog/TorrentMoreSourcesDialog.vue
+++ b/src/components/dialog/TorrentMoreSourcesDialog.vue
@@ -94,6 +94,15 @@ function handleDetail(item: Context) {
                 </VChip>
 
                 <VChip
+                  v-if="item.meta_info?.resource_pix"
+                  class="chip-resolution rounded-sm ml-1"
+                  size="x-small"
+                  variant="elevated"
+                >
+                  {{ item.meta_info.resource_pix }}
+                </VChip>
+
+                <VChip
                   v-if="item.torrent_info?.downloadvolumefactor !== 1 || item.torrent_info?.uploadvolumefactor !== 1"
                   :class="
                     getPromotionChipClass(
@@ -145,6 +154,11 @@ function handleDetail(item: Context) {
 
 .chip-season {
   background-color: #3f51b5;
+  color: white;
+}
+
+.chip-resolution {
+  background-color: #7b1fa2;
   color: white;
 }
 

--- a/src/components/dialog/__tests__/AddDownloadDialog.spec.ts
+++ b/src/components/dialog/__tests__/AddDownloadDialog.spec.ts
@@ -65,6 +65,7 @@ const TextFieldStub = defineComponent({
   props: {
     label: String,
     modelValue: { type: String, default: '' },
+    readonly: Boolean,
   },
   emits: ['click:append-inner', 'update:modelValue'],
   setup(props, { emit }) {
@@ -73,6 +74,7 @@ const TextFieldStub = defineComponent({
         props.label,
         h('input', {
           'aria-label': props.label,
+          'readonly': props.readonly,
           'value': props.modelValue ?? '',
           'onInput': (event: Event) => emit('update:modelValue', (event.target as HTMLInputElement).value),
         }),
@@ -418,5 +420,45 @@ describe('AddDownloadDialog submissions', () => {
     expect(mocks.startNProgress).toHaveBeenCalledOnce()
     expect(events.done).not.toHaveBeenCalled()
     expect(screen.getByRole('button', { name: '开始下载' })).not.toBeDisabled()
+  })
+})
+
+describe('AddDownloadDialog LunaTV contract', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+
+  it('locks fields and keeps its plugin directory out of host save_path', async () => {
+    const submitted = vi.fn()
+    const torrent = createTorrent({
+      download_path: '/media/incoming',
+      site_downloader: 'LunaTVSource',
+    })
+    server.use(downloadHandler('download/add', { data: null, success: true }, 200, submitted))
+    const user = userEvent.setup()
+
+    await renderDialog({
+      directories: [createDirectory({ download_path: '/downloads/host' })],
+      downloaders: [{ name: '下载器 A', type: 'qbittorrent' }],
+      torrent,
+    })
+
+    const downloader = await screen.findByLabelText('下载器（默认）')
+    const saveDirectory = screen.getByLabelText('保存目录（自动）')
+    expect(downloader).toHaveValue('LunaTVSource')
+    expect(downloader).toHaveAttribute('readonly')
+    expect(saveDirectory).toHaveValue('/media/incoming')
+    expect(saveDirectory).toHaveAttribute('readonly')
+
+    await user.click(screen.getByRole('button', { name: '开始下载' }))
+
+    await waitFor(() => expect(submitted).toHaveBeenCalledOnce())
+    expect(submitted.mock.calls[0][0]).toEqual({
+      downloader: 'LunaTVSource',
+      save_path: null,
+      torrent_in: torrent,
+    })
   })
 })

--- a/src/components/dialog/__tests__/AddDownloadDialog.spec.ts
+++ b/src/components/dialog/__tests__/AddDownloadDialog.spec.ts
@@ -461,4 +461,29 @@ describe('AddDownloadDialog LunaTV contract', () => {
       torrent_in: torrent,
     })
   })
+
+  it('keeps LunaTV locked when the optional display path is missing', async () => {
+    const submitted = vi.fn()
+    const torrent = createTorrent({ site_downloader: 'LunaTVSource' })
+    server.use(downloadHandler('download/add', { data: null, success: true }, 200, submitted))
+    const user = userEvent.setup()
+
+    await renderDialog({
+      directories: [createDirectory({ download_path: '/downloads/host' })],
+      downloaders: [{ name: '下载器 A', type: 'qbittorrent' }],
+      torrent,
+    })
+
+    expect(await screen.findByLabelText('下载器（默认）')).toHaveValue('LunaTVSource')
+    expect(screen.getByLabelText('保存目录（自动）')).toHaveValue('')
+
+    await user.click(screen.getByRole('button', { name: '开始下载' }))
+
+    await waitFor(() => expect(submitted).toHaveBeenCalledOnce())
+    expect(submitted.mock.calls[0][0]).toEqual({
+      downloader: 'LunaTVSource',
+      save_path: null,
+      torrent_in: torrent,
+    })
+  })
 })

--- a/src/components/dialog/__tests__/TorrentMoreSourcesDialog.spec.ts
+++ b/src/components/dialog/__tests__/TorrentMoreSourcesDialog.spec.ts
@@ -1,0 +1,40 @@
+import type { Context } from '@/api/types'
+import TorrentMoreSourcesDialog from '@/components/dialog/TorrentMoreSourcesDialog.vue'
+import { renderWithProviders } from '@tests/support/render'
+import { screen } from '@testing-library/vue'
+import { describe, expect, it } from 'vitest'
+
+function createSource(resolution: string): Context {
+  return {
+    media_info: {},
+    meta_info: {
+      edition: 'WEB-DL',
+      name: '测试媒体',
+      resource_pix: resolution,
+      resource_team: 'Team A',
+      season_episode: 'S01',
+    },
+    torrent_info: {
+      page_url: 'https://example.test/' + resolution,
+      seeders: 1,
+      site_name: '测试站点',
+      size: 1,
+      title: '测试资源 ' + resolution,
+      volume_factor: 'FREE',
+    },
+  } as Context
+}
+
+describe('TorrentMoreSourcesDialog', () => {
+  it('shows each alternative source resolution', async () => {
+    await renderWithProviders(TorrentMoreSourcesDialog, {
+      props: {
+        modelValue: true,
+        items: [createSource('720p'), createSource('480p')],
+      },
+    })
+
+    expect(screen.getByText('720p')).toBeInTheDocument()
+    expect(screen.getByText('480p')).toBeInTheDocument()
+  })
+})

--- a/src/composables/__tests__/useTorrentFilter.spec.ts
+++ b/src/composables/__tests__/useTorrentFilter.spec.ts
@@ -9,6 +9,7 @@ vi.mock('vue-i18n', () => ({
 interface TorrentOverrides {
   edition?: string
   freeState?: string
+  mediaTitleYear?: string
   name?: string
   pageUrl?: string
   priOrder?: number
@@ -21,11 +22,14 @@ interface TorrentOverrides {
   size?: number
   title?: string
   videoCode?: string
+  year?: string
 }
 
 function createTorrent(overrides: TorrentOverrides = {}): Context {
   return {
-    media_info: {},
+    media_info: {
+      title_year: overrides.mediaTitleYear,
+    },
     meta_info: {
       edition: overrides.edition ?? 'WEB-DL',
       name: overrides.name ?? '测试媒体',
@@ -33,6 +37,7 @@ function createTorrent(overrides: TorrentOverrides = {}): Context {
       resource_team: overrides.releaseGroup ?? 'Team A',
       season_episode: overrides.season ?? 'S01',
       video_encode: overrides.videoCode ?? 'H.264',
+      year: overrides.year,
     },
     torrent_info: {
       page_url: overrides.pageUrl ?? `https://example.test/${overrides.title ?? 'torrent'}`,
@@ -141,6 +146,37 @@ describe('useTorrentFilter', () => {
     expect(result[0].more?.map(item => item.torrent_info.title)).toEqual(['同组二'])
     expect(filter.totalFilteredCount.value).toBe(2)
     expect(filter.getFilteredIndices()).toEqual([0, 1])
+  })
+
+  it('groups different resolutions into more sources while preserving the first resource as the card', () => {
+    const filter = useTorrentFilter()
+    const torrents = [
+      createTorrent({ resolution: '1080p', title: '高清主资源' }),
+      createTorrent({ resolution: '720p', title: '低清来源' }),
+      createTorrent({ season: 'S02', resolution: '1080p', title: '另一季' }),
+    ]
+
+    const result = filter.filterCardData(torrents)
+
+    expect(result).toHaveLength(2)
+    expect(result[0].torrent_info.title).toBe('高清主资源')
+    expect(result[0].meta_info.resource_pix).toBe('1080p')
+    expect(result[0].more?.map(item => item.meta_info.resource_pix)).toEqual(['720p'])
+    expect(result[1].torrent_info.title).toBe('另一季')
+    expect(result[1].more).toBeUndefined()
+  })
+
+  it('keeps different media years in separate cards', () => {
+    const filter = useTorrentFilter()
+    const torrents = [
+      createTorrent({ mediaTitleYear: '测试媒体 (2025)', title: '2025 资源' }),
+      createTorrent({ mediaTitleYear: '测试媒体 (2026)', title: '2026 资源' }),
+    ]
+
+    const result = filter.filterCardData(torrents)
+
+    expect(result.map(item => item.torrent_info.title)).toEqual(['2025 资源', '2026 资源'])
+    expect(result.every(item => item.more === undefined)).toBe(true)
   })
 
   it.each([

--- a/src/composables/__tests__/useTorrentFilter.spec.ts
+++ b/src/composables/__tests__/useTorrentFilter.spec.ts
@@ -148,11 +148,11 @@ describe('useTorrentFilter', () => {
     expect(filter.getFilteredIndices()).toEqual([0, 1])
   })
 
-  it('groups different resolutions into more sources while preserving the first resource as the card', () => {
+  it('groups different sizes and selects the highest resolution as the card', () => {
     const filter = useTorrentFilter()
     const torrents = [
-      createTorrent({ resolution: '1080p', title: '高清主资源' }),
-      createTorrent({ resolution: '720p', title: '低清来源' }),
+      createTorrent({ resolution: '720p', size: 700, title: '低清先返回' }),
+      createTorrent({ resolution: '1080p', size: 1500, title: '高清主资源' }),
       createTorrent({ season: 'S02', resolution: '1080p', title: '另一季' }),
     ]
 
@@ -162,8 +162,22 @@ describe('useTorrentFilter', () => {
     expect(result[0].torrent_info.title).toBe('高清主资源')
     expect(result[0].meta_info.resource_pix).toBe('1080p')
     expect(result[0].more?.map(item => item.meta_info.resource_pix)).toEqual(['720p'])
+    expect(filter.getFilteredIndices()).toEqual([1, 0, 2])
     expect(result[1].torrent_info.title).toBe('另一季')
     expect(result[1].more).toBeUndefined()
+  })
+
+  it('keeps different sources in separate cards', () => {
+    const filter = useTorrentFilter()
+    const torrents = [
+      createTorrent({ resolution: '1080p', site: '来源 A · 31ms', title: '来源 A' }),
+      createTorrent({ resolution: '720p', site: '来源 B · 42ms', title: '来源 B' }),
+    ]
+
+    const result = filter.filterCardData(torrents)
+
+    expect(result.map(item => item.torrent_info.title)).toEqual(['来源 A', '来源 B'])
+    expect(result.every(item => item.more === undefined)).toBe(true)
   })
 
   it('keeps different media years in separate cards', () => {

--- a/src/composables/useTorrentFilter.ts
+++ b/src/composables/useTorrentFilter.ts
@@ -242,7 +242,10 @@ export function useTorrentFilter() {
       // init options
       initOptions(item)
       // group data
-      const key = `${meta_info.name}_${meta_info.resource_pix}_${meta_info.edition}_${meta_info.resource_team}_${meta_info.season_episode}_${torrent_info.size}`
+      // 分辨率用于卡片主资源的质量展示，不参与归组；同一资源的不同清晰度放入更多来源。
+      const mediaKey =
+        item.media_info?.title_year || [meta_info.name, meta_info.year].filter(Boolean).join('_')
+      const key = `${mediaKey}_${meta_info.edition}_${meta_info.resource_team}_${meta_info.season_episode}_${torrent_info.size}`
       const groupedItem = { data: item, originalIndex: index }
       if (groupMap.has(key)) {
         const group = groupMap.get(key)

--- a/src/composables/useTorrentFilter.ts
+++ b/src/composables/useTorrentFilter.ts
@@ -12,6 +12,19 @@ interface GroupedItem {
   originalIndex: number
 }
 
+function resolutionRank(value?: string): number {
+  const normalized = value?.trim().toUpperCase() ?? ''
+  if (normalized.includes('8K')) return 4320
+  if (normalized.includes('4K') || normalized.includes('UHD')) return 2160
+  if (normalized.includes('2K')) return 1440
+  if (normalized.includes('FHD')) return 1080
+  const numeric = normalized.match(/(\d{3,4})\s*[PI]?/)
+  if (numeric) return Number(numeric[1])
+  if (normalized === 'HD') return 720
+  if (normalized === 'SD') return 480
+  return 0
+}
+
 // 筛选状态类型
 export interface FilterState {
   filterForm: Record<string, string[]>
@@ -245,7 +258,9 @@ export function useTorrentFilter() {
       // 分辨率用于卡片主资源的质量展示，不参与归组；同一资源的不同清晰度放入更多来源。
       const mediaKey =
         item.media_info?.title_year || [meta_info.name, meta_info.year].filter(Boolean).join('_')
-      const key = `${mediaKey}_${meta_info.edition}_${meta_info.resource_team}_${meta_info.season_episode}_${torrent_info.size}`
+      const sourceKey =
+        torrent_info.site ?? torrent_info.site_name?.replace(/· \d+ms$/i, '').trim()
+      const key = `${mediaKey}_${sourceKey}_${meta_info.edition}_${meta_info.resource_team}_${meta_info.season_episode}`
       const groupedItem = { data: item, originalIndex: index }
       if (groupMap.has(key)) {
         const group = groupMap.get(key)
@@ -277,13 +292,20 @@ export function useTorrentFilter() {
         })
         if (matchData.length > 0) {
           matchCount += matchData.length
-          const firstItem = matchData[0]
+          const qualityOrdered = [...matchData].sort(
+            (left, right) =>
+              resolutionRank(right.data.meta_info.resource_pix) -
+                resolutionRank(left.data.meta_info.resource_pix) ||
+              left.originalIndex - right.originalIndex,
+          )
+          const firstItem = qualityOrdered[0]
           const firstData = cloneDeepWith(firstItem.data) as SearchTorrent
-          if (matchData.length > 1) firstData.more = matchData.slice(1).map(x => x.data)
+          if (qualityOrdered.length > 1)
+            firstData.more = qualityOrdered.slice(1).map(item => item.data)
           filteredData.push(firstData)
           groupIndicesMap.set(
             firstData,
-            matchData.map(item => item.originalIndex),
+            qualityOrdered.map(item => item.originalIndex),
           )
         }
       }


### PR DESCRIPTION
## Changes
- group the same title, year, season, edition and source across resolutions
- keep the highest-quality LunaTV result as the main card and show lower qualities in More Sources
- display each alternative source resolution
- lock the LunaTV downloader and plugin-managed save directory in the download dialog

## Validation
- 26 focused Vitest tests passed
- vue-tsc --noEmit passed
- ESLint passed for changed files
- production Vite build passed

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 1c7717befcd82dc77910ef25531c3b55d10e3ca6

- 按媒体、来源与版本合并 LunaTV 清晰度变体
- 最高分辨率作为主卡，其他置入更多来源
- 更多来源展示各资源分辨率
- 锁定 LunaTV 下载器和目录展示，避免提交宿主路径
- 扩展分组与下载弹窗契约测试
<!-- pr-agent-summary:end -->
