### PR TITLE
修复文件删除后的重复刷新

### DIFF
--- a/src/components/filebrowser/FileBrowser.vue
+++ b/src/components/filebrowser/FileBrowser.vue
@@ -342,7 +342,6 @@ onUnmounted(cleanupDrag)
           @pathchanged="pathChanged"
           @loading="loadingChanged"
           @refreshed="refreshPending = false"
-          @filedeleted="refreshPending = true"
           @renamed="refreshPending = true"
           @items-updated="fileListUpdated"
           @switch-tree="switchDirTree"

--- a/src/components/filebrowser/__tests__/FileBrowser.spec.ts
+++ b/src/components/filebrowser/__tests__/FileBrowser.spec.ts
@@ -72,9 +72,9 @@ const FileNavigatorStub = defineComponent({
 const FileListStub = defineComponent({
   name: 'FileList',
   props: ['refreshpending', 'sort', 'showTree'],
-  emits: ['items-updated', 'loading', 'pathchanged', 'refreshed', 'switch-tree'],
+  emits: ['items-updated', 'loading', 'pathchanged', 'refreshed', 'switch-tree', 'filedeleted'],
   template:
-    '<div><button class="emit-loading" @click="$emit(`loading`, 1)" /><button class="emit-tree" @click="$emit(`switch-tree`, true)" /></div>',
+    '<div><button class="emit-loading" @click="$emit(`loading`, 1)" /><button class="emit-tree" @click="$emit(`switch-tree`, true)" /><button class="emit-filedeleted" @click="$emit(`filedeleted`)" /></div>',
 })
 
 function createBrowserProps() {
@@ -263,6 +263,15 @@ describe('FileBrowser state and child contracts', () => {
     expect(wrapper.getComponent(FileListStub).props('refreshpending')).toBe(true)
     wrapper.getComponent(FileListStub).vm.$emit('refreshed')
     await nextTick()
+    expect(wrapper.getComponent(FileListStub).props('refreshpending')).toBe(false)
+  })
+
+  it('does not schedule a second list refresh after the child completes a delete', async () => {
+    const wrapper = mountBrowser()
+
+    await wrapper.get('.emit-filedeleted').trigger('click')
+    await nextTick()
+
     expect(wrapper.getComponent(FileListStub).props('refreshpending')).toBe(false)
   })
 


### PR DESCRIPTION
## 变更说明

文件浏览器中，文件删除成功后由 `FileList` 负责刷新列表；父组件 `FileBrowser` 不再通过 `filedeleted` 事件再次安排刷新，避免同一次删除触发重复请求。

同时补充父子事件契约测试，明确删除成功事件不会在父层生成第二次刷新。

## 影响范围

- 仅涉及文件浏览器删除后的刷新调度。
- 删除失败路径、重命名刷新、目录切换和其他文件操作逻辑不变。
- 不涉及后端接口或默认布局。

## 验证

- FileBrowser/FileList focused tests：35/35
- `yarn typecheck`
- 触及文件 ESLint
- `yarn build`
- `git diff --check`

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 87541ffea067f3a69be9039121da429b9daa77f3

- 修复删除成功后的重复列表刷新
- 移除父组件 `filedeleted` 刷新调度
- 新增事件契约测试，验证不会二次刷新
- 其他操作与接口不变，兼容性风险较低
<!-- pr-agent-summary:end -->
