### PR TITLE
feat(agent): support pasting clipboard images

### DIFF
--- a/src/components/agent/AgentAssistantPanel.vue
+++ b/src/components/agent/AgentAssistantPanel.vue
@@ -1721,10 +1721,8 @@ function openFilePicker() {
   fileInputRef.value?.click()
 }
 
-// 处理文件选择并生成待发送附件预览。
-function handleFileSelection(event: Event) {
-  const input = event.target as HTMLInputElement
-  const files = Array.from(input.files || [])
+// 将文件加入待发送附件并生成图片预览。
+function addPendingAttachments(files: File[]) {
   const nextAttachments = files.map(file => {
     const kind = getFileKind(file)
 
@@ -1740,7 +1738,26 @@ function handleFileSelection(event: Event) {
   })
 
   pendingAttachments.value.push(...nextAttachments)
+}
+
+// 处理文件选择并生成待发送附件预览。
+function handleFileSelection(event: Event) {
+  const input = event.target as HTMLInputElement
+  addPendingAttachments(Array.from(input.files || []))
   input.value = ''
+}
+
+// 将剪贴板中的截图或复制图片加入待发送附件。
+function handleInputPaste(event: ClipboardEvent) {
+  if (isBusy.value || recording.value) return
+  const images = Array.from(event.clipboardData?.items || [])
+    .filter(item => item.kind === 'file' && item.type.startsWith('image/'))
+    .map(item => item.getAsFile())
+    .filter((file): file is File => Boolean(file))
+  if (!images.length) return
+
+  event.preventDefault()
+  addPendingAttachments(images)
 }
 
 // 移除一条待发送附件。
@@ -2798,6 +2815,7 @@ onScopeDispose(() => {
             :placeholder="inputPlaceholder"
             @input="handleInputChange"
             @keydown="handleInputKeydown"
+            @paste="handleInputPaste"
             @compositionstart="handleCompositionStart"
             @compositionend="handleCompositionEnd"
           />

--- a/src/components/agent/__tests__/AgentAssistantPanel.spec.ts
+++ b/src/components/agent/__tests__/AgentAssistantPanel.spec.ts
@@ -519,6 +519,49 @@ describe('AgentAssistantPanel stream recovery', () => {
     wrapper.unmount()
   })
 
+  it('adds a pasted clipboard image to the pending attachments', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => createAgentResponse([])))
+    const createObjectURL = vi.fn(() => 'blob:pasted-image')
+    Object.defineProperty(URL, 'createObjectURL', { configurable: true, value: createObjectURL })
+    Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, value: vi.fn() })
+    const screenshot = new File(['screenshot'], 'image.png', { type: 'image/png' })
+    const wrapper = shallowMount(AgentAssistantPanel, {
+      props: { modelValue: true },
+      global: {
+        stubs: {
+          AgentMarkdownContent: agentMarkdownContentStub,
+          IconBtn: { template: '<button><slot /></button>' },
+          PerfectScrollbar: { template: '<div><slot /></div>' },
+          VIcon: true,
+        },
+      },
+    })
+    await flushPromises()
+
+    const pasteEvent = new Event('paste', { bubbles: true, cancelable: true })
+    Object.defineProperty(pasteEvent, 'clipboardData', {
+      value: {
+        items: [
+          {
+            kind: 'file',
+            type: 'image/png',
+            getAsFile: () => screenshot,
+          },
+        ],
+      },
+    })
+    wrapper.get('textarea').element.dispatchEvent(pasteEvent)
+    await flushPromises()
+
+    expect(pasteEvent.defaultPrevented).toBe(true)
+    expect(createObjectURL).toHaveBeenCalledWith(screenshot)
+    expect(wrapper.get('.agent-assistant-pending-file').text()).toContain('image.png')
+
+    wrapper.unmount()
+    Reflect.deleteProperty(URL, 'createObjectURL')
+    Reflect.deleteProperty(URL, 'revokeObjectURL')
+  })
+
   it('renders protected delivery only as transient literal text and advertises the stream capability', async () => {
     const protectedMarker = 'MP-PROTECTED-MARKER **not bold** <script>literal</script>'
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {


### PR DESCRIPTION
## Summary

- accept pasted clipboard images in the agent message input
- reuse the existing pending-attachment preview and upload flow
- ignore paste handling while the assistant is busy or audio recording is active
- add a component test covering clipboard image attachment

## Verification

- `yarn vitest run src/components/agent/__tests__/AgentAssistantPanel.spec.ts` (35 passed)
- `yarn typecheck`
- `yarn build`
- verified the production build in a MoviePilot v3t container

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 9847b3e24a9fdab7dd0fa5c2e05c2247851a02c8

- 支持粘贴剪贴板图片作为待发送附件
- 复用附件预览与上传处理流程
- 忙碌或录音时跳过粘贴处理
- 新增剪贴板图片附件组件测试
<!-- pr-agent-summary:end -->
