### PR TITLE
fix(glass): 统一弹层阅读材质并改善切页与启动接管

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -289,12 +289,12 @@ const shouldRenderGlassOpticalLayer = computed(
 const loadGlassOpticalLayer = () => import('@/components/theme/GlassOpticalLayer.vue')
 const GlassOpticalLayer = defineAsyncComponent(loadGlassOpticalLayer)
 
-// 模块下载与壁纸准备并行；实际挂载仍等待路由和壁纸，CSS 档不请求光学组件。
+// 玻璃光学组件与 Three 模块并行预载；实际挂载仍等待路由和壁纸，非玻璃或 CSS 档位不请求光学模块。
 watch(
   () => isGlassTheme.value && opticalQuality.value !== 'css',
   enabled => {
     if (!enabled) return
-    void loadGlassOpticalLayer().catch(error => {
+    void Promise.all([loadGlassOpticalLayer(), import('three')]).catch(error => {
       console.warn('[Glass] Optical component preload failed', error)
     })
   },

--- a/src/__tests__/app-glass-optical-preload.spec.ts
+++ b/src/__tests__/app-glass-optical-preload.spec.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { cwd } from 'node:process'
+import { describe, expect, it } from 'vitest'
+
+const appSource = readFileSync(resolve(cwd(), 'src/App.vue'), 'utf8')
+const preloadWatchStart = appSource.indexOf("watch(\n  () => isGlassTheme.value && opticalQuality.value !== 'css',")
+const preloadWatchEnd = appSource.indexOf('const transparentBackgroundBlur', preloadWatchStart)
+const preloadWatch = appSource.slice(preloadWatchStart, preloadWatchEnd)
+
+describe('App 玻璃光学模块预载', () => {
+  it('只在非 CSS 玻璃档位的 guard 内并行预载组件和 Three', () => {
+    expect(preloadWatchStart).toBeGreaterThanOrEqual(0)
+    expect(preloadWatchEnd).toBeGreaterThan(preloadWatchStart)
+    expect(preloadWatch).toContain('if (!enabled) return')
+    expect(preloadWatch).toContain("void Promise.all([loadGlassOpticalLayer(), import('three')])")
+    expect(preloadWatch.indexOf("import('three')")).toBeGreaterThan(preloadWatch.indexOf('if (!enabled) return'))
+    expect(appSource.match(/import\('three'\)/gu)).toHaveLength(1)
+  })
+
+  it('保留异步组件原语、首路由挂载门槛和 loader 退场时序', () => {
+    expect(appSource).toContain(
+      "const loadGlassOpticalLayer = () => import('@/components/theme/GlassOpticalLayer.vue')",
+    )
+    expect(appSource).toContain('const GlassOpticalLayer = defineAsyncComponent(loadGlassOpticalLayer)')
+    expect(appSource).toMatch(
+      /const shouldRenderGlassOpticalLayer = computed\([\s\S]*?isGlassTheme\.value[\s\S]*?opticalQuality\.value !== 'css'[\s\S]*?isInitialRouteReady\.value/u,
+    )
+    expect(appSource).toContain('v-if="shouldRenderGlassOpticalLayer"')
+    expect(appSource).toContain('const LAUNCH_EXIT_DURATION_MS = 180')
+    expect(appSource).toContain("removeEl('#loading-bg')")
+    expect(appSource).toContain('}, LAUNCH_EXIT_DURATION_MS)')
+  })
+})

--- a/src/components/theme/GlassPanelRefractionDefs.vue
+++ b/src/components/theme/GlassPanelRefractionDefs.vue
@@ -71,7 +71,7 @@ let observer: MutationObserver | null = null
 let resizeObserver: ResizeObserver | null = null
 let intersectionObserver: IntersectionObserver | null = null
 let reducedTransparency: MediaQueryList | null = null
-let timer: ReturnType<typeof setTimeout> | null = null
+let syncFrame: number | null = null
 let revision = 0
 let sequence = 0
 let disposed = false
@@ -116,8 +116,8 @@ function forget(binding: SurfaceBinding) {
 
 function suspend() {
   revision += 1
-  if (timer !== null) clearTimeout(timer)
-  timer = null
+  if (syncFrame !== null) cancelAnimationFrame(syncFrame)
+  syncFrame = null
   for (const binding of surfaces.values()) release(binding)
 }
 
@@ -260,7 +260,7 @@ function reconcileBindings() {
 }
 
 async function syncSurfaces() {
-  timer = null
+  syncFrame = null
   if (!canEnhance()) {
     suspend()
     return
@@ -274,7 +274,7 @@ async function syncSurfaces() {
     geometryAnchors.add(element)
     resizeObserver?.observe(element)
   }
-  const active: Array<{ binding: SurfaceBinding; definition: FilterDefinition }> = []
+  const pending: Array<Promise<{ binding: SurfaceBinding; definition: FilterDefinition } | null>> = []
   for (const binding of surfaces.values()) {
     if (binding.kind === 'card' && intersectionObserver && !nearbyCards.has(binding.element)) {
       release(binding)
@@ -287,15 +287,21 @@ async function syncSurfaces() {
     }
     const key = JSON.stringify(geometry)
     if (key !== binding.key) release(binding)
-    try {
-      const image = await decodedMap(geometry, key)
-      if (currentRevision !== revision || !canEnhance()) return
-      binding.key = key
-      active.push({ binding, definition: { id: binding.id, width: geometry.width, height: geometry.height, image } })
-    } catch {
-      if (currentRevision === revision) release(binding)
-    }
+    // 同屏表面并行解码，避免每张图各等一次浏览器解码周期后才让整页接管材质。
+    pending.push(
+      decodedMap(geometry, key)
+        .then(image => {
+          if (currentRevision !== revision || !canEnhance()) return null
+          binding.key = key
+          return { binding, definition: { id: binding.id, width: geometry.width, height: geometry.height, image } }
+        })
+        .catch(() => {
+          if (currentRevision === revision) release(binding)
+          return null
+        }),
+    )
   }
+  const active = (await Promise.all(pending)).filter(surface => surface !== null)
   // 过期失败也不能清空新一轮 defs，否则已经绑定的新表面会引用不存在的滤镜。
   if (currentRevision !== revision || !canEnhance()) return
   definitions.value = active.map(surface => surface.definition)
@@ -314,7 +320,6 @@ async function syncSurfaces() {
 }
 
 function scheduleSync() {
-  if (timer !== null) clearTimeout(timer)
   if (!isEligible()) {
     reset()
     return
@@ -334,9 +339,11 @@ function scheduleSync() {
     suspend()
     return
   }
-  timer = setTimeout(() => {
+  // 路由挂载、图片布局和观察器共享下一帧；连续变更不能不断延后已排定的材质接管。
+  if (syncFrame !== null) return
+  syncFrame = requestAnimationFrame(() => {
     void syncSurfaces()
-  }, 60)
+  })
 }
 
 watch(

--- a/src/components/theme/__tests__/GlassPanelRefractionDefs.spec.ts
+++ b/src/components/theme/__tests__/GlassPanelRefractionDefs.spec.ts
@@ -91,6 +91,7 @@ describe('GlassPanelRefractionDefs', () => {
         width = 1200
         height = 900
       }
+      if (this.dataset.card === 'second') width += 120
 
       return {
         x: left,
@@ -366,6 +367,33 @@ describe('GlassPanelRefractionDefs', () => {
     expectNoPanelFilter(shell.querySelector('.layout-navbar') as HTMLElement)
     expectNoPanelFilter(shell.querySelector('.layout-vertical-nav') as HTMLElement)
     expect(createGlassPanelBackdropMap).not.toHaveBeenCalled()
+  })
+
+  it('starts the scheduled frame even when more layout events arrive before it', async () => {
+    mountPanel()
+    await vi.advanceTimersByTimeAsync(8)
+    window.dispatchEvent(new Event('resize'))
+    await vi.advanceTimersByTimeAsync(8)
+    expect(createGlassNavbarDisplacementMap).toHaveBeenCalledTimes(1)
+    completePendingDecode()
+    await flushPromises()
+    expect(card.style.getPropertyValue('backdrop-filter')).toContain('url(')
+  })
+
+  it('starts different visible map decodes together instead of serializing them', async () => {
+    const second = document.createElement('div')
+    second.className = 'v-card'
+    second.dataset.card = 'second'
+    card.parentElement!.append(second)
+    mountPanel()
+    await vi.advanceTimersByTimeAsync(16)
+    expect(decodePending).toHaveLength(2)
+    expectNoPanelFilter(card)
+    expectNoPanelFilter(second)
+    completePendingDecode()
+    await flushPromises()
+    expect(card.style.getPropertyValue('backdrop-filter')).toContain('url(')
+    expect(second.style.getPropertyValue('backdrop-filter')).toContain('url(')
   })
 
   it('enhances site and plugin routes without requiring a dashboard', async () => {

--- a/src/composables/__tests__/useGlassOpticalRenderer.spec.ts
+++ b/src/composables/__tests__/useGlassOpticalRenderer.spec.ts
@@ -144,6 +144,15 @@ function setOpticalSurfaceBounds(element: HTMLElement, bounds: Pick<DOMRect, 'he
     }) as DOMRect
 }
 
+/** 与临时玻璃 CSS 材质入口对应的排除子树 fixture。 */
+const TRANSIENT_GLASS_HOST_CLASS_NAMES = [
+  ['v-overlay__content'],
+  ['theme-customizer-panel-host'],
+  ['plugin-quick-access'],
+  ['agent-assistant-panel'],
+  ['layout-vertical-nav', 'overlay-nav'],
+] as const
+
 function stubMediaPreferences({ coarsePointer = false, reducedMotion = false, reducedTransparency = false } = {}) {
   vi.stubGlobal(
     'matchMedia',
@@ -542,6 +551,104 @@ describe('glass optical surface discovery', () => {
     expect(containsGlassOpticalSurface(excludedContainer)).toBe(false)
     expect(resolveGlassOpticalSurfaceMode(overridden)).toBe('dynamic')
     expect(collectGlassOpticalRects(390, 844, 'clear')).toEqual([])
+  })
+
+  it('excludes CSS-owned transient subtrees from wallpaper optical surfaces', () => {
+    for (const classNames of TRANSIENT_GLASS_HOST_CLASS_NAMES) {
+      const host = document.createElement('div')
+      host.className = classNames.join(' ')
+      const surface = document.createElement('section')
+      surface.dataset.glassOpticalSurface = ''
+      host.append(surface)
+      document.body.append(host)
+
+      expect(containsGlassOpticalSurface(host)).toBe(false)
+    }
+
+    expect(collectGlassOpticalRects(1200, 800, 'clear')).toEqual([])
+  })
+
+  it('blocks transient subtree input before it can animate an underlying content surface', async () => {
+    const three = await import('three')
+    const render = vi.spyOn(three.WebGLRenderer.prototype, 'render')
+    const content = appendOpticalSurface('app-hover-lift-card', { height: 300, width: 400, x: 40, y: 120 })
+    const targets = TRANSIENT_GLASS_HOST_CLASS_NAMES.map(classNames => {
+      const host = document.createElement('div')
+      host.className = classNames.join(' ')
+      const target = document.createElement('span')
+      host.append(target)
+      document.body.append(host)
+
+      return target
+    })
+    let interactionListener: ((event: PointerEvent | TouchEvent) => void) | null = null
+    const scope = effectScope()
+    const renderer = scope.run(() =>
+      useGlassOpticalRenderer({
+        active: ref(true),
+        appearance: ref('clear'),
+        canvas: ref(document.createElement('canvas')),
+        interactionSource: {
+          subscribe: vi.fn((_space, listener) => {
+            interactionListener = listener
+            return vi.fn()
+          }),
+        },
+        quality: ref('balanced'),
+        routeKey: ref('/dashboard'),
+        surfaceSpace: 'scroll',
+        tintColor: ref('#8D51F9'),
+        wallpaperUrl: ref('https://example.com/wallpaper.jpg'),
+      }),
+    )
+
+    await vi.waitFor(() => expect(renderer?.state.value).toBe('ready'))
+    await vi.waitFor(() => expect(render).toHaveBeenCalled())
+    const mainScene = render.mock.calls
+      .map(call => call[0] as unknown as { children: Array<{ material?: ShaderMaterial }> })
+      .find(candidate => candidate.children[0]?.material?.uniforms.uDynamicsMode)
+    if (!mainScene) throw new Error('main optical interaction path was not initialized')
+    const dispatchInteraction: (event: PointerEvent | TouchEvent) => void =
+      interactionListener ??
+      (() => {
+        throw new Error('main optical interaction callback was not initialized')
+      })
+    const uniforms = mainScene.children[0].material!.uniforms
+
+    expect(uniforms.uRectCount.value).toBe(1)
+    expect(uniforms.uMotion.value).toBe(0)
+    for (const target of targets) {
+      dispatchInteraction({
+        clientX: 160,
+        clientY: 180,
+        pointerType: 'mouse',
+        target,
+        timeStamp: 100,
+        type: 'pointermove',
+      } as unknown as PointerEvent)
+
+      expect(uniforms.uMotion.value).toBe(0)
+    }
+
+    dispatchInteraction({
+      clientX: 180,
+      clientY: 200,
+      pointerType: 'mouse',
+      target: content,
+      timeStamp: 200,
+      type: 'pointermove',
+    } as unknown as PointerEvent)
+    dispatchInteraction({
+      clientX: 210,
+      clientY: 220,
+      pointerType: 'mouse',
+      target: content,
+      timeStamp: 220,
+      type: 'pointermove',
+    } as unknown as PointerEvent)
+    expect(uniforms.uMotion.value).toBeGreaterThan(0)
+
+    scope.stop()
   })
 
   it('discovers the shared interactive card contract used across routes', () => {
@@ -2052,10 +2159,10 @@ describe('glass optical surface discovery', () => {
   it('hands only native-owned surfaces their static background while preserving shared dynamics', async () => {
     const three = await import('three')
     const navbar = appendOpticalSurface('layout-navbar', { height: 64, width: 600, x: 20, y: 20 })
-    const assistant = appendOpticalSurface('agent-assistant-panel', { height: 240, width: 250, x: 700, y: 120 })
+    const loginCard = appendOpticalSurface('login-card', { height: 240, width: 250, x: 700, y: 120 })
     const root = document.createElement('div')
     root.className = 'app-wrapper'
-    root.append(navbar, assistant)
+    root.append(navbar, loginCard)
     document.body.append(root)
     const render = vi.spyOn(three.WebGLRenderer.prototype, 'render')
     const scope = effectScope()
@@ -3659,6 +3766,49 @@ describe('glass optical surface discovery', () => {
     expect(dispose).toHaveBeenCalledTimes(1)
     expect(contextLoss).not.toHaveBeenCalled()
     scope.stop()
+  })
+
+  it('retains the mounted canvas context across reduced-transparency toggles', async () => {
+    const three = await import('three')
+    let reduced = false
+    let change: ((event: MediaQueryListEvent) => void) | undefined
+    vi.stubGlobal('matchMedia', (query: string) => ({
+      get matches() {
+        return query === '(prefers-reduced-transparency: reduce)' && reduced
+      },
+      addEventListener: (_type: string, listener: (event: MediaQueryListEvent) => void) => {
+        if (query === '(prefers-reduced-transparency: reduce)') change = listener
+      },
+      removeEventListener: vi.fn(),
+    }))
+    const loseContext = vi.spyOn(three.WebGLRenderer.prototype, 'forceContextLoss')
+    const dispose = vi.spyOn(three.WebGLRenderer.prototype, 'dispose')
+    const scope = effectScope()
+    const renderer = scope.run(() =>
+      useGlassOpticalRenderer({
+        active: ref(true),
+        appearance: ref('clear'),
+        canvas: ref(document.createElement('canvas')),
+        quality: ref('high'),
+        routeKey: ref('/dashboard'),
+        tintColor: ref('#8D51F9'),
+        wallpaperUrl: ref('https://example.com/wallpaper.jpg'),
+      }),
+    )
+    try {
+      await vi.waitFor(() => expect(renderer?.state.value).toBe('ready'))
+      reduced = true
+      change?.({ matches: true } as MediaQueryListEvent)
+      expect(renderer?.state.value).toBe('fallback')
+      expect(dispose).toHaveBeenCalledOnce()
+      expect(loseContext).not.toHaveBeenCalled()
+      reduced = false
+      change?.({ matches: false } as MediaQueryListEvent)
+      await vi.waitFor(() => expect(renderer?.state.value).toBe('ready'))
+      expect(loseContext).not.toHaveBeenCalled()
+    } finally {
+      scope.stop()
+    }
   })
 
   it('uses the CSS fallback when reduced transparency is active', async () => {

--- a/src/composables/__tests__/usePagePresentationMotion.spec.ts
+++ b/src/composables/__tests__/usePagePresentationMotion.spec.ts
@@ -2,7 +2,6 @@ import {
   getPagePresentationMotionProgress,
   PAGE_PRESENTATION_FROSTED_START_TRANSLATE_Y,
   PAGE_PRESENTATION_MOTION_DURATION_MS,
-  PAGE_PRESENTATION_MOTION_START_OPACITY,
   PAGE_PRESENTATION_MOTION_START_TRANSLATE_Y,
   usePagePresentationMotion,
 } from '@/composables/usePagePresentationMotion'
@@ -45,12 +44,14 @@ afterEach(() => {
 })
 
 describe('page presentation motion', () => {
-  it('delegates standard clear glass to the ordinary compositor animation', () => {
+  it.each(['clear', 'tinted'])('keeps standard %s glass on the backdrop-safe motion path', appearance => {
     document.documentElement.dataset.glassQuality = 'css'
+    document.documentElement.dataset.glassAppearance = appearance
 
-    expect(motion.start('/dashboard', document.createElement('div'))).toBe(false)
-    expect(motion.active.value).toBe(false)
-    expect(callbacks.size).toBe(0)
+    expect(motion.start('/dashboard', document.createElement('div'))).toBe(true)
+    expect(motion.active.value).toBe(true)
+    expect(motion.opacity.value).toBe(1)
+    expect(callbacks.size).toBe(1)
   })
 
   it('starts standard frosted motion without waiting for a renderer geometry acknowledgement', () => {
@@ -84,12 +85,12 @@ describe('page presentation motion', () => {
 
     expect(motion.start('/dashboard')).toBe(true)
     expect(motion.active.value).toBe(true)
-    expect(motion.opacity.value).toBe(PAGE_PRESENTATION_MOTION_START_OPACITY)
+    expect(motion.opacity.value).toBe(1)
     expect(callbacks.size).toBe(1)
     expect(document.documentElement.dataset.pagePresentationMotion).toBe('active')
   })
 
-  it('holds a glass route until its shared layout geometry remains stable', () => {
+  it('holds motion until layout geometry is stable without hiding native glass', () => {
     const routeRoot = document.createElement('div')
     let routeHeight = 2096
     Object.defineProperties(routeRoot, {
@@ -102,24 +103,27 @@ describe('page presentation motion', () => {
 
     expect(motion.start('/dashboard', routeRoot)).toBe(true)
     expect(motion.active.value).toBe(true)
-    expect(motion.opacity.value).toBe(0)
+    expect(motion.opacity.value).toBe(1)
+    expect(motion.progress.value).toBe(0)
     expect(document.documentElement.dataset.pagePresentationMotion).toBe('active')
 
     ;[1016, 1080].forEach(timestamp => [...callbacks.values()].at(-1)!(timestamp))
-    expect(motion.opacity.value).toBe(0)
+    expect(motion.opacity.value).toBe(1)
+    expect(motion.progress.value).toBe(0)
 
     routeHeight = 1520
     ;[1110, 1200].forEach(timestamp => [...callbacks.values()].at(-1)!(timestamp))
-    expect(motion.opacity.value).toBe(0)
+    expect(motion.opacity.value).toBe(1)
+    expect(motion.progress.value).toBe(0)
 
     ;[1231].forEach(timestamp => [...callbacks.values()].at(-1)!(timestamp))
-    expect(motion.opacity.value).toBe(PAGE_PRESENTATION_MOTION_START_OPACITY)
+    expect(motion.opacity.value).toBe(1)
     expect(motion.translateY.value).toBe(PAGE_PRESENTATION_MOTION_START_TRANSLATE_Y)
 
     routeRoot.remove()
   })
 
-  it('reveals clear glass when the renderer confirms current surface geometry', () => {
+  it('starts clear glass motion when the renderer confirms geometry without changing opacity', () => {
     const routeRoot = document.createElement('div')
     Object.defineProperties(routeRoot, {
       offsetHeight: { configurable: true, get: () => 2096 },
@@ -131,12 +135,12 @@ describe('page presentation motion', () => {
 
     expect(motion.start('/dashboard', routeRoot)).toBe(true)
     const motionEpoch = motion.epoch.value
-    expect(motion.opacity.value).toBe(0)
+    expect(motion.opacity.value).toBe(1)
     expect(motion.reader.acknowledgeGeometryReady(motionEpoch - 1, 1040)).toBe(false)
-    expect(motion.opacity.value).toBe(0)
+    expect(motion.opacity.value).toBe(1)
 
     expect(motion.reader.acknowledgeGeometryReady(motionEpoch, 1040)).toBe(true)
-    expect(motion.opacity.value).toBe(PAGE_PRESENTATION_MOTION_START_OPACITY)
+    expect(motion.opacity.value).toBe(1)
     expect(motion.translateY.value).toBe(PAGE_PRESENTATION_MOTION_START_TRANSLATE_Y)
     expect(callbacks.size).toBe(1)
 
@@ -208,7 +212,7 @@ describe('page presentation motion', () => {
 
     expect(motion.start('/dashboard')).toBe(true)
     expect(motion.active.value).toBe(true)
-    expect(motion.opacity.value).toBe(PAGE_PRESENTATION_MOTION_START_OPACITY)
+    expect(motion.opacity.value).toBe(1)
     expect(motion.translateY.value).toBe(PAGE_PRESENTATION_MOTION_START_TRANSLATE_Y)
     expect(motion.revision.value).toBe(initialRevision + 1)
     expect(document.documentElement.dataset.pagePresentationMotion).toBe('active')
@@ -217,8 +221,7 @@ describe('page presentation motion', () => {
     firstFrame(1000 + PAGE_PRESENTATION_MOTION_DURATION_MS / 2)
     expect(motion.progress.value).toBeGreaterThan(0)
     expect(motion.progress.value).toBeLessThan(1)
-    expect(motion.opacity.value).toBeGreaterThan(PAGE_PRESENTATION_MOTION_START_OPACITY)
-    expect(motion.opacity.value).toBeLessThan(1)
+    expect(motion.opacity.value).toBe(1)
     expect(motion.translateY.value).toBeGreaterThan(0)
     expect(motion.translateY.value).toBeLessThan(PAGE_PRESENTATION_MOTION_START_TRANSLATE_Y)
 

--- a/src/composables/useGlassOpticalRenderer.ts
+++ b/src/composables/useGlassOpticalRenderer.ts
@@ -423,7 +423,6 @@ interface PreparedWallpaperTexture {
 }
 
 const SURFACE_SELECTORS = [
-  { rank: 1, selector: '.agent-assistant-panel', space: 'fixed' },
   { rank: 1, selector: '.login-card', space: 'fixed' },
   { rank: 2, selector: '.layout-vertical-nav', space: 'fixed' },
   { rank: 2, selector: '.layout-navbar', space: 'fixed' },
@@ -447,10 +446,17 @@ const SURFACE_SELECTORS = [
 const SURFACE_SELECTOR_QUERY = SURFACE_SELECTORS.map(({ selector }) => selector).join(',')
 const INTERACTION_CLIP_SELECTOR = '.app-hover-lift-card'
 const OPTICAL_BOUNDARY_SELECTOR = '[data-glass-optical-boundary]'
-const OPTICAL_EXCLUSION_SELECTOR = '[data-glass-optical-mode="excluded"]'
+const OPTICAL_EXCLUSION_SELECTOR = [
+  '[data-glass-optical-mode="excluded"]',
+  '.v-overlay__content',
+  '.theme-customizer-panel-host',
+  '.plugin-quick-access',
+  '.agent-assistant-panel',
+  '.layout-vertical-nav.overlay-nav',
+].join(',')
 const INTERACTION_CLIP_OVERSCAN_PX = 96
 
-/** 排除合同覆盖整个子树；后代不能用 dynamic 声明重新加入 renderer。 */
+/** 显式 excluded 标记与原生 CSS 临时承载层共用排除合同；后代不能重新加入 renderer。 */
 function isGlassOpticalElementExcluded(element: Element) {
   return Boolean(element.closest(OPTICAL_EXCLUSION_SELECTOR))
 }
@@ -4152,7 +4158,8 @@ export function useGlassOpticalRenderer(options: UseGlassOpticalRendererOptions)
     if (!toValue(options.active)) return
 
     if (event.matches) {
-      disposeRenderer()
+      // Canvas 仍挂载，恢复时需要复用它；释放资源但不主动丢失其 context。
+      disposeRenderer(false)
       updateRendererState('fallback')
       return
     }

--- a/src/composables/usePagePresentationMotion.ts
+++ b/src/composables/usePagePresentationMotion.ts
@@ -1,7 +1,6 @@
 import { readonly, ref, type Ref } from 'vue'
 
 export const PAGE_PRESENTATION_MOTION_DURATION_MS = 180
-export const PAGE_PRESENTATION_MOTION_START_OPACITY = 0.88
 export const PAGE_PRESENTATION_MOTION_START_TRANSLATE_Y = 4
 export const PAGE_PRESENTATION_FROSTED_START_TRANSLATE_Y = 8
 export const PAGE_PRESENTATION_LAYOUT_STABLE_MS = 120
@@ -9,7 +8,7 @@ export const PAGE_PRESENTATION_LAYOUT_HOLD_MAX_MS = 480
 
 /** renderer 只读取同一帧已经提交到 DOM 的页面呈现状态。 */
 export interface PagePresentationMotionReader {
-  /** renderer 确认当前事务的 surface 几何已稳定后，允许页面开始 reveal。 */
+  /** renderer 确认当前事务的 surface 几何已稳定后，允许页面开始入场位移。 */
   acknowledgeGeometryReady: (motionEpoch: number, timestamp?: number) => boolean
   /** 页面是否处于共享呈现事务中。 */
   active: Readonly<Ref<boolean>>
@@ -35,7 +34,6 @@ let layoutStableSince = 0
 let layoutSignature = ''
 let motionStartTranslateY = PAGE_PRESENTATION_MOTION_START_TRANSLATE_Y
 let startedAt = 0
-let preserveFrostedMaterial = false
 
 function sampleBezier(time: number, start: number, end: number) {
   const inverse = 1 - time
@@ -72,28 +70,26 @@ function clearDocumentMotionState() {
 /** 先提交 DOM 样式，再发布 revision，保证 renderer 读取到同一帧的真实矩形。 */
 function applyMotionFrame(nextProgress: number) {
   const root = document.documentElement
-  const nextOpacity = preserveFrostedMaterial
-    ? 1
-    : PAGE_PRESENTATION_MOTION_START_OPACITY + (1 - PAGE_PRESENTATION_MOTION_START_OPACITY) * nextProgress
   const nextTranslateY = motionStartTranslateY * (1 - nextProgress)
 
   root.dataset.pagePresentationMotion = 'active'
-  root.style.setProperty('--mp-page-motion-opacity', nextOpacity.toFixed(4))
+  // 父节点 opacity < 1 会截断子表面的 backdrop 采样；整层保持不透明，只动画位移。
+  root.style.setProperty('--mp-page-motion-opacity', '1')
   root.style.setProperty('--mp-page-motion-translate-y', `${nextTranslateY.toFixed(3)}px`)
-  opacity.value = nextOpacity
+  opacity.value = 1
   progress.value = nextProgress
   translateY.value = nextTranslateY
   revision.value += 1
 }
 
-/** 布局门关闭时 DOM 与 renderer 都不暴露尚未稳定的页面几何。 */
+/** 布局门只约束位移与 GPU 动态几何，原生背景材质始终保持同一采样边界。 */
 function applyLayoutHoldFrame() {
   const root = document.documentElement
 
   root.dataset.pagePresentationMotion = 'active'
-  root.style.setProperty('--mp-page-motion-opacity', preserveFrostedMaterial ? '1' : '0')
+  root.style.setProperty('--mp-page-motion-opacity', '1')
   root.style.setProperty('--mp-page-motion-translate-y', `${motionStartTranslateY}px`)
-  opacity.value = preserveFrostedMaterial ? 1 : 0
+  opacity.value = 1
   progress.value = 0
   translateY.value = motionStartTranslateY
   revision.value += 1
@@ -123,7 +119,7 @@ function acknowledgeGeometryReady(motionEpoch: number, timestamp = performance.n
   return true
 }
 
-/** 页面根持续稳定后才开始 reveal；上限避免持续布局页面永久不可见。 */
+/** 页面根持续稳定后才开始位移；上限避免连续布局让入场动画停留在起点。 */
 function sampleLayoutHold(timestamp: number, motionEpoch: number, root: HTMLElement) {
   if (!active.value || epoch.value !== motionEpoch) return
   animationFrame = null
@@ -183,7 +179,7 @@ function renderFrame(timestamp: number, motionEpoch: number) {
 }
 
 /**
- * 需要 renderer 同步或保持磨砂密度的玻璃页面由共享控制器接管；其他页面交给普通 WAAPI。
+ * 玻璃页面保持原生背景采样并与 renderer 同步位移；其他主题交给普通 WAAPI。
  * 返回 true 表示本次路由变化已经处理，包括 reduced-motion 的即时提交。
  */
 function start(nextRouteKey: string, layoutRoot?: HTMLElement | null) {
@@ -198,15 +194,10 @@ function start(nextRouteKey: string, layoutRoot?: HTMLElement | null) {
   epoch.value += 1
   const motionEpoch = epoch.value
   routeKey.value = nextRouteKey
-  preserveFrostedMaterial = document.documentElement.dataset.glassAppearance === 'frosted'
+  const isFrostedMaterial = document.documentElement.dataset.glassAppearance === 'frosted'
   const usesCssQuality = document.documentElement.dataset.glassQuality === 'css'
-  if (usesCssQuality && !preserveFrostedMaterial) {
-    settleMotion()
-    revision.value += 1
-    return false
-  }
 
-  motionStartTranslateY = preserveFrostedMaterial
+  motionStartTranslateY = isFrostedMaterial
     ? PAGE_PRESENTATION_FROSTED_START_TRANSLATE_Y
     : PAGE_PRESENTATION_MOTION_START_TRANSLATE_Y
 

--- a/src/styles/__tests__/glassOverlayMaterial.spec.ts
+++ b/src/styles/__tests__/glassOverlayMaterial.spec.ts
@@ -36,9 +36,38 @@ describe('glass overlay material styles', () => {
     expect(reading).toContain('.layout-window-controls-overlay-shell')
     expect(reading).toContain('.search-desktop-activator')
     expect(reading).toContain('--glass-control-placeholder-color: rgba(242, 245, 250, 82%)')
-    expect(reading).toContain('linear-gradient(rgba(var(--glass-v3-ink), 0.4), rgba(var(--glass-v3-ink), 0.4))')
     expect(reading).not.toContain('backdrop-filter')
     expect(reading).not.toContain('border-radius:')
+  })
+
+  it('diffuses transient overlay backgrounds independently from clear page surfaces', () => {
+    const styles = readFileSync(resolve(cwd(), 'src/styles/themes/_glass-v3.scss'), 'utf8')
+    const popupStart = styles.indexOf('// 所有临时表面采用同族阅读材质')
+    const popupEnd = styles.indexOf('  @supports not', popupStart)
+    const popup = styles.slice(popupStart, popupEnd)
+
+    expect(styles).toContain('--glass-popup-blur: 18px')
+    expect(styles).toContain('--glass-popup-blur: 24px')
+    expect(popup).toContain('--glass-overlay-blur: var(--glass-popup-blur)')
+    expect(popup).toContain('--glass-surface-backdrop-filter: none')
+    expect(popup).toContain('--glass-native-surface-backdrop-filter: none')
+    expect(popup).toContain('--app-grouped-list-backdrop-filter: none')
+    expect(popup).toContain('--v-medium-emphasis-opacity: 0.9')
+    expect(popup).toContain('.v-dialog > .v-overlay__scrim')
+    expect(popup).toContain('--v-overlay-opacity: 1')
+    expect(popup).toContain('backdrop-filter: blur(3px)')
+    for (const host of [
+      '.theme-customizer-panel-host',
+      '.plugin-quick-access',
+      '.agent-assistant-panel',
+      '.v-snackbar__wrapper',
+    ]) {
+      expect(styles).toContain(`'${host}'`)
+    }
+    expect(popup).not.toContain('.layout-navbar')
+    expect(popup).not.toContain('.v-menu > .v-overlay__scrim')
+    expect(styles).toContain('--glass-overlay-backdrop-filter: none !important')
+    expect(styles).not.toContain('linear-gradient(rgba(var(--glass-v3-ink), 0.4)')
   })
 
   it('reserves space below detached desktop navigation and follows the compact theme radius', () => {

--- a/src/styles/__tests__/glassOverlayMaterial.spec.ts
+++ b/src/styles/__tests__/glassOverlayMaterial.spec.ts
@@ -26,6 +26,21 @@ describe('glass overlay material styles', () => {
     )
   })
 
+  it('protects clear reading controls without blurring or changing the floating material', () => {
+    const styles = readFileSync(resolve(cwd(), 'src/styles/themes/_glass-v3.scss'), 'utf8')
+    const readingStart = styles.indexOf('// 固定导航的输入区需要隔开底下滚过的文字')
+    const readingEnd = styles.indexOf('    .v-card {', readingStart)
+    const reading = styles.slice(readingStart, readingEnd)
+
+    expect(reading).toContain('.layout-horizontal-nav-active')
+    expect(reading).toContain('.layout-window-controls-overlay-shell')
+    expect(reading).toContain('.search-desktop-activator')
+    expect(reading).toContain('--glass-control-placeholder-color: rgba(242, 245, 250, 82%)')
+    expect(reading).toContain('linear-gradient(rgba(var(--glass-v3-ink), 0.4), rgba(var(--glass-v3-ink), 0.4))')
+    expect(reading).not.toContain('backdrop-filter')
+    expect(reading).not.toContain('border-radius:')
+  })
+
   it('reserves space below detached desktop navigation and follows the compact theme radius', () => {
     const styles = readFileSync(resolve(cwd(), 'src/styles/themes/_glass-v3.scss'), 'utf8')
 

--- a/src/styles/__tests__/glassOverlayMaterial.spec.ts
+++ b/src/styles/__tests__/glassOverlayMaterial.spec.ts
@@ -523,12 +523,14 @@ describe('glass overlay material styles', () => {
     }
   })
 
-  it('keeps frosted route opacity static while preserving its short movement', () => {
+  it('keeps every glass route on the same backdrop root while preserving its short movement', () => {
     const styles = readFileSync(resolve(cwd(), 'src/styles/themes/glass.scss'), 'utf8')
-
-    expect(styles).toMatch(
-      /\[data-glass-appearance='frosted'\]\[data-page-presentation-motion='active'\]\s+\.mp-page-route\s*\{[\s\S]*?opacity:\s*1;[\s\S]*?transform:\s*translate3d\(0,\s*var\(--mp-page-motion-translate-y,\s*0\),\s*0\);/,
-    )
+    const rule = styles.match(/&\[data-page-presentation-motion='active'\]\s+\.mp-page-route\s*\{([^}]+)\}/)?.[1]
+    expect(rule).toBeDefined()
+    expect(rule).toContain('opacity: 1;')
+    expect(rule).toContain('filter: none;')
+    expect(rule).toContain('transform: translate3d(0, var(--mp-page-motion-translate-y, 0), 0);')
+    expect(rule).toContain('will-change: transform;')
   })
 
   it('keeps floating clear and tinted navbars on CSS material until Chromium SVG is ready', () => {

--- a/src/styles/themes/_glass-v3.scss
+++ b/src/styles/themes/_glass-v3.scss
@@ -326,6 +326,26 @@
   // 清透材质以单条原生轮廓承接真实折射，不让多组柔光在圆角处形成分离的内外弧线。
   html[data-theme='glass']:is([data-glass-appearance='clear'], [data-glass-appearance='tinted'])
     body[data-theme='glass'] {
+    // 固定导航的输入区需要隔开底下滚过的文字；透明与折射保留在外围玻璃表面。
+    .layout-wrapper[data-shell-mode='desktop']:not(.layout-horizontal-nav-active, .layout-window-controls-overlay-shell)
+      .layout-navbar
+      .search-desktop-activator {
+      --glass-control-prominent: rgba(
+        var(--glass-v3-ink),
+        clamp(0.64, calc(0.62 + var(--glass-surface-density, 0.62) * 0.18), 0.82)
+      );
+      --glass-control-prominent-focus: rgba(var(--glass-v3-ink), 0.84);
+      --glass-control-placeholder-color: rgba(242, 245, 250, 82%);
+      --glass-control-icon-color: rgba(242, 245, 250, 90%);
+    }
+
+    // 弹层作为阅读层额外吸收背景细节，沿用原有染色与高光，不对背景做散射。
+    .v-overlay__content > :where(.v-card, .v-sheet, .v-list),
+    .v-overlay__content > form > :where(.v-card, .v-sheet) {
+      background-image:
+        var(--glass-sheen), linear-gradient(rgba(var(--glass-v3-ink), 0.4), rgba(var(--glass-v3-ink), 0.4)) !important;
+    }
+
     .v-card {
       --glass-v3-surface-edge: inset 0 1px 0 var(--glass-highlight);
     }

--- a/src/styles/themes/_glass-v3.scss
+++ b/src/styles/themes/_glass-v3.scss
@@ -1,5 +1,22 @@
 @use '@configured-variables' as variables;
 
+// 临时阅读表面共用材质入口；常驻导航、内容卡片和 Footer Dock 不属于这个集合。
+$-popup-hosts: (
+  '.v-overlay__content',
+  '.theme-customizer-panel-host',
+  '.plugin-quick-access',
+  '.agent-assistant-panel',
+  '.agent-assistant-fab__bubbles',
+  '.agent-assistant-fab__bubble',
+  '.agent-assistant-command-menu',
+  '.agent-assistant-pending-files',
+  '.agent-assistant-input',
+  '.v-snackbar__wrapper',
+  '.Vue-Toastification__toast',
+  '.system-update-prompt',
+  '.layout-vertical-nav.overlay-nav'
+);
+
 // V3 表面按信息角色统一材料；只改变承载层，不改变图表、业务数据与交互命中区。
 @mixin surfaces {
   html[data-theme='glass'] {
@@ -15,6 +32,9 @@
     --glass-v3-navigation-content-gap: 16px;
     --glass-v3-navigation-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
     --glass-v3-navigation-filter: saturate(118%) brightness(var(--glass-transmission-brightness, 1));
+    --glass-popup-blur: 18px;
+    --glass-popup-surface: rgba(31, 34, 39, clamp(0.2, calc(0.14 + var(--glass-surface-density, 0.62) * 0.16), 0.32));
+    --glass-popup-filter: blur(var(--glass-popup-blur)) saturate(135%);
     --glass-v3-card-background:
       linear-gradient(128deg, rgba(255, 255, 255, var(--glass-v3-sheen)), transparent 38%),
       linear-gradient(
@@ -30,6 +50,11 @@
 
     &[data-glass-appearance='tinted'] {
       --glass-v3-card-tint: clamp(0.025, calc(var(--glass-tint-density, 0.65) * 0.13), 0.15);
+      --glass-popup-surface: color-mix(
+        in srgb,
+        rgba(31, 34, 39, clamp(0.2, calc(0.14 + var(--glass-surface-density, 0.72) * 0.16), 0.32)) 90%,
+        rgba(var(--glass-material-accent-rgb), 0.18)
+      );
     }
 
     &[data-glass-appearance='frosted'] {
@@ -37,6 +62,14 @@
       --glass-v3-fill: clamp(0.08, calc(0.065 + var(--glass-surface-density, 0.86) * 0.11), 0.21);
       --glass-v3-sheen: clamp(0.08, calc(0.07 + var(--glass-reflection, 0.35) * 0.22), 0.24);
       --glass-v3-shadow: 0 12px 30px rgba(0, 0, 0, 0.1);
+      // 弹层只比清透变体稍厚，避免与模态遮罩累加成看不见背景的灰板。
+      --glass-popup-blur: 24px;
+      --glass-popup-surface: rgba(
+        31,
+        34,
+        39,
+        clamp(0.24, calc(0.18 + var(--glass-surface-density, 0.86) * 0.14), 0.36)
+      );
     }
 
     body[data-theme='glass'] {
@@ -339,13 +372,6 @@
       --glass-control-icon-color: rgba(242, 245, 250, 90%);
     }
 
-    // 弹层作为阅读层额外吸收背景细节，沿用原有染色与高光，不对背景做散射。
-    .v-overlay__content > :where(.v-card, .v-sheet, .v-list),
-    .v-overlay__content > form > :where(.v-card, .v-sheet) {
-      background-image:
-        var(--glass-sheen), linear-gradient(rgba(var(--glass-v3-ink), 0.4), rgba(var(--glass-v3-ink), 0.4)) !important;
-    }
-
     .v-card {
       --glass-v3-surface-edge: inset 0 1px 0 var(--glass-highlight);
     }
@@ -362,6 +388,62 @@
     }
   }
 
+  // 所有临时表面采用同族阅读材质，Vuetify 容器只传递 token，由真正的表面执行一次采样。
+  html[data-theme='glass'] body[data-theme='glass'] {
+    :is(#{$-popup-hosts}) {
+      --glass-overlay-surface: var(--glass-popup-surface);
+      --glass-overlay-blur: var(--glass-popup-blur);
+      --glass-overlay-backdrop-filter: var(--glass-popup-filter);
+      --glass-native-surface-backdrop-filter: none;
+      --glass-surface-backdrop-filter: none;
+      --glass-raised-backdrop-filter: none;
+      --app-grouped-list-backdrop-filter: none;
+      --v-medium-emphasis-opacity: 0.9;
+      --v-high-emphasis-opacity: 1;
+    }
+
+    // Vuetify 子表面会重新声明主题强调度，阅读层需在实际文字所在的主题边界保持对比。
+    :is(#{$-popup-hosts}) .v-theme--glass {
+      --v-medium-emphasis-opacity: 0.9;
+      --v-high-emphasis-opacity: 1;
+    }
+
+    .v-overlay__content > :where(.v-card, .v-sheet, .v-list),
+    .v-overlay__content > form > :where(.v-card, .v-sheet) {
+      background-image: var(--glass-sheen) !important;
+    }
+
+    .layout-vertical-nav.overlay-nav::before,
+    :is(.agent-assistant-command-menu, .agent-assistant-pending-files, .agent-assistant-input) {
+      backdrop-filter: var(--glass-overlay-backdrop-filter) !important;
+      -webkit-backdrop-filter: var(--glass-overlay-backdrop-filter) !important;
+      background-color: var(--glass-overlay-surface) !important;
+      background-image: var(--glass-sheen) !important;
+    }
+
+    // 消息列表已位于扩散后的面板上，只有浮起的输入和命令区域单独处理其后方内容。
+    .agent-assistant-panel .agent-assistant-shell {
+      --agent-assistant-panel-blur: 0px;
+    }
+
+    .v-dialog {
+      --v-overlay-opacity: 1;
+    }
+
+    .v-dialog > .v-overlay__scrim {
+      background: rgba(12, 14, 18, 0.16);
+      backdrop-filter: blur(3px);
+      -webkit-backdrop-filter: blur(3px);
+    }
+  }
+
+  @supports not ((-webkit-backdrop-filter: blur(1px)) or (backdrop-filter: blur(1px))) {
+    html[data-theme='glass'] body[data-theme='glass'] :is(#{$-popup-hosts}) {
+      --glass-overlay-backdrop-filter: none !important;
+      --glass-overlay-surface: rgb(31, 34, 39) !important;
+    }
+  }
+
   @media (prefers-reduced-transparency: reduce) {
     html[data-theme='glass'] {
       --glass-v3-navigation-filter: none !important;
@@ -369,6 +451,16 @@
     }
 
     html[data-theme='glass'] body[data-theme='glass'] {
+      :is(#{$-popup-hosts}) {
+        --glass-overlay-backdrop-filter: none !important;
+        --glass-overlay-surface: rgb(31, 34, 39) !important;
+      }
+
+      .v-dialog > .v-overlay__scrim {
+        backdrop-filter: none !important;
+        -webkit-backdrop-filter: none !important;
+      }
+
       .layout-wrapper[data-shell-mode='desktop'] .layout-navbar,
       .layout-wrapper[data-shell-mode='desktop'] .layout-vertical-nav::before,
       .layout-page-content :is(.site-card, .plugin-card, .downloading-card, .subscribe-card),

--- a/src/styles/themes/glass.scss
+++ b/src/styles/themes/glass.scss
@@ -370,20 +370,12 @@ html[data-theme='glass'] {
     z-index: 1;
   }
 
-  // 页面 DOM 与 scroll renderer 共用同一 motion 时钟；canvas 本身保持壁纸坐标不动。
+  // 整页 opacity 与 will-change: opacity 会创建 backdrop root，动画期间不能截断子卡片的背景采样。
   &[data-page-presentation-motion='active'] .mp-page-route {
-    filter: none;
-    opacity: var(--mp-page-motion-opacity, 1);
-    transform: translate3d(0, var(--mp-page-motion-translate-y, 0), 0);
-    transform-origin: center top;
-    will-change: opacity, transform;
-  }
-
-  // 磨砂保持最终材质权重，只复用页面呈现时间线做短距离位移。
-  &[data-glass-appearance='frosted'][data-page-presentation-motion='active'] .mp-page-route {
     filter: none;
     opacity: 1;
     transform: translate3d(0, var(--mp-page-motion-translate-y, 0), 0);
+    transform-origin: center top;
     will-change: transform;
   }
 


### PR DESCRIPTION
## 背景

透明、色调玻璃的主页面需要保持背景清晰，但弹层直接复用这套材质会让底层文字干扰阅读。页面切换时，整页淡入还会改变子卡片的背景采样边界，叠加延后的滤镜绑定，形成可见的二次合成过程。

## 主要调整

- 区分常驻页面和临时弹层：主页面透明、色调仍不增加背景模糊；菜单、对话框、主题定制、App 下拉快捷入口、助手面板、提示信息及临时抽屉统一使用独立弹层材质。磨砂弹层使用同族、略厚的变体，保留背景颜色和轮廓。
- 为固定桌面导航搜索区增加局部阅读保护，水平浮动顶栏保持原有材质。
- 临时弹层不再重复参与共享壁纸 WebGL 采样和交互；减少透明度切换后保留可复用的 canvas context，避免恢复高质量时复用已丢失的 context。
- 玻璃页面切换只保留小幅位移，不再通过父容器 opacity 或 will-change: opacity 改变背景采样边界。普通主题维持原有动画。
- 卡片滤镜更新改为下一帧合并，同屏位移图并行解码，避免连续布局事件反复重置等待时间。
- 非 CSS 玻璃档位并行预载光学组件与 Three，保留路由、壁纸、实际挂载和启动屏退出条件，不提前分配 GPU 资源。

现有主题设置项及保存值、导航非线性响应、圆角与水平浮动动画节奏保持不变。

## 验证

- 相关组件、材质、renderer、页面呈现和预载测试共 172 项通过。
- `yarn typecheck`、`yarn lint`、变更文件格式检查、`yarn build` 和 `git diff --check` 通过。
- Chrome 三材质、三质量档共 27 个页面切换场景检查，确认页面始终保持同一背景采样边界。
- 菜单、玻璃设置、主题定制、App 下拉入口和减少透明度恢复共 13 项回归；桌面使用原生视图截图，移动宽度检查无横向溢出。
- 同场景原生 A/B/A 对照确认整页 opacity 变化会改变卡片背景采样，恢复后图像一致。

## 范围说明

这是阶段性改进，不宣称已解决整页 GPU 高占用或全部启动、切页延迟。首次进入大卡片页面的位移图准备、部分刷新中的 renderer 接管间隔，以及三质量档的视觉收益与整体成本，仍需继续优化。Safari 保持 CSS 回退，本 PR 不宣称完成原生 Safari 视觉验收。

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at c3746e5278c67e527eb4a3c6366a988ff7a5ae37

- 统一临时弹层磨砂阅读材质
- 排除弹层参与光学渲染与交互
- 切页仅位移，保持背景采样
- 并行预载 Three 与光学组件
- 合并滤镜更新并行解码卡片
- 透明度偏好切换保留 Canvas context
- 新增材质、动画与渲染回归测试
<!-- pr-agent-summary:end -->
