### PR TITLE
fix(plugin): 修复未绑定来源插件无法重新安装

### DIFF
--- a/src/api/pluginSource.ts
+++ b/src/api/pluginSource.ts
@@ -14,6 +14,29 @@ export function getPluginSourceOptions(pluginId: string, force = false): Promise
   })
 }
 
+/** 判断未安装插件是否必须由管理员明确选择在线仓库后安装。 */
+export function requiresExplicitPluginSourceInstall(options: PluginSourceOptions, installed: boolean): boolean {
+  if (installed) return false
+
+  const onlineCandidates = options.candidates.filter(
+    candidate => candidate.source_type !== 'local' && Boolean(candidate.source_key && candidate.repo_url),
+  )
+  if (onlineCandidates.length === 0) return false
+  if (options.selection_status === 'conflict') return true
+
+  const identity = options.identity
+  const hasTrustedOnlineSource = Boolean(
+    identity && identity.trusted_source_type !== 'unknown' && identity.trusted_source_key,
+  )
+  if (options.selection_status === 'incomplete' && !hasTrustedOnlineSource) return true
+
+  return (
+    options.selection_status === 'selected' &&
+    onlineCandidates.length === 1 &&
+    onlineCandidates[0].source_type === 'third_party'
+  )
+}
+
 /** 按管理员明确选择的在线来源安装未绑定插件。 */
 export function installPluginFromSource(
   pluginId: string,

--- a/src/components/dialog/PluginMarketDetailDialog.vue
+++ b/src/components/dialog/PluginMarketDetailDialog.vue
@@ -1,7 +1,11 @@
 <script lang="ts" setup>
 import api from '@/api'
 import { getApiBusinessErrorMessage, isApiBusinessFailure } from '@/api/client'
-import { getPluginSourceOptions, installPluginFromSource } from '@/api/pluginSource'
+import {
+  getPluginSourceOptions,
+  installPluginFromSource,
+  requiresExplicitPluginSourceInstall,
+} from '@/api/pluginSource'
 import type {
   Plugin,
   PluginInstallOutcome,
@@ -98,15 +102,9 @@ const onlineSourceCandidates = computed(() =>
     // 官方仓库是默认可信来源，在所有选源入口中始终置顶。
     .sort((left, right) => Number(right.source_type === 'official') - Number(left.source_type === 'official')),
 )
-const sourceNeedsSelection = computed(() => {
-  if (isInstalled.value) return false
-  if (sourceOptions.value?.selection_status === 'conflict') return true
-  return (
-    sourceOptions.value?.selection_status === 'selected' &&
-    onlineSourceCandidates.value.length === 1 &&
-    onlineSourceCandidates.value[0].source_type === 'third_party'
-  )
-})
+const sourceNeedsSelection = computed(() =>
+  sourceOptions.value ? requiresExplicitPluginSourceInstall(sourceOptions.value, isInstalled.value) : false,
+)
 const sourceHasConflict = computed(() => sourceOptions.value?.selection_status === 'conflict')
 const selectedInstallSource = computed(() =>
   onlineSourceCandidates.value.find(candidate => candidate.source_key === selectedInstallSourceKey.value),
@@ -121,6 +119,9 @@ const hasTrustedOnlineSource = computed(() => {
 const sourceNeedsInitialBinding = computed(
   () => isInstalled.value && !hasTrustedOnlineSource.value && onlineSourceCandidates.value.length > 0,
 )
+const sourceNeedsReinstallBinding = computed(
+  () => !isInstalled.value && sourceOptions.value?.selection_status === 'incomplete' && sourceNeedsSelection.value,
+)
 const changeSourceCandidates = computed(() => {
   const trustedSourceKey = sourceOptions.value?.identity?.trusted_source_key
   return onlineSourceCandidates.value.filter(candidate => candidate.source_key !== trustedSourceKey)
@@ -130,6 +131,7 @@ const sourceActionCandidates = computed(() =>
 )
 const sourceUnavailable = computed(() => {
   const unavailable = ['unavailable', 'incomplete'].includes(sourceOptions.value?.selection_status || '')
+  if (sourceNeedsSelection.value) return false
   if (!isInstalled.value) return unavailable
   // 未绑定但仍有候选时，优先展示首次绑定流程；已绑定来源失效则必须阻止普通更新。
   if (sourceNeedsInitialBinding.value) return false
@@ -544,12 +546,18 @@ onUnmounted(() => {
               <h3 id="plugin-source-title" class="plugin-market-detail-source__title">
                 {{ t('plugin.source') }}
                 <VChip v-if="sourceNeedsSelection" size="x-small" color="warning" variant="tonal">
-                  {{ t(sourceHasConflict ? 'plugin.sourceSelectionRequired' : 'plugin.sourceConfirmationRequired') }}
+                  {{
+                    t(
+                      sourceHasConflict || onlineSourceCandidates.length > 1
+                        ? 'plugin.sourceSelectionRequired'
+                        : 'plugin.sourceConfirmationRequired',
+                    )
+                  }}
                 </VChip>
               </h3>
               <p class="plugin-market-detail-source__hint">
                 {{
-                  sourceNeedsInitialBinding
+                  sourceNeedsInitialBinding || sourceNeedsReinstallBinding
                     ? t('plugin.sourceBindingHint')
                     : isInstalled
                       ? t('plugin.sourceInstalledHint')

--- a/src/components/dialog/__tests__/PluginMarketDetailDialog.spec.ts
+++ b/src/components/dialog/__tests__/PluginMarketDetailDialog.spec.ts
@@ -185,6 +185,77 @@ describe('PluginMarketDetailDialog', () => {
     expect(emitted().install).toHaveLength(1)
   })
 
+  it('reinstalls an unbound market plugin after explicitly confirming its repository', async () => {
+    mocks.apiGet.mockImplementation((url: string) => {
+      if (url === 'plugin/rating/DemoPlugin') return Promise.resolve(ratingResult)
+      if (url === 'plugin/source/DemoPlugin/options') {
+        return Promise.resolve({
+          ...defaultSourceOptions,
+          selection_status: 'incomplete',
+          selection_reason: '当前插件尚未绑定仓库',
+          identity: {
+            plugin_id: 'DemoPlugin',
+            trusted_source_type: 'unknown',
+            trusted_source_key: null,
+            binding_basis: 'legacy_unbound',
+            payload_source_type: 'unknown',
+            payload_source_key: null,
+            revision: 2,
+          },
+        } satisfies PluginSourceOptions)
+      }
+      return Promise.resolve({ success: true })
+    })
+    const { emitted } = await renderDialog({ ...basePlugin, installed: false })
+
+    expect(await screen.findByText('当前插件尚未绑定，请选择仓库。')).toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: /example\/plugins/ })).toBeChecked()
+    const installButton = screen.getByRole('button', { name: '安装到本地' })
+    expect(installButton).toBeEnabled()
+
+    await fireEvent.click(installButton)
+
+    await waitFor(() => {
+      expect(mocks.apiPost).toHaveBeenCalledWith('plugin/source/DemoPlugin/install', {
+        repo_url: 'https://github.com/example/plugins',
+        release_version: undefined,
+        force: false,
+      })
+    })
+    expect(mocks.apiGet).not.toHaveBeenCalledWith('plugin/install/DemoPlugin', expect.anything())
+    expect(emitted().install).toHaveLength(1)
+  })
+
+  it('keeps an unbound market plugin unavailable when no online repository is known', async () => {
+    mocks.apiGet.mockImplementation((url: string) => {
+      if (url === 'plugin/rating/DemoPlugin') return Promise.resolve(ratingResult)
+      if (url === 'plugin/source/DemoPlugin/options') {
+        return Promise.resolve({
+          ...defaultSourceOptions,
+          selection_status: 'incomplete',
+          selection_reason: '当前插件尚未绑定仓库',
+          identity: {
+            plugin_id: 'DemoPlugin',
+            trusted_source_type: 'unknown',
+            trusted_source_key: null,
+            binding_basis: 'legacy_unbound',
+            payload_source_type: 'unknown',
+            payload_source_key: null,
+            revision: 2,
+          },
+          candidates: [],
+        } satisfies PluginSourceOptions)
+      }
+      return Promise.resolve({ success: true })
+    })
+    await renderDialog({ ...basePlugin, installed: false })
+
+    expect(await screen.findByText('当前插件尚未绑定仓库')).toBeInTheDocument()
+    expect(screen.queryByRole('radio')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '安装到本地' })).toBeDisabled()
+    expect(mocks.apiPost).not.toHaveBeenCalled()
+  })
+
   it('shows trusted and local payload sources separately and changes source with the current revision', async () => {
     mocks.apiGet.mockImplementation((url: string) => {
       if (url === 'plugin/rating/DemoPlugin') return Promise.resolve(ratingResult)

--- a/src/views/plugin/PluginCardListView.vue
+++ b/src/views/plugin/PluginCardListView.vue
@@ -2,7 +2,12 @@
 import { useToast } from 'vue-toastification'
 import api from '@/api'
 import { getApiBusinessErrorMessage } from '@/api/client'
-import { changePluginSource, getPluginSourceOptions, installPluginFromSource } from '@/api/pluginSource'
+import {
+  changePluginSource,
+  getPluginSourceOptions,
+  installPluginFromSource,
+  requiresExplicitPluginSourceInstall,
+} from '@/api/pluginSource'
 import type {
   Plugin,
   PluginInstallOutcome,
@@ -888,12 +893,17 @@ async function installPlugin(
   let useExplicitSource = false
   try {
     const sourceOptions = inspectedSourceOptions || (await getPluginSourceOptions(pluginId))
-    if (sourceOptions.selection_status === 'conflict') {
-      if (!repoUrl) {
-        releaseInstallReservation()
-        openPluginMarketDetail(item)
-        return
-      }
+    const sourceRequiresExplicitInstall =
+      sourceOptions.selection_status === 'conflict' ||
+      (sourceOptions.selection_status === 'incomplete' &&
+        requiresExplicitPluginSourceInstall(sourceOptions, Boolean(item.installed)))
+    if (sourceRequiresExplicitInstall && !repoUrl) {
+      releaseInstallReservation()
+      openPluginMarketDetail(item)
+      return
+    }
+    if (repoUrl) {
+      // 上层确认的仓库必须属于同一来源快照，避免用户选择在安装事务中被静默丢弃。
       const selectedCandidate = sourceOptions.candidates.find(
         candidate => candidate.repo_url === repoUrl && candidate.source_type !== 'local',
       )

--- a/src/views/plugin/__tests__/PluginCardListView.spec.ts
+++ b/src/views/plugin/__tests__/PluginCardListView.spec.ts
@@ -1526,6 +1526,100 @@ describe('PluginCardListView search installation', () => {
     await waitForRequestsToFinish()
   })
 
+  it('preserves an explicitly confirmed third-party source from the detail dialog', async () => {
+    let requestBody: unknown
+    let ordinaryInstallRequests = 0
+    const target = createPlugin({ id: 'ConfirmedPlugin', plugin_name: '确认来源插件' })
+    const sourceOptions: PluginSourceOptions = {
+      plugin_id: 'ConfirmedPlugin',
+      inventory_complete: true,
+      selection_status: 'selected',
+      selection_reason: '唯一在线来源',
+      identity: null,
+      candidates: [
+        {
+          source_type: 'third_party',
+          source_key: 'github:example/plugins',
+          repo_url: 'https://github.com/example/plugins',
+          package_generation: 'v3',
+          plugin_version: '1.0.0',
+        },
+      ],
+    }
+    await renderList({ market: () => [target] })
+    await waitForRequestsToFinish()
+    server.use(
+      http.post(apiUrls.sourceBind('ConfirmedPlugin'), async ({ request }) => {
+        requestBody = await request.json()
+        return apiJson(null)
+      }),
+      http.get(apiUrls.install('ConfirmedPlugin'), () => {
+        ordinaryInstallRequests += 1
+        return apiJson(null)
+      }),
+    )
+
+    getDynamicButtonConfig().onClick()
+    await getDialogEvents()['open-plugin'](target)
+    await getDialogProps().installHandler?.(undefined, 'https://github.com/example/plugins', sourceOptions)
+
+    await waitFor(() => expect(mocks.toastSuccess).toHaveBeenCalledWith('插件 确认来源插件 安装成功！'))
+    expect(requestBody).toEqual({
+      force: false,
+      repo_url: 'https://github.com/example/plugins',
+    })
+    expect(ordinaryInstallRequests).toBe(0)
+    await waitForRequestsToFinish()
+  })
+
+  it('uses the explicitly selected source to reinstall an unbound market plugin', async () => {
+    let requestBody: unknown
+    const target = createPlugin({ id: 'LegacyPlugin', plugin_name: '存量插件' })
+    const sourceOptions: PluginSourceOptions = {
+      plugin_id: 'LegacyPlugin',
+      inventory_complete: true,
+      selection_status: 'incomplete',
+      selection_reason: '当前插件尚未绑定仓库',
+      identity: {
+        plugin_id: 'LegacyPlugin',
+        trusted_source_type: 'unknown',
+        trusted_source_key: null,
+        binding_basis: 'legacy_unbound',
+        payload_source_type: 'unknown',
+        payload_source_key: null,
+        revision: 2,
+      },
+      candidates: [
+        {
+          source_type: 'third_party',
+          source_key: 'github:example/plugins',
+          repo_url: 'https://github.com/example/plugins',
+          package_generation: 'v3',
+          plugin_version: '1.0.0',
+        },
+      ],
+    }
+    await renderList({ market: () => [target] })
+    await waitForRequestsToFinish()
+    server.use(
+      http.post(apiUrls.sourceBind('LegacyPlugin'), async ({ request }) => {
+        requestBody = await request.json()
+        return apiJson(null)
+      }),
+    )
+
+    getDynamicButtonConfig().onClick()
+    await getDialogEvents()['open-plugin'](target)
+    await getDialogProps().installHandler?.(undefined, 'https://github.com/example/plugins', sourceOptions)
+
+    await waitFor(() => expect(mocks.toastSuccess).toHaveBeenCalledWith('插件 存量插件 安装成功！'))
+    expect(requestBody).toEqual({
+      force: false,
+      repo_url: 'https://github.com/example/plugins',
+    })
+    await waitForRequestsToFinish()
+  })
+
   it('opens source selection instead of silently installing a conflicting plugin ID', async () => {
     let installRequests = 0
     const target = createPlugin({ id: 'ConflictPlugin', plugin_name: '重名插件' })


### PR DESCRIPTION
## 问题

卸载过的存量插件可能保留未绑定的来源身份。后端此时会返回 `incomplete`，即使市场中仍有可用在线候选，详情弹窗也会把来源视为不可用，导致“安装到本地”按钮置灰且没有选仓入口。

## 调整

- 允许未安装且来源未绑定的插件在存在在线候选时明确选择仓库后重新安装。
- 将详情弹窗确认的仓库继续透传到列表安装事务，并校验仓库属于同一来源快照后调用显式来源安装接口。
- 保持无在线候选的 `incomplete` 状态不可安装，继续由后端执行最终来源准入和绑定。

## 验证

- `yarn typecheck`
- `yarn lint`
- `yarn lint:suppressions:prune`
- `yarn vitest run src/components/dialog/__tests__/PluginMarketDetailDialog.spec.ts src/views/plugin/__tests__/PluginCardListView.spec.ts`（79 passed）
- `git diff --check`
