### PR TITLE
feat(download): add recognition-based source organizer

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -417,6 +417,8 @@ export interface DownloadHistory {
   poster?: string
   // 下载器 Hash
   download_hash?: string
+  // 下载器实例
+  downloader?: string
   // 种子名称
   torrent_name?: string
   // 种子描述
@@ -1070,6 +1072,17 @@ export interface DownloadTaskUpdateData {
   hash: string
   downloader: string
   results: DownloadTaskMutationResult[]
+}
+
+/** 资源目录按媒体类别重新定位的预览或执行结果。 */
+export interface DownloadSourceClassificationData {
+  hash: string
+  downloader: string
+  current_save_path: string
+  target_save_path: string
+  category: string
+  changed: boolean
+  executed: boolean
 }
 
 // 缺失剧集信息

--- a/src/components/dialog/DownloadHistoryDialog.vue
+++ b/src/components/dialog/DownloadHistoryDialog.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import api from '@/api'
-import type { DownloadHistory, DownloadingInfo } from '@/api/types'
-import DownloadTaskSettingsDialog from '@/components/dialog/DownloadTaskSettingsDialog.vue'
+import type { DownloadHistory } from '@/api/types'
+import SourceClassificationDialog from '@/components/dialog/SourceClassificationDialog.vue'
 import { useGlobalSettingsStore } from '@/stores'
 import { getDisplayImageUrl } from '@/utils/imageUtils'
 import { formatDateDifference } from '@core/utils/formatters'
@@ -22,8 +22,7 @@ const currentPage = ref(1)
 const pageSize = 30
 const loading = ref(false)
 const isRefreshed = ref(false)
-const selectedTask = ref<DownloadingInfo>()
-const taskSettingsVisible = ref(false)
+const classifyTask = ref<DownloadHistory>()
 
 /** 分页加载下载历史，并将新页追加到现有列表。 */
 async function loadHistory({ done }: { done: (status: 'empty' | 'error' | 'ok') => void }) {
@@ -86,17 +85,6 @@ function getSeasonEpisode(item: DownloadHistory) {
   return `${item.seasons || ''}${item.episodes || ''}`
 }
 
-/** 以下载历史中的精确 Hash 打开任务设置和资源目录分类。 */
-function openTaskSettings(item: DownloadHistory) {
-  if (!item.download_hash) return
-  selectedTask.value = {
-    downloader: item.downloader,
-    hash: item.download_hash,
-    media: {},
-    title: getHistoryTitle(item),
-  }
-  taskSettingsVisible.value = true
-}
 </script>
 
 <template>
@@ -185,11 +173,9 @@ function openTaskSettings(item: DownloadHistory) {
                       <VIcon icon="mdi-dots-vertical" />
                       <VMenu activator="parent" close-on-content-click>
                         <VList>
-                          <VListItem v-if="item.download_hash" @click="openTaskSettings(item)">
-                            <template #prepend>
-                              <VIcon icon="mdi-folder-move-outline" />
-                            </template>
-                            <VListItemTitle>{{ t('dialog.downloadHistory.classifySource') }}</VListItemTitle>
+                          <VListItem v-if="item.download_hash" @click="classifyTask = item">
+                            <template #prepend><VIcon icon="mdi-folder-move-outline" /></template>
+                            <VListItemTitle>识别与资源归类</VListItemTitle>
                           </VListItem>
                           <VListItem base-color="error" @click="deleteHistory(item)">
                             <template #prepend>
@@ -218,12 +204,7 @@ function openTaskSettings(item: DownloadHistory) {
         </div>
       </VCardText>
 
-      <DownloadTaskSettingsDialog
-        v-if="selectedTask"
-        v-model="taskSettingsVisible"
-        :task="selectedTask"
-        :downloader-name="selectedTask.downloader"
-      />
+      <SourceClassificationDialog v-if="classifyTask" :task="classifyTask" @close="classifyTask = undefined" />
     </VCard>
   </VDialog>
 </template>

--- a/src/components/dialog/DownloadHistoryDialog.vue
+++ b/src/components/dialog/DownloadHistoryDialog.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import api from '@/api'
-import type { DownloadHistory } from '@/api/types'
+import type { DownloadHistory, DownloadingInfo } from '@/api/types'
+import DownloadTaskSettingsDialog from '@/components/dialog/DownloadTaskSettingsDialog.vue'
 import { useGlobalSettingsStore } from '@/stores'
 import { getDisplayImageUrl } from '@/utils/imageUtils'
 import { formatDateDifference } from '@core/utils/formatters'
@@ -21,6 +22,8 @@ const currentPage = ref(1)
 const pageSize = 30
 const loading = ref(false)
 const isRefreshed = ref(false)
+const selectedTask = ref<DownloadingInfo>()
+const taskSettingsVisible = ref(false)
 
 /** 分页加载下载历史，并将新页追加到现有列表。 */
 async function loadHistory({ done }: { done: (status: 'empty' | 'error' | 'ok') => void }) {
@@ -81,6 +84,18 @@ function getHistoryTitle(item: DownloadHistory) {
 /** 合并下载历史的季号和集号。 */
 function getSeasonEpisode(item: DownloadHistory) {
   return `${item.seasons || ''}${item.episodes || ''}`
+}
+
+/** 以下载历史中的精确 Hash 打开任务设置和资源目录分类。 */
+function openTaskSettings(item: DownloadHistory) {
+  if (!item.download_hash) return
+  selectedTask.value = {
+    downloader: item.downloader,
+    hash: item.download_hash,
+    media: {},
+    title: getHistoryTitle(item),
+  }
+  taskSettingsVisible.value = true
 }
 </script>
 
@@ -170,6 +185,12 @@ function getSeasonEpisode(item: DownloadHistory) {
                       <VIcon icon="mdi-dots-vertical" />
                       <VMenu activator="parent" close-on-content-click>
                         <VList>
+                          <VListItem v-if="item.download_hash" @click="openTaskSettings(item)">
+                            <template #prepend>
+                              <VIcon icon="mdi-folder-move-outline" />
+                            </template>
+                            <VListItemTitle>{{ t('dialog.downloadHistory.classifySource') }}</VListItemTitle>
+                          </VListItem>
                           <VListItem base-color="error" @click="deleteHistory(item)">
                             <template #prepend>
                               <VIcon icon="mdi-delete" />
@@ -196,6 +217,13 @@ function getSeasonEpisode(item: DownloadHistory) {
           {{ t('dialog.downloadHistory.noDataHint') }}
         </div>
       </VCardText>
+
+      <DownloadTaskSettingsDialog
+        v-if="selectedTask"
+        v-model="taskSettingsVisible"
+        :task="selectedTask"
+        :downloader-name="selectedTask.downloader"
+      />
     </VCard>
   </VDialog>
 </template>

--- a/src/components/dialog/DownloadHistoryDialog.vue
+++ b/src/components/dialog/DownloadHistoryDialog.vue
@@ -84,7 +84,6 @@ function getHistoryTitle(item: DownloadHistory) {
 function getSeasonEpisode(item: DownloadHistory) {
   return `${item.seasons || ''}${item.episodes || ''}`
 }
-
 </script>
 
 <template>

--- a/src/components/dialog/DownloadTaskSettingsDialog.vue
+++ b/src/components/dialog/DownloadTaskSettingsDialog.vue
@@ -2,6 +2,7 @@
 import api, { ApiRequestError, getApiBusinessErrorMessage, isApiResponse } from '@/api'
 import type {
   DownloadingInfo,
+  DownloadSourceClassificationData,
   DownloadTaskMutationResult,
   DownloadTaskUpdateData,
   DownloadTaskUpdateRequest,
@@ -39,7 +40,10 @@ const toast = useToast()
 const display = useDisplay()
 const formRef = ref()
 const saving = ref(false)
+const classifying = ref(false)
 const results = ref<DownloadTaskMutationResult[]>([])
+const classificationPreview = ref<DownloadSourceClassificationData>()
+const manualMediaCategory = ref('')
 const initialValues = ref<DownloadTaskSettingsForm>()
 
 const visible = computed({
@@ -85,6 +89,8 @@ function resetForm() {
   form.value = createInitialForm()
   initialValues.value = { ...form.value, tags: [], trackers: '' }
   results.value = []
+  classificationPreview.value = undefined
+  manualMediaCategory.value = ''
   formRef.value?.resetValidation?.()
 }
 
@@ -234,6 +240,51 @@ async function saveSettings() {
   }
 }
 
+/** 请求后端按下载历史与当前目录规则计算目标位置。 */
+async function classifySource(execute: boolean) {
+  if (!props.task.hash || classifying.value) return
+  classifying.value = true
+  try {
+    const request: { downloader?: string; execute: boolean; media_category?: string } = {
+      downloader: props.downloaderName || props.task.downloader,
+      execute,
+    }
+    const mediaCategory = manualMediaCategory.value.trim()
+    if (mediaCategory) request.media_category = mediaCategory
+    const data = await api.post<DownloadSourceClassificationData>(
+      `download/${props.task.hash}/classify-source`,
+      request,
+      { feedback: 'silent' },
+    )
+    classificationPreview.value = data
+    if (!execute) return
+    toast.success(
+      data.executed
+        ? t('downloading.settings.sourceClassificationSuccess')
+        : t('downloading.settings.sourceClassificationUnchanged'),
+    )
+    emit('saved', {
+      downloader: data.downloader,
+      hash: data.hash,
+      results: [
+        {
+          operation: 'save_path',
+          success: true,
+          message: data.executed
+            ? t('downloading.settings.sourceClassificationSuccess')
+            : t('downloading.settings.sourceClassificationUnchanged'),
+        },
+      ],
+    })
+    visible.value = false
+  } catch (error) {
+    console.error('资源目录按类别分类失败:', error)
+    toast.error(getApiBusinessErrorMessage(error) || t('downloading.settings.sourceClassificationFailed'))
+  } finally {
+    classifying.value = false
+  }
+}
+
 watch(
   () => props.modelValue,
   value => {
@@ -331,6 +382,69 @@ watch(
                 />
               </VCol>
             </VRow>
+
+            <VTextField
+              v-model="manualMediaCategory"
+              class="mt-3"
+              :label="t('downloading.settings.manualMediaCategory')"
+              :hint="t('downloading.settings.manualMediaCategoryHint')"
+              persistent-hint
+              prepend-inner-icon="mdi-shape-plus-outline"
+              @update:model-value="classificationPreview = undefined"
+            />
+
+            <VAlert class="mt-3" type="info" variant="tonal" density="compact">
+              <div>{{ t('downloading.settings.sourceClassificationHint') }}</div>
+              <template #append>
+                <VBtn
+                  variant="tonal"
+                  size="small"
+                  prepend-icon="mdi-folder-arrow-right-outline"
+                  :loading="classifying && !classificationPreview"
+                  :disabled="classifying || !task.hash"
+                  @click="classifySource(false)"
+                >
+                  {{ t('downloading.settings.previewSourceClassification') }}
+                </VBtn>
+              </template>
+            </VAlert>
+
+            <VCard
+              v-if="classificationPreview"
+              class="download-task-settings-dialog__classification-preview mt-3"
+              variant="outlined"
+            >
+              <VCardText>
+                <div class="text-caption text-medium-emphasis">
+                  {{ t('downloading.settings.classificationCategory') }}
+                </div>
+                <div class="mb-2">{{ classificationPreview.category }}</div>
+                <div class="text-caption text-medium-emphasis">
+                  {{ t('downloading.settings.currentSavePath') }}
+                </div>
+                <code>{{ classificationPreview.current_save_path }}</code>
+                <div class="text-caption text-medium-emphasis mt-2">
+                  {{ t('downloading.settings.targetSavePath') }}
+                </div>
+                <code>{{ classificationPreview.target_save_path }}</code>
+              </VCardText>
+              <VCardActions v-if="classificationPreview.changed">
+                <VSpacer />
+                <VBtn
+                  color="primary"
+                  variant="flat"
+                  prepend-icon="mdi-folder-move-outline"
+                  :loading="classifying"
+                  :disabled="classifying"
+                  @click="classifySource(true)"
+                >
+                  {{ t('downloading.settings.confirmSourceClassification') }}
+                </VBtn>
+              </VCardActions>
+              <VCardText v-else class="pt-0 text-success">
+                {{ t('downloading.settings.sourceClassificationUnchanged') }}
+              </VCardText>
+            </VCard>
           </section>
 
           <section class="download-task-settings-dialog__section">
@@ -423,6 +537,10 @@ watch(
 
 .download-task-settings-dialog__results {
   border-radius: var(--app-control-radius);
+}
+
+.download-task-settings-dialog__classification-preview code {
+  overflow-wrap: anywhere;
 }
 
 .download-task-settings-dialog__result {

--- a/src/components/dialog/SourceClassificationDialog.vue
+++ b/src/components/dialog/SourceClassificationDialog.vue
@@ -274,4 +274,3 @@ async function submit(execute = false) {
     />
   </VDialog>
 </template>
-

--- a/src/components/dialog/SourceClassificationDialog.vue
+++ b/src/components/dialog/SourceClassificationDialog.vue
@@ -1,0 +1,277 @@
+<script setup lang="ts">
+import api, { getApiBusinessErrorMessage } from '@/api'
+import type { DownloadHistory, MediaDataSource, MusicEntityType } from '@/api/types'
+import MediaIdSelector from '@/components/misc/MediaIdSelector.vue'
+import { useToast } from 'vue-toastification'
+
+type MediaTypeName = '电影' | '电视剧' | '音乐'
+type OrganizationMode = 'recognize' | 'manual'
+
+interface OrganizationPlan {
+  hash: string
+  downloader: string
+  mode: OrganizationMode
+  recognized: boolean
+  media_type?: string
+  media_source?: string
+  media_id?: string
+  title?: string
+  year?: string
+  current_save_path: string
+  target_save_path: string
+  current_content_path?: string
+  category?: string
+  secondary_categories: string[]
+  current_root_name?: string
+  proposed_root_name?: string
+  rename_supported: boolean
+  rename_required: boolean
+  changed: boolean
+  executed: boolean
+  relocated: boolean
+  renamed: boolean
+}
+
+const props = defineProps<{ task: DownloadHistory }>()
+const emit = defineEmits(['close'])
+const toast = useToast()
+
+const normalizeType = (value?: string): MediaTypeName | undefined =>
+  ['电影', '电视剧', '音乐'].includes(value || '') ? (value as MediaTypeName) : undefined
+
+const mode = ref<OrganizationMode>('recognize')
+const typeName = ref<MediaTypeName | undefined>(normalizeType(props.task.type))
+const mediaSource = ref<MediaDataSource | null>(props.task.media_source || null)
+const mediaId = ref(props.task.media_id || '')
+const musicType = ref<Exclude<MusicEntityType, 'artist'>>('album')
+const episodeGroup = ref('')
+const targetPath = ref('')
+const targetPathItems = ref<{ title: string; value: string }[]>([])
+const smartRename = ref(true)
+const selectorVisible = ref(false)
+const busy = ref(false)
+const error = ref('')
+const plan = ref<OrganizationPlan>()
+
+onMounted(async () => {
+  try {
+    const directories =
+      await api.get<
+        { name?: string; download_path?: string; save_path?: string; media_type?: string; media_category?: string }[]
+      >('download/paths')
+    targetPathItems.value = directories
+      .filter(item => item.download_path)
+      .map(item => ({
+        title: [item.name, item.media_type, item.media_category, item.download_path].filter(Boolean).join(' · '),
+        value: item.download_path || item.save_path || '',
+      }))
+  } catch {
+    // 目录列表加载失败时仍允许管理员输入配置根下的完整路径。
+  }
+})
+
+const typeItems = [
+  { title: '自动（使用下载历史）', value: undefined },
+  { title: '电影', value: '电影' },
+  { title: '电视剧', value: '电视剧' },
+  { title: '音乐', value: '音乐' },
+]
+
+const sourceItems = computed(() => {
+  const automatic = [{ title: '自动', value: null }]
+  if (typeName.value === '音乐') {
+    return [
+      ...automatic,
+      { title: 'MusicBrainz', value: 'musicbrainz' },
+      { title: 'TheAudioDB', value: 'theaudiodb' },
+      { title: '豆瓣音乐', value: 'doubanmusic' },
+    ]
+  }
+  return [
+    ...automatic,
+    { title: 'TheMovieDb', value: 'themoviedb' },
+    { title: '豆瓣', value: 'douban' },
+    { title: 'Bangumi', value: 'bangumi' },
+    { title: 'AniList', value: 'anilist' },
+  ]
+})
+
+function invalidatePlan() {
+  plan.value = undefined
+  error.value = ''
+}
+
+watch([mode, typeName, mediaSource, mediaId, musicType, episodeGroup, targetPath, smartRename], invalidatePlan)
+watch(typeName, () => {
+  const allowed = sourceItems.value.some(item => item.value === mediaSource.value)
+  if (!allowed) {
+    mediaSource.value = null
+    mediaId.value = ''
+  }
+})
+watch(mediaSource, (next, previous) => {
+  if (next !== previous) mediaId.value = ''
+})
+
+function selectMedia(item: { music_type?: MusicEntityType }) {
+  if (item.music_type === 'album' || item.music_type === 'recording') musicType.value = item.music_type
+  selectorVisible.value = false
+}
+
+async function submit(execute = false) {
+  if (!props.task.download_hash || busy.value) return
+  busy.value = true
+  error.value = ''
+  try {
+    const result = await api.post<OrganizationPlan>(
+      `download/${props.task.download_hash}/classify-source`,
+      {
+        execute,
+        mode: mode.value,
+        target_path: mode.value === 'manual' ? targetPath.value.trim() : undefined,
+        type_name: typeName.value,
+        media_source: mediaSource.value || undefined,
+        media_id: mediaSource.value && mediaId.value.trim() ? mediaId.value.trim() : undefined,
+        music_type: typeName.value === '音乐' ? musicType.value : undefined,
+        episode_group: typeName.value === '电视剧' && episodeGroup.value.trim() ? episodeGroup.value.trim() : undefined,
+        smart_rename: smartRename.value,
+        expected_current_path: execute ? plan.value?.current_save_path : undefined,
+        expected_target_path: execute ? plan.value?.target_save_path : undefined,
+        expected_content_path: execute ? plan.value?.current_content_path : undefined,
+        expected_root_name: execute ? plan.value?.proposed_root_name : undefined,
+      },
+      { feedback: 'silent' },
+    )
+    plan.value = result
+    if (execute) {
+      toast.success(result.executed ? '已由下载器执行识别归类计划' : '任务已符合当前规则')
+      emit('close')
+    }
+  } catch (reason) {
+    error.value = getApiBusinessErrorMessage(reason) || '识别或预览失败'
+  } finally {
+    busy.value = false
+  }
+}
+</script>
+
+<template>
+  <VDialog :model-value="true" max-width="920" scrollable @update:model-value="emit('close')">
+    <VCard title="识别与资源归类">
+      <VCardText>
+        <div class="text-subtitle-1 mb-4">{{ task.title || task.torrent_name }}</div>
+        <VAlert type="info" variant="tonal" class="mb-5">
+          复用 MoviePilot 的媒体识别，并且只通过下载器改保存位置或种子根目录名。不会刮削媒体，也不会修改音频标签。
+        </VAlert>
+
+        <VBtnToggle v-model="mode" mandatory divided color="primary" class="mb-5">
+          <VBtn value="recognize" prepend-icon="mdi-auto-fix">系统识别归类</VBtn>
+          <VBtn value="manual" prepend-icon="mdi-folder-edit-outline">手动指定目录</VBtn>
+        </VBtnToggle>
+
+        <VRow>
+          <VCol cols="12" md="4">
+            <VSelect v-model="typeName" :items="typeItems" label="类型" :disabled="busy" clearable />
+          </VCol>
+          <VCol cols="12" md="4">
+            <VSelect v-model="mediaSource" :items="sourceItems" label="数据源" :disabled="busy" />
+          </VCol>
+          <VCol v-if="typeName === '音乐'" cols="12" md="4">
+            <VSelect
+              v-model="musicType"
+              :items="[
+                { title: '专辑', value: 'album' },
+                { title: '单曲', value: 'recording' },
+              ]"
+              label="音乐实体"
+              :disabled="busy"
+            />
+          </VCol>
+          <VCol v-if="typeName === '电视剧'" cols="12" md="4">
+            <VTextField v-model="episodeGroup" label="剧集组（可选）" :disabled="busy" />
+          </VCol>
+          <VCol v-if="mediaSource" cols="12">
+            <VTextField v-model="mediaId" label="数据源原生 ID" :disabled="busy">
+              <template #append-inner>
+                <IconBtn aria-label="搜索媒体 ID" @click="selectorVisible = true">
+                  <VIcon icon="mdi-magnify" />
+                </IconBtn>
+              </template>
+            </VTextField>
+          </VCol>
+          <VCol v-if="mode === 'manual'" cols="12">
+            <VCombobox
+              v-model="targetPath"
+              :items="targetPathItems"
+              label="目标资源目录"
+              placeholder="/volume1/UT/Musics/Album"
+              hint="必须位于 MoviePilot 已配置的资源目录内"
+              persistent-hint
+              :disabled="busy"
+              clearable
+            />
+          </VCol>
+        </VRow>
+
+        <VSwitch
+          v-model="smartRename"
+          color="primary"
+          label="识别后规范化种子根目录名"
+          hint="仅支持 qBittorrent 的单根目录任务，由 qBittorrent 执行 renameFolder，保持做种关系"
+          persistent-hint
+          class="mb-3"
+        />
+
+        <VAlert v-if="error" type="error" variant="tonal" class="mt-3">{{ error }}</VAlert>
+        <VCard v-if="plan" variant="tonal" class="mt-5">
+          <VCardTitle class="text-subtitle-1">执行预览</VCardTitle>
+          <VCardText style="overflow-wrap: anywhere">
+            <VRow dense>
+              <VCol cols="12" md="6"
+                ><b>识别：</b>{{ plan.title || '未识别' }}{{ plan.year ? ` (${plan.year})` : '' }}</VCol
+              >
+              <VCol cols="12" md="6"><b>类型：</b>{{ plan.media_type || '-' }}</VCol>
+              <VCol cols="12" md="6"><b>主分类：</b>{{ plan.category || '-' }}</VCol>
+              <VCol cols="12" md="6"><b>副分类：</b>{{ plan.secondary_categories.join('、') || '-' }}</VCol>
+            </VRow>
+            <VDivider class="my-3" />
+            <div>
+              <b>当前位置：</b><code>{{ plan.current_save_path }}</code>
+            </div>
+            <div class="mt-2">
+              <b>目标位置：</b><code>{{ plan.target_save_path }}</code>
+            </div>
+            <div class="mt-3">
+              <b>当前根目录：</b><code>{{ plan.current_root_name || '无单一根目录' }}</code>
+            </div>
+            <div class="mt-2">
+              <b>规范根目录：</b><code>{{ plan.proposed_root_name || '-' }}</code>
+            </div>
+            <VAlert v-if="!plan.changed" type="success" variant="tonal" class="mt-4">任务已符合当前规则</VAlert>
+          </VCardText>
+        </VCard>
+      </VCardText>
+      <VCardActions>
+        <VBtn :disabled="busy" @click="emit('close')">关闭</VBtn>
+        <VSpacer />
+        <VBtn :loading="busy" :disabled="busy || (mode === 'manual' && !targetPath.trim())" @click="submit(false)">
+          识别并预览
+        </VBtn>
+        <VBtn v-if="plan?.changed" color="primary" variant="flat" :disabled="busy" @click="submit(true)">
+          确认由下载器执行
+        </VBtn>
+      </VCardActions>
+    </VCard>
+  </VDialog>
+
+  <VDialog v-if="mediaSource" v-model="selectorVisible" max-width="50rem">
+    <MediaIdSelector
+      v-model="mediaId"
+      :type="mediaSource"
+      :music-types="typeName === '音乐' ? [musicType] : undefined"
+      @select="selectMedia"
+      @close="selectorVisible = false"
+    />
+  </VDialog>
+</template>
+

--- a/src/components/dialog/__tests__/DownloadHistoryDialog.spec.ts
+++ b/src/components/dialog/__tests__/DownloadHistoryDialog.spec.ts
@@ -256,6 +256,23 @@ describe('DownloadHistoryDialog', () => {
     expect(deletedBodies).toEqual([item])
   })
 
+  it('opens resource-category management for a history that still has a task hash', async () => {
+    const item = createHistory({
+      download_hash: '0123456789abcdef0123456789abcdef01234567',
+      downloader: 'qb-main',
+      title: '待重新分类',
+    })
+    server.use(downloadHistoryHandler([item]))
+    const user = userEvent.setup()
+
+    await renderDialog()
+
+    await user.click(await screen.findByText('资源目录按类别分类'))
+
+    expect(screen.getByRole('button', { name: '预览按类别分类' })).toBeInTheDocument()
+    expect(screen.getAllByText('待重新分类')).not.toHaveLength(0)
+  })
+
   it('offers a retry after the first load fails', async () => {
     const item = createHistory({ title: '重试成功历史' })
     let requestCount = 0

--- a/src/components/dialog/__tests__/DownloadTaskSettingsDialog.spec.ts
+++ b/src/components/dialog/__tests__/DownloadTaskSettingsDialog.spec.ts
@@ -3,6 +3,7 @@ import DownloadTaskSettingsDialog from '@/components/dialog/DownloadTaskSettings
 import { fireEvent, screen, waitFor } from '@testing-library/vue'
 import { renderWithProviders } from '@tests/support/render'
 import { updateDownloadTaskHandler } from '@tests/support/msw/handlers/download'
+import { classifyDownloadSourceHandler } from '@tests/support/msw/handlers/download'
 import { server } from '@tests/support/msw/server'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -154,5 +155,47 @@ describe('DownloadTaskSettingsDialog', () => {
     await renderDialog()
 
     expect(screen.getByRole('button', { name: '保存' })).toBeDisabled()
+  })
+
+  it('previews the category target before asking the downloader to move', async () => {
+    const requested = vi.fn<(body: { downloader?: string; execute: boolean; media_category?: string }) => void>()
+    server.use(
+      classifyDownloadSourceHandler(
+        HASH,
+        body => ({
+          category: 'Album',
+          changed: true,
+          current_save_path: '/volume1/UT/Musics',
+          downloader: 'qb-main',
+          executed: body.execute,
+          hash: HASH,
+          target_save_path: '/volume1/UT/Musics/Album',
+        }),
+        requested,
+      ),
+    )
+    const { emitted } = await renderDialog()
+
+    await fireEvent.update(screen.getByLabelText('手动媒体分类（可选）'), 'Album')
+    await fireEvent.click(screen.getByRole('button', { name: '预览按类别分类' }))
+
+    expect(await screen.findByText('/volume1/UT/Musics/Album')).toBeInTheDocument()
+    expect(requested).toHaveBeenNthCalledWith(1, {
+      downloader: 'qb-main',
+      execute: false,
+      media_category: 'Album',
+    })
+    expect(emitted().saved).toBeUndefined()
+
+    await fireEvent.click(screen.getByRole('button', { name: '确认由下载器移动' }))
+
+    await waitFor(() => expect(requested).toHaveBeenCalledTimes(2))
+    expect(requested).toHaveBeenNthCalledWith(2, {
+      downloader: 'qb-main',
+      execute: true,
+      media_category: 'Album',
+    })
+    expect(mocks.toastSuccess).toHaveBeenCalledWith('资源目录已按类别重新定位')
+    expect(emitted().saved).toHaveLength(1)
   })
 })

--- a/src/locales/en-US.ts
+++ b/src/locales/en-US.ts
@@ -1549,6 +1549,19 @@ export default {
       saveSuccess: 'Download task settings saved',
       saveFailed: 'Failed to save download task settings',
       partialFailure: 'Some settings were not applied. Review the operation results.',
+      sourceClassificationHint:
+        'Recalculate the location from the media category stored at download time and the current resource-directory rules. After confirmation, the downloader moves the task without directly manipulating PT files.',
+      previewSourceClassification: 'Preview category location',
+      confirmSourceClassification: 'Move with downloader',
+      classificationCategory: 'Media Category',
+      currentSavePath: 'Current Save Path',
+      targetSavePath: 'Target Save Path',
+      sourceClassificationSuccess: 'Resource directory moved to its category location',
+      sourceClassificationUnchanged: 'The current save path already matches the category rule',
+      sourceClassificationFailed: 'Failed to classify the resource directory',
+      manualMediaCategory: 'Manual Media Category (optional)',
+      manualMediaCategoryHint:
+        'Use only when old download history has no category, for example Album. It must exactly match a path in the active classification policy.',
     },
   },
   resource: {
@@ -4271,6 +4284,7 @@ export default {
       noDataHint: 'Added download tasks will be displayed here',
       loadFailed: 'Failed to load download history',
       deleteFailed: 'Failed to delete download history',
+      classifySource: 'Classify resource directory',
     },
     siteUserData: {
       title: 'Site User Data',

--- a/src/locales/zh-CN.ts
+++ b/src/locales/zh-CN.ts
@@ -1528,6 +1528,18 @@ export default {
       saveSuccess: '下载任务设置已保存',
       saveFailed: '下载任务设置保存失败',
       partialFailure: '部分设置未生效，请查看逐项结果',
+      sourceClassificationHint:
+        '按下载时的媒体分类与当前资源目录规则重新定位。确认后由下载器移动，不直接操作 PT 文件。',
+      previewSourceClassification: '预览按类别分类',
+      confirmSourceClassification: '确认由下载器移动',
+      classificationCategory: '媒体分类',
+      currentSavePath: '当前保存目录',
+      targetSavePath: '目标保存目录',
+      sourceClassificationSuccess: '资源目录已按类别重新定位',
+      sourceClassificationUnchanged: '当前保存目录已符合分类规则',
+      sourceClassificationFailed: '资源目录按类别分类失败',
+      manualMediaCategory: '手动媒体分类（可选）',
+      manualMediaCategoryHint: '仅当旧下载历史没有分类时填写，例如 Album；必须与当前自动分类策略中的目录完全一致。',
     },
   },
   resource: {
@@ -4181,6 +4193,7 @@ export default {
       noDataHint: '已添加的下载任务会显示在这里',
       loadFailed: '下载历史加载失败',
       deleteFailed: '下载历史删除失败',
+      classifySource: '资源目录按类别分类',
     },
     siteUserData: {
       title: '站点用户数据',

--- a/tests/support/msw/handlers/download.ts
+++ b/tests/support/msw/handlers/download.ts
@@ -1,4 +1,10 @@
-import type { DownloadHistory, DownloadingInfo, DownloadTaskUpdateData, DownloadTaskUpdateRequest } from '@/api/types'
+import type {
+  DownloadHistory,
+  DownloadingInfo,
+  DownloadSourceClassificationData,
+  DownloadTaskUpdateData,
+  DownloadTaskUpdateRequest,
+} from '@/api/types'
 import { HttpResponse, http, type JsonBodyType } from 'msw'
 import { apiFailureJson, apiJson } from '../response'
 
@@ -13,8 +19,28 @@ export const downloadApiUrls = {
   action: (operation: 'start' | 'stop', hash: string) => new URL(`download/${operation}/${hash}`, API_BASE_URL).href,
   delete: (hash: string) => new URL(`download/${hash}`, API_BASE_URL).href,
   update: (hash: string) => new URL(`download/${hash}`, API_BASE_URL).href,
+  classifySource: (hash: string) => new URL(`download/${hash}/classify-source`, API_BASE_URL).href,
   list: new URL('download/', API_BASE_URL).href,
   history: new URL('history/download', API_BASE_URL).href,
+}
+
+/** 拦截资源目录分类预览或执行请求。 */
+export function classifyDownloadSourceHandler(
+  hash: string,
+  response:
+    | DownloadSourceClassificationData
+    | ((body: { downloader?: string; execute: boolean; media_category?: string }) => DownloadSourceClassificationData),
+  onRequest: (body: {
+    downloader?: string
+    execute: boolean
+    media_category?: string
+  }) => void | Promise<void> = () => {},
+) {
+  return http.post(downloadApiUrls.classifySource(hash), async ({ request }) => {
+    const body = (await request.json()) as { downloader?: string; execute: boolean; media_category?: string }
+    await onRequest(body)
+    return apiJson(typeof response === 'function' ? response(body) : response)
+  })
 }
 
 /** 拦截下载任务高级修改并保留请求体供断言。 */


### PR DESCRIPTION
## Summary
- replace the narrow category action with a unified recognition and source-organization dialog
- reuse media type, data source, native ID search, music entity, and TV episode-group inputs
- support system-recognized destinations or a manually selected configured download directory
- preview media identity, primary/secondary category, target path, and qBittorrent root rename before execution

## Safety UX
- explicitly states that this operation does not scrape metadata or modify audio tags
- only enables execution after a successful preview
- explains that qBittorrent performs root renaming to preserve the seeding relationship

Backend companion: jxxghp/MoviePilot#6599

## Verification
- Vue typecheck and production build passed on the deployment snapshot
- deployed asset was served successfully by the test MoviePilot instance

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at e5cd9bc4c4e740bb2949c2adbbef6d5306117089

- 新增下载历史识别归类与手动迁移
- 支持预览后由下载器移动、重命名
- 扩展任务设置中的分类目录预览
- 补充接口模拟测试；历史入口文案不一致风险
<!-- pr-agent-summary:end -->
