### PR TITLE
fix(plugin): 插件清单请求显式分页，修复市场和已安装列表只显示前 50 个

### DIFF
--- a/src/api/__tests__/pluginCatalog.spec.ts
+++ b/src/api/__tests__/pluginCatalog.spec.ts
@@ -37,8 +37,21 @@ describe('fetchAllPlugins', () => {
     expect(mocks.apiGet).toHaveBeenNthCalledWith(1, 'plugin/', {
       params: { count: PLUGIN_LIST_PAGE_SIZE, force: true, page: 1, state: 'market' },
     })
+    // 强制刷新只在首页发送，后续页读取已刷新的清单。
     expect(mocks.apiGet).toHaveBeenNthCalledWith(2, 'plugin/', {
-      params: { count: PLUGIN_LIST_PAGE_SIZE, force: true, page: 2, state: 'market' },
+      params: { count: PLUGIN_LIST_PAGE_SIZE, force: false, page: 2, state: 'market' },
+    })
+  })
+
+  it('调用方显式传 force=false 时各页保持 force=false', async () => {
+    mocks.apiGet
+      .mockResolvedValueOnce(buildPlugins(PLUGIN_LIST_PAGE_SIZE))
+      .mockResolvedValueOnce(buildPlugins(1, PLUGIN_LIST_PAGE_SIZE))
+
+    await fetchAllPlugins({ state: 'market', force: false })
+
+    expect(mocks.apiGet).toHaveBeenNthCalledWith(2, 'plugin/', {
+      params: { count: PLUGIN_LIST_PAGE_SIZE, force: false, page: 2, state: 'market' },
     })
   })
 

--- a/src/api/__tests__/pluginCatalog.spec.ts
+++ b/src/api/__tests__/pluginCatalog.spec.ts
@@ -1,0 +1,73 @@
+import { fetchAllPlugins, PLUGIN_LIST_PAGE_SIZE } from '@/api/pluginCatalog'
+import type { Plugin } from '@/api/types'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  apiGet: vi.fn(),
+}))
+
+vi.mock('@/api', () => ({
+  default: createDataApiMock({
+    get: (...args: unknown[]) => mocks.apiGet(...args),
+  }),
+}))
+
+/** 构造指定数量的最小插件对象，ID 从给定序号开始递增。 */
+function buildPlugins(count: number, start = 0): Plugin[] {
+  return Array.from({ length: count }, (_, index) => ({
+    id: `Plugin${start + index}`,
+    plugin_name: `插件 ${start + index}`,
+  }))
+}
+
+describe('fetchAllPlugins', () => {
+  beforeEach(() => {
+    mocks.apiGet.mockReset()
+  })
+
+  it('按最大页大小显式分页请求，并在返回不足一页时停止', async () => {
+    mocks.apiGet
+      .mockResolvedValueOnce(buildPlugins(PLUGIN_LIST_PAGE_SIZE))
+      .mockResolvedValueOnce(buildPlugins(30, PLUGIN_LIST_PAGE_SIZE))
+
+    const plugins = await fetchAllPlugins({ state: 'market', force: true })
+
+    expect(plugins).toHaveLength(PLUGIN_LIST_PAGE_SIZE + 30)
+    expect(mocks.apiGet).toHaveBeenCalledTimes(2)
+    expect(mocks.apiGet).toHaveBeenNthCalledWith(1, 'plugin/', {
+      params: { count: PLUGIN_LIST_PAGE_SIZE, force: true, page: 1, state: 'market' },
+    })
+    expect(mocks.apiGet).toHaveBeenNthCalledWith(2, 'plugin/', {
+      params: { count: PLUGIN_LIST_PAGE_SIZE, force: true, page: 2, state: 'market' },
+    })
+  })
+
+  it('不足一页时只请求一次，且不伪造 force 参数', async () => {
+    mocks.apiGet.mockResolvedValueOnce(buildPlugins(3))
+
+    const plugins = await fetchAllPlugins({ state: 'installed' }, { feedback: 'silent' })
+
+    expect(plugins.map(plugin => plugin.id)).toEqual(['Plugin0', 'Plugin1', 'Plugin2'])
+    expect(mocks.apiGet).toHaveBeenCalledTimes(1)
+    // 数据客户端测试桩会剥离请求层的 feedback 选项，这里只断言端点与参数。
+    expect(mocks.apiGet).toHaveBeenCalledWith('plugin/', {
+      params: { count: PLUGIN_LIST_PAGE_SIZE, page: 1, state: 'installed' },
+    })
+  })
+
+  it('后端忽略分页重复返回整页时按插件 ID 去重并停止翻页', async () => {
+    mocks.apiGet.mockResolvedValue(buildPlugins(PLUGIN_LIST_PAGE_SIZE))
+
+    const plugins = await fetchAllPlugins({ state: 'market' })
+
+    expect(plugins).toHaveLength(PLUGIN_LIST_PAGE_SIZE)
+    expect(mocks.apiGet).toHaveBeenCalledTimes(2)
+  })
+
+  it('空结果直接返回空数组', async () => {
+    mocks.apiGet.mockResolvedValueOnce([])
+
+    await expect(fetchAllPlugins({ state: 'market' })).resolves.toEqual([])
+    expect(mocks.apiGet).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/api/pluginCatalog.ts
+++ b/src/api/pluginCatalog.ts
@@ -1,0 +1,48 @@
+import api from './index'
+import type { ApiFeedbackMode } from './client'
+import type { Plugin } from './types'
+
+/** 后端集合接口允许的最大单页数量，与 `COLLECTION_MAX_PAGE_SIZE` 保持一致。 */
+export const PLUGIN_LIST_PAGE_SIZE = 200
+
+/** 插件清单页数上限，防止后端忽略分页参数时无限翻页。 */
+const PLUGIN_LIST_MAX_PAGES = 50
+
+export type PluginListState = 'all' | 'installed' | 'market'
+
+export interface PluginListParams {
+  state: PluginListState
+  force?: boolean
+}
+
+export interface PluginListOptions {
+  feedback?: ApiFeedbackMode
+}
+
+/**
+ * 分页拉取完整插件清单。
+ *
+ * `GET /plugin/` 省略分页参数时后端只返回前 `max_results`（默认 50）条，
+ * Web 端的市场、已安装列表和搜索都需要完整清单，因此按最大页大小逐页读取，
+ * 直到返回不足一页或不再出现新插件为止。
+ */
+export async function fetchAllPlugins(params: PluginListParams, options: PluginListOptions = {}): Promise<Plugin[]> {
+  const plugins: Plugin[] = []
+  const seenIds = new Set<string>()
+
+  for (let page = 1; page <= PLUGIN_LIST_MAX_PAGES; page += 1) {
+    const chunk: Plugin[] = await api.get('plugin/', {
+      ...options,
+      params: { ...params, page, count: PLUGIN_LIST_PAGE_SIZE },
+    })
+    if (!Array.isArray(chunk) || chunk.length === 0) break
+
+    const fresh = chunk.filter(plugin => !seenIds.has(plugin.id))
+    fresh.forEach(plugin => seenIds.add(plugin.id))
+    plugins.push(...fresh)
+
+    if (fresh.length === 0 || chunk.length < PLUGIN_LIST_PAGE_SIZE) break
+  }
+
+  return plugins
+}

--- a/src/api/pluginCatalog.ts
+++ b/src/api/pluginCatalog.ts
@@ -25,6 +25,9 @@ export interface PluginListOptions {
  * `GET /plugin/` 省略分页参数时后端只返回前 `max_results`（默认 50）条，
  * Web 端的市场、已安装列表和搜索都需要完整清单，因此按最大页大小逐页读取，
  * 直到返回不足一页或不再出现新插件为止。
+ *
+ * `force` 只随第一页发送：后端在首页完成强制刷新后，后续页读取同一份已刷新的清单，
+ * 避免一次刷新触发多次完整的市场拉取，也避免各页来自不同的刷新结果。
  */
 export async function fetchAllPlugins(params: PluginListParams, options: PluginListOptions = {}): Promise<Plugin[]> {
   const plugins: Plugin[] = []
@@ -33,7 +36,12 @@ export async function fetchAllPlugins(params: PluginListParams, options: PluginL
   for (let page = 1; page <= PLUGIN_LIST_MAX_PAGES; page += 1) {
     const chunk: Plugin[] = await api.get('plugin/', {
       ...options,
-      params: { ...params, page, count: PLUGIN_LIST_PAGE_SIZE },
+      params: {
+        ...params,
+        ...(params.force && page > 1 ? { force: false } : {}),
+        page,
+        count: PLUGIN_LIST_PAGE_SIZE,
+      },
     })
     if (!Array.isArray(chunk) || chunk.length === 0) break
 

--- a/src/components/cards/PluginCard.vue
+++ b/src/components/cards/PluginCard.vue
@@ -3,6 +3,7 @@ import { useToast } from 'vue-toastification'
 import { useConfirm } from '@/composables/useConfirm'
 import api from '@/api'
 import { getApiBusinessErrorMessage } from '@/api/client'
+import { fetchAllPlugins } from '@/api/pluginCatalog'
 import type { Plugin, PluginRating, PluginSourceTransition } from '@/api/types'
 import { getLogoUrl, getProxyImageUrl } from '@/utils/imageUtils'
 import { usePluginCardAccent } from '@/composables/usePluginCardAccent'
@@ -378,12 +379,7 @@ async function fetchMarketPlugin(pluginId?: string) {
   if (!pluginId) return null
 
   try {
-    const marketPlugins: Plugin[] = await api.get('plugin/', {
-      params: {
-        state: 'market',
-        force: false,
-      },
-    })
+    const marketPlugins: Plugin[] = await fetchAllPlugins({ state: 'market', force: false })
 
     return marketPlugins.find(plugin => plugin.id === pluginId) || null
   } catch (error) {

--- a/src/components/cards/__tests__/PluginCardAbout.spec.ts
+++ b/src/components/cards/__tests__/PluginCardAbout.spec.ts
@@ -152,7 +152,7 @@ describe('PluginCard about menu', () => {
 
     await waitFor(() => {
       expect(mocks.apiGet).toHaveBeenCalledWith('plugin/', {
-        params: { force: false, state: 'market' },
+        params: { count: 200, force: false, page: 1, state: 'market' },
       })
     })
     expect(open).toHaveBeenCalledWith('about:blank', '_blank')

--- a/src/components/dialog/SearchBarDialog.vue
+++ b/src/components/dialog/SearchBarDialog.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import api from '@/api'
+import { fetchAllPlugins } from '@/api/pluginCatalog'
 import type { MediaDataSource, Site, Plugin, Subscribe } from '@/api/types'
 import { getNavMenus, getSettingTabs } from '@/router/i18n-menu'
 import { NavMenu } from '@/@layouts/types'
@@ -355,11 +356,7 @@ const pluginItems = ref<Plugin[]>([])
 /** 加载已安装插件，供搜索结果匹配。 */
 async function fetchInstalledPlugins() {
   try {
-    pluginItems.value = await api.get('plugin/', {
-      params: {
-        state: 'installed',
-      },
-    })
+    pluginItems.value = await fetchAllPlugins({ state: 'installed' })
   } catch (error) {
     console.error(error)
   }

--- a/src/layouts/default/components/QuickAccess.vue
+++ b/src/layouts/default/components/QuickAccess.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import api from '@/api'
+import { fetchAllPlugins } from '@/api/pluginCatalog'
 import type { Plugin } from '@/api/types'
 import { getLogoUrl } from '@/utils/imageUtils'
 import { useI18n } from 'vue-i18n'
@@ -73,7 +73,7 @@ function getQuickAccessElement() {
   const element = quickAccessRef.value
   if (!element) return null
 
-  return element instanceof HTMLElement ? element : element.$el ?? null
+  return element instanceof HTMLElement ? element : (element.$el ?? null)
 }
 
 // 计算显示状态
@@ -162,11 +162,7 @@ async function fetchPluginsWithPage() {
 
   try {
     loading.value = true
-    const allPlugins: Plugin[] = await api.get('plugin/', {
-      params: {
-        state: 'installed',
-      },
-    })
+    const allPlugins: Plugin[] = await fetchAllPlugins({ state: 'installed' })
 
     // 只保留有详情页面且已启用的插件
     pluginsWithPage.value = allPlugins

--- a/src/views/plugin/PluginCardListView.vue
+++ b/src/views/plugin/PluginCardListView.vue
@@ -2,6 +2,7 @@
 import { useToast } from 'vue-toastification'
 import api from '@/api'
 import { getApiBusinessErrorMessage } from '@/api/client'
+import { fetchAllPlugins } from '@/api/pluginCatalog'
 import {
   changePluginSource,
   getPluginSourceOptions,
@@ -1100,11 +1101,7 @@ async function fetchInstalledPlugins(context: KeepAliveRefreshContext = {}): Pro
   }
 
   try {
-    const installedPlugins: Plugin[] = await api.get('plugin/', {
-      params: {
-        state: 'installed',
-      },
-    })
+    const installedPlugins: Plugin[] = await fetchAllPlugins({ state: 'installed' })
     if (generation !== installedWriterGeneration) return false
 
     const previousById = new Map([...uninstalledList.value, ...dataList.value].map(plugin => [plugin.id, plugin]))
@@ -1258,12 +1255,7 @@ async function fetchUninstalledPlugins(
   }
 
   try {
-    const marketResponse: Plugin[] = await api.get('plugin/', {
-      params: {
-        state: 'market',
-        force: force,
-      },
-    })
+    const marketResponse: Plugin[] = await fetchAllPlugins({ state: 'market', force })
     if (generation !== marketWriterGeneration) return
 
     if (commit) applyMarketSnapshot(marketResponse)


### PR DESCRIPTION
## 关联 Issue

jxxghp/MoviePilot#6567

## 问题

v3 更新到最新后，插件市场只显示 jxxghp 与 thsrite 两个仓库的插件，「插件仓库」筛选下拉也只剩这两项；配置了 54 个仓库、后端日志显示「获取到 394 个线上插件」的实例同样只能看到 50 个。已安装插件超过 50 个时，「我的插件」也会少显示。

## 根因

后端 `GET /api/v1/plugin/` 在 jxxghp/MoviePilot@6d4d7331d（2026-09-01）为 Agent 场景新增了 `query` 与 `max_results`（默认 50、上限 200），并在末尾 `plugins[:max_results]` 截断；随后 d512f528b 增加了显式 `page`/`count` 分页，但按文档约定「省略分页参数时保留旧 `max_results` 默认值」。

前端市场、已安装列表、快捷入口和全局搜索四处仍以 `plugin/?state=...` 全量请求、不带任何分页参数，于是每次只拿到按 `PLUGIN_MARKET` 顺序排在最前的 50 个插件，恰好全部来自 jxxghp 与 thsrite，表现为「只剩两个仓库」。

## 修改

- 新增 `src/api/pluginCatalog.ts` 的 `fetchAllPlugins()`：按后端 `COLLECTION_MAX_PAGE_SIZE`（200）显式传 `page`/`count` 逐页拉取，返回不足一页即停止；按插件 ID 去重并在整页无新增时停止、页数设上限，兼容忽略分页参数的旧后端，不会重复或无限翻页；`force` 只随第一页发送，后续页读取后端已刷新的同一份清单，避免一次刷新触发多次市场拉取。
- `PluginCardListView.vue`（市场 + 已安装）、`PluginCard.vue`（补齐 repo_url 的市场查找）、`SearchBarDialog.vue`（全局搜索）、`QuickAccess.vue`（快捷入口）四处调用改用该助手，请求参数语义不变（原来传 `force` 的仍传 `force`）。
- `QuickAccess.vue` 因 `api` 不再使用而移除导入，并顺带通过 Prettier 修正了该文件一行既有格式偏差（`format:check` 会检查变更文件）。

## 测试

- 新增 `src/api/__tests__/pluginCatalog.spec.ts` 5 个用例：整页续拉与不足一页停止且 `force` 只在首页、显式 `force=false` 各页不变、单页不伪造 `force`、后端忽略分页时按 ID 去重并停止、空结果。
- `PluginCardAbout.spec.ts` 中对 `plugin/` 请求参数的断言同步补上 `page`/`count`；`PluginCardListView.spec.ts` 既有 msw 用例无需修改，全部通过。
- 本地 `yarn lint`、`yarn format:check`、`yarn typecheck`、`yarn build` 全部通过；`yarn test:run` 全量 130 个文件 / 1547 个用例通过。

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at c860d85e142c168bb7207d94643b618be2457b01

- 显式分页加载完整插件清单
- 市场、已安装、搜索统一接入
- 首页仅发送 `force` 刷新
- 去重限页兼容旧后端
<!-- pr-agent-summary:end -->
