### PR TITLE
改善订阅批量删除失败体验

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -144,6 +144,12 @@ export interface Subscribe {
   episode_group?: string
 }
 
+/** 订阅删除成功后的机器可判断结果。 */
+export interface SubscribeDeletionResult {
+  // 数据库删除事务已提交
+  status: 'deleted'
+}
+
 // 订阅分享
 export interface SubscribeShare {
   // 分享ID

--- a/src/views/subscribe/SubscribeListView.vue
+++ b/src/views/subscribe/SubscribeListView.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import draggable from 'vuedraggable'
 import api from '@/api'
-import type { Subscribe } from '@/api/types'
+import type { Subscribe, SubscribeDeletionResult } from '@/api/types'
 import NoDataFound from '@/components/states/NoDataFound.vue'
 import SubscribeCard from '@/components/cards/SubscribeCard.vue'
 import ProgressiveCardGrid from '@/components/misc/ProgressiveCardGrid.vue'
@@ -426,11 +426,19 @@ async function batchDeleteSubscribes() {
 
   try {
     loading.value = true
-    const promises = selectedSubscribes.value.map(id => api.delete<null>(`subscribe/${id}`, { feedback: 'silent' }))
+    const selectedIds = [...selectedSubscribes.value]
+    const promises = selectedIds.map(id =>
+      api.delete<SubscribeDeletionResult>(`subscribe/${id}`, { feedback: 'silent' }),
+    )
     const results = await Promise.allSettled(promises)
 
-    const successCount = results.filter(result => result.status === 'fulfilled').length
-    const failedCount = results.length - successCount
+    const deletedIds = selectedIds.filter((_, index) => {
+      const result = results[index]
+      return result.status === 'fulfilled' && result.value?.status === 'deleted'
+    })
+    const failedIds = selectedIds.filter(id => !deletedIds.includes(id))
+    const successCount = deletedIds.length
+    const failedCount = failedIds.length
 
     if (successCount > 0) {
       $toast.success(t('subscribe.batchDeleteSuccess', { count: successCount }))
@@ -439,8 +447,10 @@ async function batchDeleteSubscribes() {
       $toast.error(t('subscribe.batchDeleteFailed', { count: failedCount }))
     }
 
+    // 失败项保留在选择集中，用户可直接修复后重试；全部成功时才退出批量模式。
+    selectedSubscribes.value = failedIds
     await fetchData()
-    exitBatchMode()
+    if (failedIds.length === 0) exitBatchMode()
   } catch (error) {
     console.error(error)
     $toast.error(t('subscribe.batchDeleteError'))

--- a/src/views/subscribe/__tests__/SubscribeListView.spec.ts
+++ b/src/views/subscribe/__tests__/SubscribeListView.spec.ts
@@ -605,7 +605,7 @@ describe('SubscribeListView batch operations', () => {
 
   it('completes a successful batch delete through the id endpoint', async () => {
     const deleted = vi.fn()
-    server.use(deleteSubscribeByIdHandler(1, { success: true }, 200, deleted))
+    server.use(deleteSubscribeByIdHandler(1, { data: { status: 'deleted' }, success: true }, 200, deleted))
     await renderList({ listResponse: [movie(1, 'Alpha')] })
     await screen.findByText('Alpha')
     await fireEvent.click(screen.getByRole('button', { name: 'host-enter-batch' }))
@@ -615,6 +615,28 @@ describe('SubscribeListView batch operations', () => {
 
     await waitFor(() => expect(deleted).toHaveBeenCalledOnce())
     await waitFor(() => expect(batchState()).toMatchObject({ enabled: false, selectedCount: 0 }))
+  })
+
+  it('keeps failed subscriptions selected for an immediate retry', async () => {
+    const firstDeleted = vi.fn()
+    const secondDeleted = vi.fn()
+    server.use(
+      deleteSubscribeByIdHandler(1, { data: { status: 'deleted' }, success: true }, 200, firstDeleted),
+      deleteSubscribeByIdHandler(2, { message: '暂时失败', success: false }, 503, secondDeleted),
+    )
+    await renderList({ listResponse: [movie(1, 'Alpha'), movie(2, 'Beta')] })
+    await screen.findByText('Alpha')
+    await fireEvent.click(screen.getByRole('button', { name: 'host-enter-batch' }))
+    await fireEvent.click(screen.getByRole('button', { name: 'host-toggle-select-all' }))
+
+    await fireEvent.click(screen.getByRole('button', { name: 'host-batch-delete' }))
+
+    await waitFor(() => expect(firstDeleted).toHaveBeenCalledOnce())
+    await waitFor(() => expect(secondDeleted).toHaveBeenCalledOnce())
+    await waitFor(() => expect(mocks.toastSuccess).toHaveBeenCalledWith('成功删除 1 个订阅'))
+    expect(mocks.toastError).toHaveBeenCalledWith('删除失败 1 个订阅')
+    await waitFor(() => expect(card(2)).toHaveAttribute('data-selected', 'true'))
+    expect(batchState()).toMatchObject({ enabled: true, selectedCount: 1 })
   })
 
   it.each([

--- a/tests/support/msw/handlers/subscribe.ts
+++ b/tests/support/msw/handlers/subscribe.ts
@@ -351,7 +351,7 @@ export function subscribeDetailsHandler(
 
 export function deleteSubscribeByIdHandler(
   id: number,
-  response: SubscribeMutationResponse = { success: true },
+  response: SubscribeMutationResponse = { data: { status: 'deleted' }, success: true },
   status = 200,
   onRequest: () => void = () => {},
 ) {


### PR DESCRIPTION
## 目标

配合后端删除结果契约，改善订阅批量删除的部分失败体验，避免失败项被静默清空。

## 主要变化

- 仅将后端返回 `status=deleted` 的请求计入成功数量。
- 批量操作部分失败时保留失败订阅的选中状态和批量模式，用户可直接重试。
- 补充删除结果类型、MSW 响应和部分失败回归测试。
- 单条订阅历史删除继续在失败时保留记录并提示错误。

## 验证

- `yarn vitest run src/views/subscribe/__tests__/SubscribeListView.spec.ts src/components/dialog/__tests__/SubscribeHistoryDialog.spec.ts`：46 passed
- `yarn typecheck`：通过
- 定向 ESLint：通过
- `git diff --check`：通过
- 已使用登录态浏览器确认前端订阅页可加载，并通过真实 API 验证后端删除成功/404 契约。

## 关联

- 配对后端 PR：jxxghp/MoviePilot#6514

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 9e7d533c51f624eb7bf6e904108805ae833bae75

- 按 `status: deleted` 判定删除成功
- 批量删除失败项保留选中，可重试
- 全部成功后才退出批量操作模式
- 补充部分失败与 MSW 契约测试
<!-- pr-agent-summary:end -->
