### PR TITLE
feat(resource): 搜索筛选项按已选条件级联收敛

### DIFF
--- a/src/composables/__tests__/useTorrentFilter.spec.ts
+++ b/src/composables/__tests__/useTorrentFilter.spec.ts
@@ -81,6 +81,92 @@ describe('useTorrentFilter', () => {
     expect(filter.filterOptions.season).toEqual(['S10', 'S02', 'S10E01-E03', 'S01E12', 'Special'])
   })
 
+  it('cascades filter options to the values that still match the other selected dimensions', () => {
+    const filter = useTorrentFilter()
+    const torrents = [
+      createTorrent({ freeState: 'FREE', season: 'S01', site: 'Site A' }),
+      createTorrent({ freeState: 'NORMAL', season: 'S02', site: 'Site B' }),
+      createTorrent({ freeState: 'NORMAL', season: 'S02', site: 'Site A' }),
+      createTorrent({ freeState: 'FREE', season: 'S03', site: 'Site C' }),
+    ]
+    filter.filterForm.freeState = ['FREE']
+
+    const result = filter.filterRowData(torrents)
+
+    expect(filter.filterOptions.site).toEqual(['Site A', 'Site C'])
+    expect(filter.filterOptions.season).toEqual(['S03', 'S01'])
+    expect(filter.filterOptions.freeState).toEqual(['FREE', 'NORMAL'])
+    expect(result.map(item => item.torrent_info.site_name)).toEqual(['Site A', 'Site C'])
+    expect(filter.totalFilteredCount.value).toBe(2)
+  })
+
+  it('excludes only the dimension itself so a constrained dimension keeps its alternative values', () => {
+    const filter = useTorrentFilter()
+    const torrents = [
+      createTorrent({ freeState: 'FREE', site: 'Site A' }),
+      createTorrent({ freeState: 'NORMAL', site: 'Site A' }),
+      createTorrent({ freeState: 'FREE', site: 'Site C' }),
+      createTorrent({ freeState: 'NORMAL', site: 'Site B' }),
+    ]
+    filter.filterForm.site = ['Site A']
+    filter.filterForm.freeState = ['FREE']
+
+    filter.filterRowData(torrents)
+
+    expect(filter.filterOptions.site).toEqual(['Site A', 'Site C'])
+    expect(filter.filterOptions.freeState).toEqual(['FREE', 'NORMAL'])
+    expect(filter.totalFilteredCount.value).toBe(1)
+  })
+
+  it('keeps an already selected value available and sticky when other dimensions exclude it', () => {
+    const filter = useTorrentFilter()
+    const torrents = [
+      createTorrent({ freeState: 'NORMAL', site: 'Site A', title: '普通资源' }),
+      createTorrent({ freeState: 'FREE', site: 'Site B', title: '免费资源 B' }),
+      createTorrent({ freeState: 'FREE', site: 'Site C', title: '免费资源 C' }),
+    ]
+    filter.filterForm.site = ['Site A', 'Site B']
+    filter.filterForm.freeState = ['FREE']
+    const selectedSites = filter.filterForm.site
+
+    expect(filter.filterRowData(torrents).map(item => item.torrent_info.title)).toEqual(['免费资源 B'])
+    expect(filter.getFilteredIndices()).toEqual([1])
+    expect(filter.filterOptions.site).toEqual(['Site B', 'Site C', 'Site A'])
+    expect(filter.filterForm.site).toBe(selectedSites)
+    expect(filter.filterForm.site).toEqual(['Site A', 'Site B'])
+
+    filter.filterForm.freeState = []
+    expect(filter.filterRowData(torrents).map(item => item.torrent_info.title)).toEqual(['普通资源', '免费资源 B'])
+  })
+
+  it('cascades options with the same rules in grouped card view', () => {
+    const filter = useTorrentFilter()
+    const torrents = [
+      createTorrent({ freeState: 'FREE', pageUrl: 'https://example.test/a1', site: 'Site A', title: '同组一' }),
+      createTorrent({ freeState: 'FREE', pageUrl: 'https://example.test/a2', site: 'Site A', title: '同组二' }),
+      createTorrent({ freeState: 'NORMAL', name: '另一媒体', site: 'Site B', title: '另一组' }),
+    ]
+    filter.filterForm.freeState = ['FREE']
+
+    const result = filter.filterCardData(torrents)
+
+    expect(filter.filterOptions.site).toEqual(['Site A'])
+    expect(filter.filterOptions.freeState).toEqual(['FREE', 'NORMAL'])
+    expect(result).toHaveLength(1)
+    expect(result[0].more?.map(item => item.torrent_info.title)).toEqual(['同组二'])
+    expect(filter.totalFilteredCount.value).toBe(2)
+    expect(filter.getFilteredIndices()).toEqual([0, 1])
+  })
+
+  it('clears options but keeps selections when there is nothing to filter', () => {
+    const filter = useTorrentFilter()
+    filter.filterForm.site = ['Site A']
+
+    expect(filter.filterRowData([])).toEqual([])
+    expect(filter.filterOptions.site).toEqual([])
+    expect(filter.filterForm.site).toEqual(['Site A'])
+  })
+
   it('combines filters and exposes every matching original row index', () => {
     const filter = useTorrentFilter()
     const torrents = [

--- a/src/composables/useTorrentFilter.ts
+++ b/src/composables/useTorrentFilter.ts
@@ -78,27 +78,17 @@ export function useTorrentFilter() {
   // 筛选后的总数量
   const totalFilteredCount = ref(0)
 
-  // 初始化过滤选项
-  function initOptions(data: Context) {
-    const { torrent_info, meta_info } = data
-    const optionValue = (options: Array<string>, value: string | undefined) => {
-      if (value && !options.includes(value)) {
-        options.push(value)
-        // 如果是season选项，立即触发重新计算
-        if (options === filterOptions.season) {
-          sortSeasonOptions()
-        }
-      }
-    }
-
-    optionValue(filterOptions.site, torrent_info?.site_name)
-    optionValue(filterOptions.season, meta_info?.season_episode)
-    optionValue(filterOptions.releaseGroup, meta_info?.resource_team)
-    optionValue(filterOptions.videoCode, meta_info?.video_encode)
-    optionValue(filterOptions.freeState, torrent_info?.volume_factor)
-    optionValue(filterOptions.edition, meta_info?.edition)
-    optionValue(filterOptions.resolution, meta_info?.resource_pix)
+  // 各筛选维度对应的资源字段读取器，选项收集与结果筛选共用同一来源
+  const filterValueGetters: Record<string, (data: Context) => string | undefined> = {
+    site: data => data.torrent_info?.site_name,
+    season: data => data.meta_info?.season_episode,
+    releaseGroup: data => data.meta_info?.resource_team,
+    videoCode: data => data.meta_info?.video_encode,
+    freeState: data => data.torrent_info?.volume_factor,
+    edition: data => data.meta_info?.edition,
+    resolution: data => data.meta_info?.resource_pix,
   }
+  const filterKeys = Object.keys(filterValueGetters)
 
   // 直接对季集选项进行排序的函数
   function sortSeasonOptions() {
@@ -166,11 +156,60 @@ export function useTorrentFilter() {
 
   // 匹配过滤函数
   const match = (filter: Array<string>, value: string | undefined) =>
-    filter.length === 0 || (value && filter.includes(value))
+    filter.length === 0 || (!!value && filter.includes(value))
 
   // 搜索结果必须同时包含可展示的元数据和种子信息。
   function isRenderableContext(data: Context | null | undefined): data is Context {
     return Boolean(data?.meta_info && data?.torrent_info)
+  }
+
+  // 资源是否满足某个维度当前选中的筛选条件
+  function matchesFilter(key: string, data: Context) {
+    return match(filterForm[key], filterValueGetters[key](data))
+  }
+
+  // 资源是否同时满足全部维度的筛选条件
+  function matchesAllFilters(data: Context) {
+    return filterKeys.every(key => matchesFilter(key, data))
+  }
+
+  // 清空全部过滤选项
+  function resetOptions() {
+    for (const key of filterKeys) {
+      filterOptions[key] = []
+    }
+  }
+
+  // 级联收集过滤选项：每个维度只提供“满足其余维度筛选条件”的资源取值，自身维度不参与约束。
+  // 例如选中促销=免费后，站点选项只剩仍有免费资源的站点，而促销维度本身仍可切换或多选。
+  // 已选中的值始终保留在选项中，保证对应筹码可见、可取消，不会因其他维度收窄而静默丢失。
+  function collectOptions(items: Context[]) {
+    const collected: Record<string, Set<string>> = {}
+    for (const key of filterKeys) {
+      collected[key] = new Set<string>()
+    }
+
+    for (const data of items) {
+      if (!isRenderableContext(data)) continue
+
+      const unmatchedKeys = filterKeys.filter(key => !matchesFilter(key, data))
+      // 两个及以上维度不满足时，无论排除哪一个维度都无法命中，不贡献任何选项
+      if (unmatchedKeys.length > 1) continue
+      // 全部满足时贡献到每个维度；仅一个维度不满足时只贡献到该维度（即排除自身维度）
+      const targetKeys = unmatchedKeys.length === 1 ? unmatchedKeys : filterKeys
+      for (const key of targetKeys) {
+        const value = filterValueGetters[key](data)
+        if (value) collected[key].add(value)
+      }
+    }
+
+    for (const key of filterKeys) {
+      for (const value of filterForm[key]) {
+        collected[key].add(value)
+      }
+      filterOptions[key] = [...collected[key]]
+    }
+    sortSeasonOptions()
   }
 
   // 筛选列表视图数据（不分组）
@@ -178,22 +217,14 @@ export function useTorrentFilter() {
     // 重置状态
     filteredIndices.value = []
 
-    // 清空并重新初始化过滤选项
-    for (const key in filterOptions) {
-      filterOptions[key] = []
-    }
-
     if (!items?.length) {
+      resetOptions()
       totalFilteredCount.value = 0
       return []
     }
 
-    // 首先收集所有过滤选项
-    items.forEach(data => {
-      if (isRenderableContext(data)) {
-        initOptions(data)
-      }
-    })
+    // 按当前筛选条件级联收集过滤选项
+    collectOptions(items)
 
     // 筛选数据
     let filteredData: Context[] = []
@@ -201,16 +232,7 @@ export function useTorrentFilter() {
     items.forEach((data, index) => {
       if (!isRenderableContext(data)) return
 
-      const { meta_info, torrent_info } = data
-      if (
-        match(filterForm.site, torrent_info.site_name) &&
-        match(filterForm.freeState, torrent_info.volume_factor) &&
-        match(filterForm.season, meta_info.season_episode) &&
-        match(filterForm.releaseGroup, meta_info.resource_team) &&
-        match(filterForm.videoCode, meta_info.video_encode) &&
-        match(filterForm.resolution, meta_info.resource_pix) &&
-        match(filterForm.edition, meta_info.edition)
-      ) {
+      if (matchesAllFilters(data)) {
         filteredData.push(data)
         filteredIndices.value.push(index)
       }
@@ -221,11 +243,6 @@ export function useTorrentFilter() {
     // 排序
     filteredData = sortData(filteredData)
 
-    // 确保季集选项排序
-    if (filterOptions.season.length > 0) {
-      sortSeasonOptions()
-    }
-
     return filteredData
   }
 
@@ -234,15 +251,14 @@ export function useTorrentFilter() {
     // 重置状态
     filteredIndices.value = []
 
-    // 清空并重新初始化过滤选项
-    for (const key in filterOptions) {
-      filterOptions[key] = []
-    }
-
     if (!items?.length) {
+      resetOptions()
       totalFilteredCount.value = 0
       return []
     }
+
+    // 按当前筛选条件级联收集过滤选项
+    collectOptions(items)
 
     // 数据分组
     const groupMap = new Map<string, GroupedItem[]>()
@@ -251,8 +267,6 @@ export function useTorrentFilter() {
       if (!isRenderableContext(item)) return
 
       const { torrent_info, meta_info } = item
-      // init options
-      initOptions(item)
       // group data
       const resourceName = isMusicResource(item) ? getTorrentTitle(item) : meta_info.name
       const musicQuality = isMusicResource(item)
@@ -277,18 +291,7 @@ export function useTorrentFilter() {
 
     groupMap.forEach(value => {
       if (value.length > 0) {
-        const matchData = value.filter(item => {
-          const { meta_info, torrent_info } = item.data
-          return (
-            match(filterForm.site, torrent_info.site_name) &&
-            match(filterForm.freeState, torrent_info.volume_factor) &&
-            match(filterForm.season, meta_info.season_episode) &&
-            match(filterForm.releaseGroup, meta_info.resource_team) &&
-            match(filterForm.videoCode, meta_info.video_encode) &&
-            match(filterForm.resolution, meta_info.resource_pix) &&
-            match(filterForm.edition, meta_info.edition)
-          )
-        })
+        const matchData = value.filter(item => matchesAllFilters(item.data))
         if (matchData.length > 0) {
           matchCount += matchData.length
           const firstItem = matchData[0]
@@ -310,11 +313,6 @@ export function useTorrentFilter() {
 
     // 索引顺序跟随排序后的卡片分组，同时保留组内的原始资源顺序。
     filteredIndices.value = sortedData.flatMap(item => groupIndicesMap.get(item) ?? [])
-
-    // 确保季集选项排序
-    if (filterOptions.season.length > 0) {
-      sortSeasonOptions()
-    }
 
     return sortedData
   }


### PR DESCRIPTION
## 关联 Issue

无（用户反馈）。

## 问题

资源搜索结果页的筛选栏里，每个维度（站点 / 促销 / 季集 / 制作组 / 编码 / 质量 / 分辨率）的可选项都是从**全部**搜索结果中收集的，维度之间互不联动。

复现：搜索一部影片，在“促销”里勾选“免费”。此时结果列表已经只剩免费资源（谓词是各维度 AND），但“站点”下拉里仍然列出没有任何免费资源的站点（例如某站只有普通/付费资源）。再点这样的站点，得到的必然是空结果，只能靠“当前筛选条件没有匹配项 → 清除筛选”回退。促销、季集、制作组等其他维度之间同理。

## 根因

`useTorrentFilter.ts` 中 `filterRowData` / `filterCardData` 先对全部资源调用 `initOptions` 收集选项，再用 7 个 `match()` 做 AND 筛选，选项收集阶段完全不看当前已选条件。

## 修改

只改 `src/composables/useTorrentFilter.ts`，UI 组件与 i18n 不动（三个筛选组件本来就直接渲染 `filterOptions[key]`，空选项维度已自动隐藏）。

- 用一张 `filterValueGetters` 读取器表统一“维度 → 资源字段”的映射，选项收集与结果筛选共用，去掉两处重复的 7 行 `match(...)` 谓词（新增 `matchesFilter` / `matchesAllFilters`）。
- 新增 `collectOptions(items)`：按 faceted search 的常规做法级联收集选项——维度 K 只收集“其余维度全部命中”的资源取值，K 自身不参与约束。单次遍历，每条资源先算 7 个维度是否命中，不命中数 ≥2 的资源不贡献任何选项，恰好 1 个不命中的只贡献到该维度。
  - 效果：勾选促销=免费后，站点选项只剩仍有免费资源的站点；而促销维度自身仍列出全部促销状态，可以继续切换或多选。
- 已选中的值始终保留在对应维度的选项中：Vuetify `VChipGroup` 会静默丢弃不在选项里的 model 值，若不保留，用户已选的筹码会在下次点击时不可预期地消失；保留后仍可看见、可取消，也保持了现有“当前筛选条件没有匹配项 → 清除筛选”空态的可达性。
- `sortSeasonOptions()` 改为每次收集后调用一次（等价于原来的每次 push 后排序，选项顺序与原实现一致）；`selectAll(key)` 不改，语义自然变为“全选当前可用项”。
- 空数据时选项清空、表单保留，与原行为一致。

## 测试

- `src/composables/__tests__/useTorrentFilter.spec.ts` 新增 5 个用例：促销选中后站点/季集选项级联收敛；排除自身维度（已约束维度仍保留其它取值）；已选站点被其它维度排除时仍保留在选项中且表单引用不变，取消促销后结果恢复；卡片视图同规则（分组、`more`、原始索引）；空数据清空选项保留表单。原有用例全部保持不变并通过。
- `yarn lint`、`yarn format:check`、`yarn typecheck`、`yarn test:run`（全量 142 个文件 / 1690 个用例通过）、`yarn build` 均通过。

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at de8475db31374c43b3abfe3c16cbc8bfcb6b73cd

- 筛选选项按已选维度级联收敛
- 统一字段读取与筛选匹配逻辑
- 保留已选项，避免筛选状态丢失
- 覆盖列表、卡片及空数据测试
<!-- pr-agent-summary:end -->
