### PR TITLE
fix: 更新插件时保留已绑定仓库

### DIFF
--- a/src/components/cards/PluginCard.vue
+++ b/src/components/cards/PluginCard.vue
@@ -307,7 +307,7 @@ async function resetPlugin() {
 }
 
 // 更新插件
-async function updatePlugin(releaseVersion?: string) {
+async function updatePlugin(releaseVersion?: string, repoUrl?: string) {
   if (!releaseVersion && props.plugin?.system_version_compatible === false) {
     $toast.error(props.plugin?.system_version_message || t('plugin.incompatibleSystemVersion'))
     return
@@ -338,6 +338,7 @@ async function updatePlugin(releaseVersion?: string) {
       params: {
         release_version: releaseVersion,
         force: true,
+        ...(repoUrl ? { repo_url: repoUrl } : {}),
       },
     })
 

--- a/src/components/cards/__tests__/PluginCard.spec.ts
+++ b/src/components/cards/__tests__/PluginCard.spec.ts
@@ -189,6 +189,7 @@ describe('PluginCard lifecycle actions', () => {
       params: {
         force: true,
         release_version: '0.9.0',
+        repo_url: 'https://github.com/example/releases',
       },
     })
     expect(mocks.confirm).toHaveBeenCalledWith(expect.objectContaining({ content: expect.stringContaining('v0.9.0') }))

--- a/src/components/dialog/PluginMarketDetailDialog.vue
+++ b/src/components/dialog/PluginMarketDetailDialog.vue
@@ -369,6 +369,7 @@ async function installPlugin(releaseVersion?: string, repoUrl?: string) {
         params: {
           release_version: releaseVersion,
           force: isInstalled.value || props.plugin?.has_update || Boolean(releaseVersion),
+          ...(selectedRepoUrl ? { repo_url: selectedRepoUrl } : {}),
         },
         feedback: 'silent',
       })

--- a/src/components/dialog/__tests__/PluginMarketDetailDialog.spec.ts
+++ b/src/components/dialog/__tests__/PluginMarketDetailDialog.spec.ts
@@ -655,6 +655,7 @@ describe('PluginMarketDetailDialog', () => {
       params: {
         force: true,
         release_version: undefined,
+        repo_url: 'https://github.com/example/releases',
       },
     })
     expect(mocks.toastSuccess).toHaveBeenCalledWith('插件 演示插件 更新成功！')


### PR DESCRIPTION
## 问题

插件版本历史已经能解析当前绑定仓库，但卡片和详情弹窗在执行普通更新时会丢弃该参数，只向后端发送插件 ID 和版本。存在本地开发载荷时，后端因此无法校验用户正在更新的绑定仓库。

## 调整

- 插件卡片更新方法继续接收版本历史返回的仓库地址，并通过 `repo_url` 传给普通更新接口；
- 插件详情中的当前版本和历史版本更新同样保留所选绑定仓库；
- 不改变来源选择、绑定或换仓交互，不增加新的确认弹窗。

后端仍会把该参数作为绑定仓库一致性提示，而不是选源授权；显式绑定和换仓继续使用原有独立接口。

配套后端：jxxghp/MoviePilot#6482

## 验证

- 组件测试：`60 passed`
- `yarn typecheck`：通过
- `yarn lint`：通过
- `yarn lint:suppressions:prune`：通过
- `git diff --check`：通过

本 PR 不改变可见 UI，无新增截图。

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 4f8f8102f33bc0b53c2c5c112357428ab9a70a9d

- 更新插件时保留已绑定仓库
- 卡片更新透传 `repo_url`
- 详情更新使用选中仓库地址
- 补充仓库参数的组件测试
<!-- pr-agent-summary:end -->
