### PR TITLE
feat(glass): 收敛玻璃导航与卡片渲染性能

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -537,14 +537,6 @@
       "count": 1
     }
   },
-  "src/layouts/default/components/UserProfile.vue": {
-    "@typescript-eslint/no-unused-vars": {
-      "count": 5
-    },
-    "sonarjs/no-ignored-exceptions": {
-      "count": 2
-    }
-  },
   "src/pages/__tests__/subscribe.spec.ts": {
     "@typescript-eslint/no-unused-vars": {
       "count": 1

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -106,17 +106,6 @@
       "count": 1
     }
   },
-  "src/components/cards/MediaCard.vue": {
-    "@typescript-eslint/no-explicit-any": {
-      "count": 1
-    },
-    "@typescript-eslint/no-unused-vars": {
-      "count": 1
-    },
-    "no-useless-assignment": {
-      "count": 1
-    }
-  },
   "src/components/cards/PersonCard.vue": {
     "no-useless-assignment": {
       "count": 1

--- a/src/components/cards/MediaCard.vue
+++ b/src/components/cards/MediaCard.vue
@@ -644,9 +644,9 @@ onBeforeUnmount(() => {
             </template>
           </VImg>
 
-          <!-- 详情 -->
+          <!-- 详情按实际可见状态挂载，虚拟列表重入不创建不可见的操作组件。 -->
           <VCardText
-            v-show="isMediaCardDetailVisible(hover.isHovering)"
+            v-if="isMediaCardDetailVisible(hover.isHovering)"
             class="w-full h-full flex flex-col flex-wrap justify-end align-left text-white absolute bottom-0 cursor-pointer pa-2"
             style="background: linear-gradient(rgba(45, 55, 72, 40%) 0%, rgba(45, 55, 72, 90%) 100%)"
           >

--- a/src/components/cards/MediaCard.vue
+++ b/src/components/cards/MediaCard.vue
@@ -3,6 +3,12 @@ import { ref } from 'vue'
 
 const activeTouchMediaCardId = ref<number | null>(null)
 let mediaCardIdSeed = 0
+
+/** 为当前模块内的卡片分配稳定触摸交互身份。 */
+function nextMediaCardId() {
+  mediaCardIdSeed += 1
+  return mediaCardIdSeed
+}
 </script>
 
 <script lang="ts" setup>
@@ -28,21 +34,28 @@ import {
   setCachedMediaExistsStatus,
 } from '@/utils/mediaStatusCache'
 import { buildMusicDetailRoute, getMusicKey } from '@/utils/music'
+import {
+  forgetMediaPosterReveal,
+  rememberMediaPosterReveal,
+  wasMediaPosterRevealed,
+} from '@/utils/mediaPosterPresentationCache'
 
 const SearchSiteDialog = defineAsyncComponent(() => import('@/components/dialog/SearchSiteDialog.vue'))
 
-// 国际化
-const { t } = useI18n()
-
 interface MediaCardMedia extends MediaInfo {
+  /** 已知总集数，用于订阅信息展示。 */
   total_episode?: number
+  /** 当前媒体来源提供的集数。 */
   episode_count?: number
 }
 
 // 输入参数
 const props = defineProps({
+  /** 展示、搜索与订阅共用的媒体信息。 */
   media: Object as PropType<MediaCardMedia>,
+  /** 可选卡片宽度，由布局容器决定时省略。 */
   width: String,
+  /** 可选卡片高度，由海报比例决定时省略。 */
   height: String,
 })
 
@@ -81,14 +94,15 @@ function resetPosterRevealState() {
 }
 
 /** 仅允许当前真实海报请求完成 renderer 排除提交。 */
-function completePosterReveal(revision: number, usesFallback: boolean) {
-  if (revision !== imageRequestRevision.value || usesFallback) return
+function completePosterReveal(revision: number, src: string) {
+  if (revision !== imageRequestRevision.value || !src || !isImageLoaded.value || imageLoadError.value) return
 
   if (posterRevealFallbackTimer !== null) {
     window.clearTimeout(posterRevealFallbackTimer)
     posterRevealFallbackTimer = null
   }
   hasCompletedPosterReveal.value = true
+  rememberMediaPosterReveal(src)
 }
 
 // 当前订阅状态
@@ -108,7 +122,7 @@ const subscribedSeasonsLoaded = ref(false)
 const subscribedSeasonsLoading = ref(false)
 
 // 来源角标字典
-const sourceIconDict: { [key: string]: any } = {
+const sourceIconDict: Record<string, string> = {
   themoviedb: getLogoUrl('tmdb'),
   douban: getLogoUrl('douban-black'),
   bangumi: getLogoUrl('bangumi'),
@@ -138,7 +152,7 @@ const selectedSites = ref<number[]>([])
 // 搜索菜单显示状态
 const searchMenuShow = ref(false)
 
-const mediaCardId = ++mediaCardIdSeed
+const mediaCardId = nextMediaCardId()
 
 // 粗指针设备使用点击展开详情，避免 iOS 返回后沿用 VHover 的触摸态。
 const isTouchLikePointer = ref(
@@ -456,9 +470,8 @@ const placeholderIcon = computed(() => {
   }
 })
 
-// 计算图片地址
-const getImgUrl: Ref<string> = computed(() => {
-  if (imageLoadError.value) return ''
+// 请求身份由真实地址决定；错误占位不能反过来触发同一地址的自动重试。
+const resolvedPosterUrl = computed(() => {
   if (props.media?.type === '音乐') {
     // 音乐封面优先使用 cover_url（ListenBrainz/MusicBrainz 统计接口返回），回退到 poster_path
     const musicCover = props.media?.cover_url || props.media?.poster_path
@@ -470,6 +483,8 @@ const getImgUrl: Ref<string> = computed(() => {
   return getDisplayImageUrl(url, globalSettings.GLOBAL_IMAGE_CACHE)
 })
 
+const getImgUrl = computed(() => (imageLoadError.value ? '' : resolvedPosterUrl.value))
+
 const hasLoadedRealPoster = computed(
   () => Boolean(getImgUrl.value) && isImageLoaded.value && hasCompletedPosterReveal.value && !imageLoadError.value,
 )
@@ -479,11 +494,14 @@ const imageRequest = computed(() => {
   const revision = imageRequestRevision.value
   const src = getImgUrl.value
   const usesFallback = !src
+  // 每个请求固定重入策略，当前淡入登记缓存时不能反过来中断自身动画。
+  const revisit = wasMediaPosterRevealed(src)
 
   return {
     handleError: () => {
       if (revision !== imageRequestRevision.value || usesFallback) return
 
+      forgetMediaPosterReveal(src)
       resetPosterRevealState()
       isImageLoaded.value = false
       imageLoadError.value = true
@@ -495,8 +513,12 @@ const imageRequest = computed(() => {
       resetPosterRevealState()
       isImageLoaded.value = true
       if (!usesFallback) {
+        if (revisit) {
+          completePosterReveal(revision, src)
+          return
+        }
         posterRevealFallbackTimer = window.setTimeout(
-          () => completePosterReveal(revision, usesFallback),
+          () => completePosterReveal(revision, src),
           POSTER_REVEAL_FALLBACK_MS,
         )
       }
@@ -510,9 +532,10 @@ const imageRequest = computed(() => {
         return
       }
 
-      completePosterReveal(revision, usesFallback)
+      completePosterReveal(revision, src)
     },
     key: revision,
+    revisit,
     src,
   }
 })
@@ -543,7 +566,7 @@ watch(isSubscribed, subscribed => {
 })
 
 watch(
-  [() => props.media, () => props.media?.poster_path, () => props.media?.cover_url],
+  [() => props.media, resolvedPosterUrl],
   ([media], [previousMedia]) => {
     imageRequestRevision.value += 1
     resetPosterRevealState()
@@ -593,6 +616,7 @@ onBeforeUnmount(() => {
           :class="{
             'app-hover-lift-card--hovering': isMediaCardActive(hover.isHovering),
             'media-card--image-loaded': isImageLoaded,
+            'media-card--poster-revisit': imageRequest.revisit,
             'ring-1': isImageLoaded,
           }"
           @click.stop="handleMediaCardClick(hover.isHovering)"
@@ -605,6 +629,8 @@ onBeforeUnmount(() => {
             v-else
             aspect-ratio="2/3"
             :src="imageRequest.src"
+            :eager="imageRequest.revisit"
+            :transition="imageRequest.revisit ? false : 'fade-transition'"
             class="object-cover aspect-w-2 aspect-h-3"
             cover
             @load="imageRequest.handleLoad"

--- a/src/components/cards/__tests__/MediaCard.spec.ts
+++ b/src/components/cards/__tests__/MediaCard.spec.ts
@@ -191,10 +191,12 @@ function getActionButtons(container: Element) {
 }
 
 /** 获取媒体搜索操作按钮并确保其已渲染。 */
-function getSearchButton(container: Element) {
-  const button = getActionButtons(container)[0]
-  expect(button).toBeDefined()
-  return button
+async function getSearchButton(container: Element) {
+  return waitFor(() => {
+    const button = getActionButtons(container)[0]
+    expect(button).toBeDefined()
+    return button
+  })
 }
 
 /** 筛选用于触发媒体状态懒加载的观察器。 */
@@ -260,6 +262,7 @@ describe('MediaCard', () => {
       title: '视口状态剧集',
       year: '2026',
     })
+    await fireEvent.mouseEnter(getHoverArea(container))
     await waitFor(() => expect(getActionButtons(container).at(-1)).toHaveClass('text-error'))
     expect(getStatusObservers()[0]?.disconnect).toHaveBeenCalledOnce()
   })
@@ -284,6 +287,7 @@ describe('MediaCard', () => {
 
     expect(getStatusObservers()).toHaveLength(2)
     getStatusObservers().forEach(observer => observer.trigger())
+    for (const area of container.querySelectorAll('.media-card-hover-area')) await fireEvent.mouseEnter(area)
 
     await waitFor(() => {
       expect(subscribeRequest).toHaveBeenCalledOnce()
@@ -496,7 +500,7 @@ describe('MediaCard', () => {
         type: '音乐',
       })
 
-      await fireEvent.click(getSearchButton(container))
+      await fireEvent.click(await getSearchButton(container))
       await waitFor(() =>
         expect(mocks.routerPush).toHaveBeenCalledWith({
           path: '/resource',
@@ -534,7 +538,7 @@ describe('MediaCard', () => {
     const { container } = await renderCard(media)
 
     await fireEvent.mouseEnter(getHoverArea(container))
-    await fireEvent.click(getSearchButton(container))
+    await fireEvent.click(await getSearchButton(container))
 
     await waitFor(() =>
       expect(mocks.routerPush).toHaveBeenCalledWith({
@@ -563,7 +567,7 @@ describe('MediaCard', () => {
     const { container } = await renderCard(media)
 
     await fireEvent.mouseEnter(getHoverArea(container))
-    await fireEvent.click(getSearchButton(container))
+    await fireEvent.click(await getSearchButton(container))
 
     await waitFor(() =>
       expect(mocks.routerPush).toHaveBeenCalledWith(
@@ -591,7 +595,7 @@ describe('MediaCard', () => {
     const { container } = await renderCard(media)
 
     await fireEvent.mouseEnter(getHoverArea(container))
-    await fireEvent.click(getSearchButton(container))
+    await fireEvent.click(await getSearchButton(container))
     await waitFor(() => expect(mocks.openSharedDialog).toHaveBeenCalledOnce())
 
     const [, dialogProps, dialogEvents] = mocks.openSharedDialog.mock.calls[0] as [
@@ -632,7 +636,7 @@ describe('MediaCard', () => {
     const { container } = await renderCard(createMediaInfo({ tmdb_id: 9504 }))
 
     await fireEvent.mouseEnter(getHoverArea(container))
-    await fireEvent.click(getSearchButton(container))
+    await fireEvent.click(await getSearchButton(container))
 
     await waitFor(() => expect(mocks.openSharedDialog).toHaveBeenCalledOnce())
     const [, dialogProps] = mocks.openSharedDialog.mock.calls[0] as [unknown, { selected: number[] }]
@@ -669,9 +673,8 @@ describe('MediaCard', () => {
     )
     const { container } = await renderCard(media)
     getStatusObservers()[0]?.trigger()
-    await waitFor(() => expect(getActionButtons(container).at(-1)).toHaveClass('text-error'))
-
     await fireEvent.mouseEnter(getHoverArea(container))
+    await waitFor(() => expect(getActionButtons(container).at(-1)).toHaveClass('text-error'))
     await fireEvent.click(getActionButtons(container).at(-1) as HTMLButtonElement)
 
     await waitFor(() => expect(mocks.openSharedDialog).toHaveBeenCalledOnce())
@@ -717,9 +720,8 @@ describe('MediaCard', () => {
     )
     const { container } = await renderCard(media)
     getStatusObservers()[0]?.trigger()
-    await waitFor(() => expect(getActionButtons(container).at(-1)).toHaveClass('text-error'))
-
     await fireEvent.mouseEnter(getHoverArea(container))
+    await waitFor(() => expect(getActionButtons(container).at(-1)).toHaveClass('text-error'))
     await fireEvent.click(getActionButtons(container).at(-1) as HTMLButtonElement)
 
     await waitFor(() => expect(mocks.openSharedDialog).toHaveBeenCalledOnce())
@@ -772,9 +774,8 @@ describe('MediaCard', () => {
     )
     const { container } = await renderCard(media)
     getStatusObservers()[0]?.trigger()
-    await waitFor(() => expect(getActionButtons(container).at(-1)).toHaveClass('text-error'))
-
     await fireEvent.mouseEnter(getHoverArea(container))
+    await waitFor(() => expect(getActionButtons(container).at(-1)).toHaveClass('text-error'))
     await fireEvent.click(getActionButtons(container).at(-1) as HTMLButtonElement)
 
     await waitFor(() => expect(mocks.openSharedDialog).toHaveBeenCalledOnce())
@@ -1086,6 +1087,22 @@ describe('MediaCard', () => {
     expect(getActionButtons(container)).toHaveLength(0)
   })
 
+  it('mounts details only while hovered without replacing the media shell', async () => {
+    const { container } = await renderCard(createMediaInfo({ tmdb_id: 9700 }))
+    const card = getCard(container)
+    expect(container.querySelector('.media-card-title')).toBeNull()
+    expect(getActionButtons(container)).toHaveLength(0)
+
+    await fireEvent.mouseEnter(getHoverArea(container))
+    await waitFor(() => expect(getActionButtons(container)).toHaveLength(2))
+    expect(getCard(container)).toBe(card)
+
+    await fireEvent.mouseLeave(getHoverArea(container))
+    await waitFor(() => expect(container.querySelector('.media-card-title')).toBeNull())
+    expect(getActionButtons(container)).toHaveLength(0)
+    expect(getCard(container)).toBe(card)
+  })
+
   it('uses first tap to reveal details, second tap to route, and outside pointerdown to collapse', async () => {
     vi.spyOn(window, 'matchMedia').mockReturnValue({
       ...window.matchMedia(''),
@@ -1093,15 +1110,16 @@ describe('MediaCard', () => {
     })
     const media = createMediaInfo({ title: '触摸卡片', tmdb_id: 9701 })
     const { container } = await renderCard(media)
-    const detail = container.querySelector<HTMLElement>('.media-card-title')?.parentElement
-    expect(detail).not.toBeNull()
+    expect(container.querySelector('.media-card-title')).toBeNull()
 
     await fireEvent.click(getCard(container))
+    const detail = container.querySelector<HTMLElement>('.media-card-title')?.parentElement
+    expect(detail).toBeInTheDocument()
     expect(detail).not.toHaveStyle({ display: 'none' })
     expect(mocks.routerPush).not.toHaveBeenCalled()
 
     await fireEvent.pointerDown(document.body)
-    expect(detail).toHaveStyle({ display: 'none' })
+    expect(container.querySelector('.media-card-title')).toBeNull()
 
     await fireEvent.click(getCard(container))
     await fireEvent.click(getCard(container))

--- a/src/components/cards/__tests__/MediaCard.spec.ts
+++ b/src/components/cards/__tests__/MediaCard.spec.ts
@@ -1,6 +1,7 @@
 import type { MediaInfo } from '@/api/types'
 import MediaCard from '@/components/cards/MediaCard.vue'
 import { clearCachedMediaSubscribeStatuses } from '@/utils/mediaStatusCache'
+import { clearMediaPosterPresentationCache, wasMediaPosterRevealed } from '@/utils/mediaPosterPresentationCache'
 import { fireEvent, waitFor } from '@testing-library/vue'
 import { createMediaInfo } from '@tests/support/factories/media'
 import { mediaExistsHandler } from '@tests/support/msw/handlers/media'
@@ -100,6 +101,8 @@ interface RenderCardOptions {
 }
 
 interface ControlledImageRequest {
+  /** 图片是否在进入视口前发起加载。 */
+  eager: boolean
   /** 模拟当前 VImg 请求失败。 */
   fail: () => void
   /** 模拟当前 VImg 请求成功。 */
@@ -108,6 +111,8 @@ interface ControlledImageRequest {
   reveal: () => void
   /** 当前 VImg 实例发起的图片地址。 */
   src: string
+  /** VImg 自身的图片呈现过渡，不等同卡片的 CSS 淡入。 */
+  transition: boolean | string | undefined
 }
 
 /** 创建可保留旧实例回调的图片替身，用于验证媒体复用时的迟到事件隔离。 */
@@ -115,11 +120,12 @@ function createControlledImageStub(requests: ControlledImageRequest[]) {
   return defineComponent({
     name: 'VImg',
     emits: ['error', 'load'],
-    props: { src: String },
+    props: { src: String, eager: Boolean, transition: [Boolean, String] },
     setup(props, { emit, slots }) {
       const src = props.src ?? ''
       const imageElement = ref<HTMLImageElement | null>(null)
       const request = {
+        eager: props.eager,
         fail: () => emit('error', src),
         load: () => emit('load', src),
         reveal: () => {
@@ -128,6 +134,7 @@ function createControlledImageStub(requests: ControlledImageRequest[]) {
           imageElement.value?.dispatchEvent(event)
         },
         src,
+        transition: props.transition,
       }
       requests.push(request)
 
@@ -216,6 +223,7 @@ describe('MediaCard', () => {
   beforeEach(() => {
     intersectionObservers = []
     clearCachedMediaSubscribeStatuses()
+    clearMediaPosterPresentationCache()
     vi.stubGlobal('IntersectionObserver', IntersectionObserverMock)
     vi.spyOn(console, 'error').mockImplementation(() => {})
     vi.spyOn(console, 'log').mockImplementation(() => {})
@@ -822,6 +830,128 @@ describe('MediaCard', () => {
     expect(container.querySelector('.media-card-placeholder')).not.toBeNull()
     expect(getCard(container)).not.toHaveClass('ring-1')
     expect(getCard(container)).not.toHaveAttribute('data-glass-optical-mode')
+  })
+
+  it('reuses a revealed poster without replaying either fade but still waits for its own load', async () => {
+    const requests: ControlledImageRequest[] = []
+    const media = createMediaInfo({ poster_path: '/original/revisit.jpg', tmdb_id: 9560 })
+    const options = {
+      props: { media },
+      initialState: { user: { superUser: true } },
+      global: { stubs: { VImg: createControlledImageStub(requests) } },
+    }
+    const first = await renderWithProviders(MediaCard, options)
+    expect(requests[0]).toMatchObject({ eager: false, transition: 'fade-transition' })
+    requests[0].load()
+    requests[0].reveal()
+    await waitFor(() => expect(getCard(first.container)).toHaveAttribute('data-glass-optical-mode', 'excluded'))
+    first.unmount()
+
+    const second = await renderWithProviders(MediaCard, options)
+    const request = requests.at(-1)!
+    expect(request).toMatchObject({ eager: true, transition: false })
+    expect(getCard(second.container)).toHaveClass('media-card--poster-revisit')
+    expect(getCard(second.container)).not.toHaveClass('media-card--image-loaded')
+    expect(getCard(second.container)).not.toHaveAttribute('data-glass-optical-mode')
+    request.load()
+    await waitFor(() => expect(getCard(second.container)).toHaveAttribute('data-glass-optical-mode', 'excluded'))
+
+    request.fail()
+    await waitFor(() => expect(getCard(second.container)).not.toHaveAttribute('data-glass-optical-mode'))
+    expect(wasMediaPosterRevealed(request.src)).toBe(false)
+    expect(second.container.querySelector('.media-card-placeholder')).not.toBeNull()
+  })
+
+  it('does not remember a poster that unmounted before completing its first reveal', async () => {
+    const requests: ControlledImageRequest[] = []
+    const media = createMediaInfo({ poster_path: '/original/partial-reveal.jpg', tmdb_id: 9561 })
+    const options = {
+      props: { media },
+      initialState: { user: { superUser: true } },
+      global: { stubs: { VImg: createControlledImageStub(requests) } },
+    }
+    const first = await renderWithProviders(MediaCard, options)
+    requests[0].load()
+    first.unmount()
+    const second = await renderWithProviders(MediaCard, options)
+    expect(requests.at(-1)).toMatchObject({ eager: false, transition: 'fade-transition' })
+    expect(getCard(second.container)).not.toHaveClass('media-card--poster-revisit')
+  })
+
+  it('uses the real VImg lazy lifecycle only for the first presentation', async () => {
+    const media = createMediaInfo({ poster_path: '/original/real-revisit.jpg', tmdb_id: 9562 })
+    const first = await renderCard(media)
+    expect(first.container.querySelector('.v-img__img')).toBeNull()
+    const imageObserver = intersectionObservers.find(observer =>
+      observer.observe.mock.calls.some(([element]) => element.classList.contains('v-img')),
+    )
+    expect(imageObserver).toBeDefined()
+    imageObserver!.trigger()
+
+    await waitFor(() => expect(first.container.querySelector('.v-img__img')).not.toBeNull())
+    const firstImage = first.container.querySelector<HTMLImageElement>('.v-img__img')!
+    expect(firstImage).toHaveStyle({ display: 'none' })
+    expect(first.container.querySelector('.v-img__placeholder')).not.toBeNull()
+    expect(getCard(first.container)).not.toHaveAttribute('data-glass-optical-mode')
+    await fireEvent.load(firstImage)
+    expect(getCard(first.container)).toHaveClass('media-card--image-loaded')
+    expect(getCard(first.container)).not.toHaveAttribute('data-glass-optical-mode')
+    const revealed = new Event('transitionend', { bubbles: true })
+    Object.defineProperty(revealed, 'propertyName', { value: 'opacity' })
+    await fireEvent(firstImage, revealed)
+    await waitFor(() => expect(getCard(first.container)).toHaveAttribute('data-glass-optical-mode', 'excluded'))
+    first.unmount()
+
+    // 不触发任何 IntersectionObserver，真实 VImg 在重挂载时即进入 loading。
+    const second = await renderCard(media)
+    await waitFor(() => expect(second.container.querySelector('.v-img__img')).not.toBeNull())
+    const secondImage = second.container.querySelector<HTMLImageElement>('.v-img__img')!
+    expect(secondImage).toHaveStyle({ display: 'none' })
+    expect(second.container.querySelector('.v-img__placeholder')).not.toBeNull()
+    expect(getCard(second.container)).not.toHaveAttribute('data-glass-optical-mode')
+    await fireEvent.load(secondImage)
+    expect(secondImage).not.toHaveStyle({ display: 'none' })
+    expect(second.container.querySelector('.v-img__placeholder')).toBeNull()
+    expect(getCard(second.container)).toHaveAttribute('data-glass-optical-mode', 'excluded')
+  })
+
+  it('resets poster presentation when the same media object changes its effective image source', async () => {
+    const requests: ControlledImageRequest[] = []
+    const media = reactive(
+      createMediaInfo({
+        poster_path: '/original/movie-cover.jpg',
+        cover_url: 'https://example.com/music-cover.jpg',
+        tmdb_id: 9563,
+        type: '电影',
+      }),
+    )
+    const { container } = await renderWithProviders(MediaCard, {
+      props: { media },
+      initialState: { user: { superUser: true } },
+      global: { stubs: { VImg: createControlledImageStub(requests) } },
+    })
+    const movieRequest = requests[0]
+    movieRequest.load()
+    movieRequest.reveal()
+    await waitFor(() => expect(getCard(container)).toHaveAttribute('data-glass-optical-mode', 'excluded'))
+
+    media.type = '音乐'
+    await waitFor(() => expect(requests.some(request => request.src.includes('music-cover.jpg'))).toBe(true))
+    const musicRequest = requests.find(request => request.src.includes('music-cover.jpg'))!
+    expect(musicRequest.src).not.toBe(movieRequest.src)
+    expect(getCard(container)).not.toHaveClass('media-card--image-loaded')
+    expect(getCard(container)).not.toHaveAttribute('data-glass-optical-mode')
+    movieRequest.load()
+    movieRequest.reveal()
+    movieRequest.fail()
+    expect(getCard(container)).not.toHaveAttribute('data-glass-optical-mode')
+    expect(container.querySelector('.media-card-placeholder')).toBeNull()
+
+    musicRequest.load()
+    await waitFor(() => expect(getCard(container)).toHaveClass('media-card--image-loaded'))
+    expect(getCard(container)).not.toHaveAttribute('data-glass-optical-mode')
+    musicRequest.reveal()
+    await waitFor(() => expect(getCard(container)).toHaveAttribute('data-glass-optical-mode', 'excluded'))
   })
 
   it('excludes music cards from the renderer after the cover finishes revealing', async () => {

--- a/src/components/dialog/GlassSettingsDialog.vue
+++ b/src/components/dialog/GlassSettingsDialog.vue
@@ -390,6 +390,7 @@ onScopeDispose(cancelGlassPreview)
               {{ t(option.label) }}
             </VBtn>
           </VBtnToggle>
+          <p class="glass-settings-dialog__hint">{{ t('theme.glassNavbarStyleHint') }}</p>
         </section>
 
         <section>

--- a/src/components/dialog/__tests__/GlassSettingsDialog.spec.ts
+++ b/src/components/dialog/__tests__/GlassSettingsDialog.spec.ts
@@ -191,11 +191,13 @@ describe('GlassSettingsDialog', () => {
       if (!appearanceControl) throw new Error('appearance control was not rendered')
 
       expect(wrapper.find('.glass-settings-dialog__navbar-style').attributes('data-model-value')).toBe('clear')
+      expect(wrapper.text()).toContain('theme.glassNavbarStyleHint')
 
       await appearanceControl.vm.$emit('update:modelValue', 'frosted')
       await wrapper.vm.$nextTick()
 
       expect(wrapper.find('.glass-settings-dialog__navbar-style').exists()).toBe(false)
+      expect(wrapper.text()).not.toContain('theme.glassNavbarStyleHint')
       expect(mocks.previewGlassSettings).toHaveBeenLastCalledWith(
         expect.objectContaining({ glassAppearance: 'frosted', glassNavbarStyle: 'clear' }),
       )
@@ -206,6 +208,7 @@ describe('GlassSettingsDialog', () => {
       const restoredStyleControl = wrapper.find('.glass-settings-dialog__navbar-style')
       expect(restoredStyleControl.attributes('data-model-value')).toBe('clear')
       expect(wrapper.findAll('.glass-settings-dialog__navbar-style-option')).toHaveLength(2)
+      expect(wrapper.text()).toContain('theme.glassNavbarStyleHint')
       expect(mocks.previewGlassSettings).toHaveBeenLastCalledWith(
         expect.objectContaining({ glassAppearance: appearance, glassNavbarStyle: 'clear' }),
       )

--- a/src/components/theme/GlassFixedShellBackplate.vue
+++ b/src/components/theme/GlassFixedShellBackplate.vue
@@ -13,8 +13,8 @@ interface Props {
   transitionDurationMs: number
 }
 
-/** 共用稳定壁纸背板、但拥有独立外轮廓的导航表面。 */
-type GeometrySurface = 'sidebar' | 'navbar'
+/** 桌面侧栏的稳定壁纸范围；顶栏从自身下方读取滚动正文。 */
+type GeometrySurface = 'sidebar'
 
 /** SVG objectBoundingBox 坐标，分别以背板的实际宽和高归一化。 */
 interface NormalizedClipRect {
@@ -44,7 +44,7 @@ interface BackplateBounds {
   width: number
 }
 
-const GEOMETRY_SURFACES: readonly GeometrySurface[] = ['sidebar', 'navbar']
+const GEOMETRY_SURFACES: readonly GeometrySurface[] = ['sidebar']
 const GEOMETRY_ATTRIBUTE_FILTER = [
   'class',
   'data-glass-appearance',
@@ -70,11 +70,9 @@ const mainBackplateStyle = computed(() => ({
 }))
 
 const observedElements: Record<GeometrySurface, HTMLElement | null> = {
-  navbar: null,
   sidebar: null,
 }
 const transitionHandlers: Record<GeometrySurface, EventListener | null> = {
-  navbar: null,
   sidebar: null,
 }
 
@@ -216,7 +214,6 @@ function refreshObservedElements() {
   }
 
   bindGeometrySurface('sidebar', shell?.querySelector<HTMLElement>('.layout-vertical-nav:not(.overlay-nav)') ?? null)
-  bindGeometrySurface('navbar', shell?.querySelector<HTMLElement>('.layout-navbar') ?? null)
 }
 
 function applyGeometry(nextRects: NormalizedClipRect[]) {
@@ -234,9 +231,8 @@ function syncGeometry() {
   const shell = observedShell
   const backplate = readBackplateBounds()
   const sidebar = observedElements.sidebar
-  const navbar = observedElements.navbar
 
-  if (!shell || !backplate || !isConnectedDesktopShell(shell) || !sidebar || !navbar) {
+  if (!shell || !backplate || !isConnectedDesktopShell(shell) || !sidebar) {
     applyGeometry([])
     return
   }
@@ -480,6 +476,30 @@ onBeforeUnmount(() => {
   .layout-wrapper.layout-navbar-floating-eligible.layout-navbar-away-from-top
   > .glass-fixed-shell-backplate--main {
   clip-path: inset(0 0 calc(100% - var(--layout-navbar-block-size)) 0 round var(--shell-floating-navbar-radius));
+}
+
+// 桌面顶栏必须直接采样正文；首帧 CSS 与运行时圆角裁剪都只为侧栏保留壁纸。
+.layout-wrapper[data-shell-mode='desktop']:not(.layout-window-controls-overlay-shell)
+  > .glass-fixed-shell-backplate--main {
+  clip-path: inset(
+    var(--glass-v3-navigation-inset, 8px) calc(100% - var(--glass-fixed-shell-nav-inline-size))
+      var(--glass-v3-navigation-inset, 8px) var(--glass-v3-navigation-inset, 8px) round
+      var(--glass-v3-navigation-radius, 16px)
+  );
+}
+
+[dir='rtl']
+  .layout-wrapper[data-shell-mode='desktop']:not(.layout-window-controls-overlay-shell)
+  > .glass-fixed-shell-backplate--main {
+  clip-path: inset(
+    var(--glass-v3-navigation-inset, 8px) var(--glass-v3-navigation-inset, 8px) var(--glass-v3-navigation-inset, 8px)
+      calc(100% - var(--glass-fixed-shell-nav-inline-size)) round var(--glass-v3-navigation-radius, 16px)
+  );
+}
+
+.layout-wrapper[data-shell-mode='desktop'].layout-horizontal-nav-active:not(.layout-window-controls-overlay-shell)
+  > .glass-fixed-shell-backplate--main {
+  display: none;
 }
 
 .glass-fixed-shell-backplate--overlay-nav {

--- a/src/components/theme/GlassMediaBackdrop.vue
+++ b/src/components/theme/GlassMediaBackdrop.vue
@@ -1,0 +1,242 @@
+<script setup lang="ts">
+import { isChromiumFixedShellBackplateBrowser } from '@/composables/useGlassFixedShellBackplate'
+import { useMediaQuery } from '@vueuse/core'
+import {
+  computed,
+  onActivated,
+  onDeactivated,
+  onMounted,
+  onUnmounted,
+  ref,
+  shallowRef,
+  watch,
+  type CSSProperties,
+} from 'vue'
+import { useTheme } from 'vuetify'
+
+interface SharedBackdrop extends CSSProperties {
+  /** 所有待显示海报的圆角并集，使用承载层局部坐标。 */
+  clipPath: string
+  /** 只分配尚未被海报覆盖的行区间，不随累计分页高度增长。 */
+  height: string
+  /** 相对列表容器的起点，随虚拟占位更新而非逐帧追随 scrollY。 */
+  top: string
+}
+
+const root = ref<HTMLElement | null>(null)
+const backdrop = shallowRef<SharedBackdrop | null>(null)
+const theme = useTheme()
+const reducedTransparency = useMediaQuery('(prefers-reduced-transparency: reduce)')
+const supported =
+  typeof CSS !== 'undefined' &&
+  typeof CSS.supports === 'function' &&
+  CSS.supports('clip-path', 'path("M0 0H1V1Z")') &&
+  CSS.supports('backdrop-filter', 'blur(1px)') &&
+  isChromiumFixedShellBackplateBrowser()
+const enabled = computed(() => supported && theme.global.name.value === 'glass' && !reducedTransparency.value)
+const ownedCards = new Set<HTMLElement>()
+let active = false
+let frame = 0
+let mutationObserver: MutationObserver | null = null
+let resizeObserver: ResizeObserver | null = null
+let themeObserver: MutationObserver | null = null
+
+function releaseCards() {
+  for (const card of ownedCards) delete card.dataset.glassSharedBackdrop
+  ownedCards.clear()
+  backdrop.value = null
+}
+
+/** 共享层只处理无位移表面；悬停及其退出动画由原生卡片独立采样。 */
+function isStationary(card: HTMLElement, css: CSSStyleDeclaration) {
+  if (card.classList.contains('app-hover-lift-card--hovering')) return false
+  if (css.transform === 'none' || !css.transform) return true
+
+  return new DOMMatrixReadOnly(css.transform).isIdentity
+}
+
+function cornerRadius(value: string, width: number, height: number) {
+  const parts = value.split(' ')
+  const parse = (part: string, size: number) =>
+    part.endsWith('%') ? (parseFloat(part) * size) / 100 : parseFloat(part)
+  return [
+    Math.min(width / 2, Math.max(0, parse(parts[0], width) || 0)),
+    Math.min(height / 2, Math.max(0, parse(parts[1] ?? parts[0], height) || 0)),
+  ]
+}
+
+function update() {
+  frame = 0
+  const container = root.value
+  if (!active || !enabled.value || !container || container.closest('.v-overlay__content')) {
+    releaseCards()
+    return
+  }
+  const base = container.getBoundingClientRect()
+  if (!base.width || !base.height) {
+    releaseCards()
+    return
+  }
+
+  const nextCards = new Set<HTMLElement>()
+  const rects = []
+  let top = Infinity
+  let bottom = -Infinity
+  for (const card of container.querySelectorAll<HTMLElement>('.media-card')) {
+    if (card.dataset.glassOpticalMode === 'excluded') continue
+    const css = getComputedStyle(card)
+    if (!isStationary(card, css)) continue
+    const box = card.getBoundingClientRect()
+    if (!box.width || !box.height) continue
+    const x = box.left - base.left
+    const y = box.top - base.top
+    rects.push({
+      x,
+      y,
+      w: box.width,
+      h: box.height,
+      corners: [
+        css.borderTopLeftRadius,
+        css.borderTopRightRadius,
+        css.borderBottomRightRadius,
+        css.borderBottomLeftRadius,
+      ].map(value => cornerRadius(value, box.width, box.height)),
+    })
+    top = Math.min(top, y)
+    bottom = Math.max(bottom, y + box.height)
+    nextCards.add(card)
+  }
+
+  const paths = rects.map(({ x, y: offsetY, w, h, corners: [tl, tr, br, bl] }) => {
+    const y = offsetY - top
+    return `M${x + tl[0]} ${y}H${x + w - tr[0]}A${tr[0]} ${tr[1]} 0 0 1 ${x + w} ${y + tr[1]}V${y + h - br[1]}A${br[0]} ${br[1]} 0 0 1 ${x + w - br[0]} ${y + h}H${x + bl[0]}A${bl[0]} ${bl[1]} 0 0 1 ${x} ${y + h - bl[1]}V${y + tl[1]}A${tl[0]} ${tl[1]} 0 0 1 ${x + tl[0]} ${y}Z`
+  })
+  // 先计算完整几何，再在同一帧交接采样所有权；不得提前移除尚未就绪的逐卡滤镜。
+  const nextBackdrop = paths.length
+    ? { clipPath: `path("${paths.join(' ')}")`, top: `${top}px`, height: `${bottom - top}px` }
+    : null
+  if (
+    nextBackdrop?.clipPath !== backdrop.value?.clipPath ||
+    nextBackdrop?.top !== backdrop.value?.top ||
+    nextBackdrop?.height !== backdrop.value?.height
+  )
+    backdrop.value = nextBackdrop
+  for (const card of ownedCards) {
+    if (!nextCards.has(card)) delete card.dataset.glassSharedBackdrop
+  }
+  ownedCards.clear()
+  for (const card of nextCards) {
+    if (card.dataset.glassSharedBackdrop !== 'true') card.dataset.glassSharedBackdrop = 'true'
+    ownedCards.add(card)
+  }
+}
+
+function schedule() {
+  if (active && enabled.value && !frame) frame = requestAnimationFrame(update)
+}
+
+function stop() {
+  if (frame) cancelAnimationFrame(frame)
+  frame = 0
+  mutationObserver?.disconnect()
+  resizeObserver?.disconnect()
+  themeObserver?.disconnect()
+  mutationObserver = null
+  resizeObserver = null
+  themeObserver = null
+  releaseCards()
+}
+
+function start() {
+  stop()
+  if (!active || !enabled.value || !root.value) return
+  mutationObserver = new MutationObserver(records => {
+    if (
+      records.some(record => {
+        if (record.type === 'childList')
+          return [...record.addedNodes, ...record.removedNodes].some(
+            node =>
+              node instanceof Element &&
+              (node.matches('.media-card,[data-progressive-grid-index]') || node.querySelector('.media-card')),
+          )
+        return record.target instanceof Element && record.target.matches('.media-card,.progressive-card-grid__spacer')
+      })
+    )
+      schedule()
+  })
+  mutationObserver.observe(root.value, {
+    subtree: true,
+    childList: true,
+    attributes: true,
+    attributeFilter: ['data-glass-optical-mode', 'class', 'style'],
+  })
+  resizeObserver = new ResizeObserver(schedule)
+  resizeObserver.observe(root.value)
+  themeObserver = new MutationObserver(schedule)
+  themeObserver.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme-radius'] })
+  schedule()
+}
+
+onMounted(() => {
+  active = true
+  start()
+})
+onActivated(() => {
+  active = true
+  start()
+})
+onDeactivated(() => {
+  active = false
+  stop()
+})
+onUnmounted(() => {
+  active = false
+  stop()
+})
+watch(enabled, start, { flush: 'post' })
+</script>
+
+<template>
+  <div
+    ref="root"
+    class="glass-media-backdrop"
+    :class="{ 'glass-media-backdrop--active': enabled }"
+    @transitionend="schedule"
+  >
+    <div
+      v-if="backdrop"
+      class="glass-media-backdrop__sampling"
+      :style="backdrop"
+      aria-hidden="true"
+      data-glass-optical-mode="excluded"
+    />
+    <slot />
+  </div>
+</template>
+
+<style scoped>
+.glass-media-backdrop--active {
+  position: relative;
+}
+
+.glass-media-backdrop--active > :deep(.progressive-card-grid) {
+  position: relative;
+  z-index: 1;
+}
+
+.glass-media-backdrop__sampling {
+  position: absolute;
+  z-index: 0;
+  pointer-events: none;
+  inset-inline-start: 0;
+  inline-size: 100%;
+  backdrop-filter: var(--glass-native-surface-backdrop-filter);
+  -webkit-backdrop-filter: var(--glass-native-surface-backdrop-filter);
+}
+
+/* 只移交原生采样；卡片自身的颜色、轮廓和增强档光学资格保持不变。 */
+:deep(.media-card[data-glass-shared-backdrop='true']) {
+  --glass-native-surface-backdrop-filter: none;
+  --glass-surface-backdrop-filter: none;
+}
+</style>

--- a/src/components/theme/GlassNavbarRefractionDefs.vue
+++ b/src/components/theme/GlassNavbarRefractionDefs.vue
@@ -151,7 +151,9 @@ function isRefractionActive(surface: NavigationSurface) {
     theme !== 'glass' ||
     (glassAppearance !== 'clear' && glassAppearance !== 'tinted') ||
     (glassQuality !== 'balanced' && glassQuality !== 'high') ||
-    transparencyQuery?.matches
+    transparencyQuery?.matches ||
+    document.visibilityState === 'hidden' ||
+    !document.hasFocus()
   )
     return false
 
@@ -356,6 +358,10 @@ onMounted(() => {
 
   transparencyQuery = window.matchMedia('(prefers-reduced-transparency: reduce)')
   transparencyQuery.addEventListener('change', scheduleDisplacementMapSync)
+  // Panel 暂停时会释放绑定，后台不能因此启动备用图；恢复后再检查当前几何与所有权。
+  window.addEventListener('focus', scheduleDisplacementMapSync)
+  window.addEventListener('blur', scheduleDisplacementMapSync)
+  document.addEventListener('visibilitychange', scheduleDisplacementMapSync)
   stateObserver = new MutationObserver(handleStateMutations)
   stateObserver.observe(document.documentElement, {
     attributes: true,
@@ -427,6 +433,9 @@ onBeforeUnmount(() => {
   stateObserver = null
   transparencyQuery?.removeEventListener('change', scheduleDisplacementMapSync)
   transparencyQuery = null
+  window.removeEventListener('focus', scheduleDisplacementMapSync)
+  window.removeEventListener('blur', scheduleDisplacementMapSync)
+  document.removeEventListener('visibilitychange', scheduleDisplacementMapSync)
   window.removeEventListener('resize', scheduleDisplacementMapSync)
   observedShell = null
 })

--- a/src/components/theme/GlassNavbarRefractionDefs.vue
+++ b/src/components/theme/GlassNavbarRefractionDefs.vue
@@ -155,6 +155,9 @@ function isRefractionActive(surface: NavigationSurface) {
   )
     return false
 
+  // Panel 解码并绑定后无需准备第二张备用图；只有 owner 标记时仍须保留未就绪/失败回退。
+  if (element.hasAttribute('data-glass-panel-refraction')) return false
+
   if (surface === 'navbar') {
     return (
       (shell.dataset.shellMode === 'desktop' &&
@@ -378,7 +381,7 @@ onMounted(() => {
     stateObserver.observe(element, {
       attributes: true,
       attributeOldValue: true,
-      attributeFilter: ['class', 'style'],
+      attributeFilter: ['class', 'style', 'data-glass-panel-refraction'],
     })
     const transitionHandler: EventListener = event => handleGeometryTransition(surface, event as TransitionEvent)
     transitionHandlers[surface] = transitionHandler

--- a/src/components/theme/GlassPanelRefractionDefs.vue
+++ b/src/components/theme/GlassPanelRefractionDefs.vue
@@ -9,7 +9,7 @@ import {
 } from '@/utils/glassNavbarRefraction'
 import { getGlassMaterialResponse } from '@/utils/glassOptics'
 
-/** 内容面使用真实背景，固定磨砂导航复用稳定背板。 */
+/** 内容面和顶栏使用真实背景，磨砂侧栏复用稳定背板。 */
 type SurfaceKind = 'card' | 'navbar' | 'sidebar' | 'backplate'
 
 interface FilterDefinition {
@@ -165,15 +165,15 @@ function collectSurfaces() {
     result.set(element, 'card')
   }
   if (!shell.matches('.layout-horizontal-nav-active, .layout-window-controls-overlay-shell')) {
+    const header = shell.querySelector<HTMLElement>('.layout-navbar')
+    if (header) result.set(header, 'navbar')
     if (settings.value.glassAppearance === 'frosted') {
       for (const element of shell.querySelectorAll<HTMLElement>(
         '.glass-fixed-shell-backplate--main .glass-fixed-shell-backplate__layer',
       ))
         result.set(element, 'backplate')
     } else {
-      const header = shell.querySelector<HTMLElement>('.layout-navbar')
       const sidebar = shell.querySelector<HTMLElement>('.layout-vertical-nav:not(.overlay-nav)')
-      if (header) result.set(header, 'navbar')
       if (sidebar) result.set(sidebar, 'sidebar')
     }
   }
@@ -189,7 +189,7 @@ function readGeometry(binding: SurfaceBinding) {
   const radius = Number.parseFloat(getComputedStyle(binding.element).borderTopLeftRadius) || 0
   const panels =
     binding.kind === 'backplate'
-      ? ['.layout-navbar', '.layout-vertical-nav'].flatMap(selector => {
+      ? ['.layout-vertical-nav'].flatMap(selector => {
           const element = shell?.querySelector<HTMLElement>(selector)
           if (!element) return []
           const rect = element.getBoundingClientRect()

--- a/src/components/theme/__tests__/GlassFixedShellBackplate.spec.ts
+++ b/src/components/theme/__tests__/GlassFixedShellBackplate.spec.ts
@@ -162,6 +162,7 @@ describe('GlassFixedShellBackplate', () => {
     document.querySelectorAll('.layout-wrapper').forEach(element => element.remove())
     document.documentElement.removeAttribute('data-theme')
     document.documentElement.removeAttribute('data-theme-radius')
+    document.documentElement.removeAttribute('dir')
     vi.restoreAllMocks()
     vi.unstubAllGlobals()
   })
@@ -230,7 +231,7 @@ describe('GlassFixedShellBackplate', () => {
     expect(overlay.findAll('[data-backplate-slot]')).toHaveLength(2)
   })
 
-  it('maps both connected surfaces to backplate-relative objectBoundingBox geometry', async () => {
+  it('maps the connected sidebar to backplate-relative objectBoundingBox geometry', async () => {
     const { wrapper } = mountConnectedShell()
     await settleGeometry()
 
@@ -240,7 +241,7 @@ describe('GlassFixedShellBackplate', () => {
     const rects = clipPath.findAll('rect')
 
     expect(clipPath.attributes('clipPathUnits')).toBe('objectBoundingBox')
-    expect(rects).toHaveLength(2)
+    expect(rects).toHaveLength(1)
     expect(mainElement.style.clipPath).toMatch(/^url\(#glass-fixed-shell-clip-/u)
     expect(Number(rects[0].attributes('x'))).toBeCloseTo(8 / 1185, 8)
     expect(Number(rects[0].attributes('y'))).toBeCloseTo(8 / 790, 8)
@@ -248,12 +249,6 @@ describe('GlassFixedShellBackplate', () => {
     expect(Number(rects[0].attributes('height'))).toBeCloseTo(774 / 790, 8)
     expect(Number(rects[0].attributes('rx'))).toBeCloseTo(16 / 1185, 8)
     expect(Number(rects[0].attributes('ry'))).toBeCloseTo(16 / 790, 8)
-    expect(Number(rects[1].attributes('x'))).toBeCloseTo(268 / 1185, 8)
-    expect(Number(rects[1].attributes('y'))).toBeCloseTo(8 / 790, 8)
-    expect(Number(rects[1].attributes('width'))).toBeCloseTo(909 / 1185, 8)
-    expect(Number(rects[1].attributes('height'))).toBeCloseTo(72 / 790, 8)
-    expect(Number(rects[1].attributes('rx'))).toBeCloseTo(16 / 1185, 8)
-    expect(Number(rects[1].attributes('ry'))).toBeCloseTo(16 / 790, 8)
     expect(wrapper.findAll('[data-backplate-surface="main"]')).toHaveLength(1)
     expect(wrapper.findAll('[data-backplate-slot]')).toHaveLength(2)
   })
@@ -266,7 +261,7 @@ describe('GlassFixedShellBackplate', () => {
     expect(wrapper.findAll('clipPath rect')).toHaveLength(0)
   })
 
-  it('updates the shared clip when theme radius changes without resizing navigation', async () => {
+  it('updates the shared clip when theme radius changes without resizing the sidebar', async () => {
     const { wrapper, sidebar } = mountConnectedShell()
     await settleGeometry()
     const style = window.getComputedStyle(sidebar)
@@ -281,20 +276,64 @@ describe('GlassFixedShellBackplate', () => {
     }
   })
 
+  it('keeps the sidebar clip when the navbar changes size or is missing', async () => {
+    const { wrapper, navbar } = mountConnectedShell()
+    await settleGeometry()
+
+    navbarRect = createRect(273, 11, 640, 112)
+    resizeCallback?.([], {} as ResizeObserver)
+    await settleGeometry()
+
+    expect(wrapper.findAll('clipPath rect')).toHaveLength(1)
+    expect(Number(wrapper.find('clipPath rect').attributes('width'))).toBeCloseTo(252 / 1185, 8)
+
+    navbar.remove()
+    resizeCallback?.([], {} as ResizeObserver)
+    await settleGeometry()
+
+    expect(wrapper.findAll('clipPath rect')).toHaveLength(1)
+    expect(Number(wrapper.find('clipPath rect').attributes('x'))).toBeCloseTo(8 / 1185, 8)
+  })
+
+  it('falls back to no dynamic clip when the connected sidebar is missing', async () => {
+    const { wrapper, sidebar } = mountConnectedShell()
+    await settleGeometry()
+
+    sidebar.remove()
+    resizeCallback?.([], {} as ResizeObserver)
+    await settleGeometry()
+
+    expect((wrapper.get('[data-backplate-surface="main"]').element as HTMLElement).style.clipPath).toBe('')
+    expect(wrapper.findAll('clipPath rect')).toHaveLength(0)
+  })
+
+  it('uses the real collapsed sidebar bounds in RTL', async () => {
+    document.documentElement.setAttribute('dir', 'rtl')
+    sidebarRect = createRect(1122, 11, 60, 774)
+    navbarRect = createRect(13, 11, 909, 72)
+    const { wrapper } = mountConnectedShell()
+    await settleGeometry()
+
+    const rect = wrapper.get('clipPath rect')
+    expect(Number(rect.attributes('x'))).toBeCloseTo((1122 - 5) / 1185, 8)
+    expect(Number(rect.attributes('y'))).toBeCloseTo(8 / 790, 8)
+    expect(Number(rect.attributes('width'))).toBeCloseTo(60 / 1185, 8)
+    expect(Number(rect.attributes('height'))).toBeCloseTo(774 / 790, 8)
+  })
+
   it('refreshes dimensions and disconnects the resize observer on unmount', async () => {
     const { wrapper } = mountConnectedShell()
     await settleGeometry()
 
     backplateRect = createRect(5, 3, 1180, 790)
     sidebarRect = createRect(13, 11, 60, 774)
-    navbarRect = createRect(273, 11, 904, 96)
     resizeCallback?.([], {} as ResizeObserver)
     await settleGeometry()
 
     const rects = wrapper.findAll('clipPath rect')
     expect(Number(rects[0].attributes('width'))).toBeCloseTo(60 / 1180, 8)
-    expect(Number(rects[1].attributes('x'))).toBeCloseTo(268 / 1180, 8)
-    expect(Number(rects[1].attributes('height'))).toBeCloseTo(96 / 790, 8)
+    expect(Number(rects[0].attributes('x'))).toBeCloseTo(8 / 1180, 8)
+    expect(Number(rects[0].attributes('height'))).toBeCloseTo(774 / 790, 8)
 
     wrapper.unmount()
     expect(resizeDisconnect).toHaveBeenCalledOnce()

--- a/src/components/theme/__tests__/GlassMediaBackdrop.spec.ts
+++ b/src/components/theme/__tests__/GlassMediaBackdrop.spec.ts
@@ -1,0 +1,248 @@
+import { mount } from '@vue/test-utils'
+import { defineComponent, h, KeepAlive, nextTick, ref } from 'vue'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import GlassMediaBackdrop from '@/components/theme/GlassMediaBackdrop.vue'
+
+const state = vi.hoisted(() => ({ chromium: true }))
+const themeName = ref('glass')
+const reducedTransparency = ref(false)
+vi.mock('@/composables/useGlassFixedShellBackplate', () => ({
+  isChromiumFixedShellBackplateBrowser: () => state.chromium,
+}))
+vi.mock('vuetify', () => ({ useTheme: () => ({ global: { name: themeName } }) }))
+vi.mock('@vueuse/core', () => ({ useMediaQuery: () => reducedTransparency }))
+
+let frames: Map<number, FrameRequestCallback>
+let nextId = 1
+let resizeCallbacks: ResizeObserverCallback[]
+const wrappers: ReturnType<typeof mount>[] = []
+
+async function settle() {
+  await nextTick()
+  for (let i = 0; i < 10; i++) {
+    const pending = [...frames.entries()]
+    frames.clear()
+    for (const [, callback] of pending) callback(16 * i)
+    await nextTick()
+    await Promise.resolve()
+    if (!frames.size) break
+  }
+}
+
+function renderBackdrop(
+  slot = '<div class="progressive-card-grid"><div class="media-card" data-y="8000" style="border-top-left-radius:16px;border-top-right-radius:16px;border-bottom-right-radius:16px;border-bottom-left-radius:16px"></div></div>',
+) {
+  const wrapper = mount(GlassMediaBackdrop, { slots: { default: slot }, attachTo: document.body })
+  wrappers.push(wrapper)
+  return wrapper
+}
+
+beforeEach(() => {
+  state.chromium = true
+  themeName.value = 'glass'
+  reducedTransparency.value = false
+  frames = new Map()
+  resizeCallbacks = []
+  vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+    const id = nextId++
+    frames.set(id, callback)
+    return id
+  })
+  vi.stubGlobal('cancelAnimationFrame', (id: number) => frames.delete(id))
+  vi.stubGlobal('CSS', { supports: () => true })
+  vi.stubGlobal(
+    'DOMMatrixReadOnly',
+    class {
+      isIdentity: boolean
+      constructor(value: string) {
+        this.isIdentity = value === 'matrix(1, 0, 0, 1, 0, 0)'
+      }
+    },
+  )
+  vi.stubGlobal(
+    'ResizeObserver',
+    class {
+      constructor(callback: ResizeObserverCallback) {
+        resizeCallbacks.push(callback)
+      }
+      observe() {}
+      disconnect() {}
+    },
+  )
+  vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (this: HTMLElement) {
+    const card = this.classList.contains('media-card')
+    return new DOMRect(
+      card ? Number(this.dataset.x ?? 10) : 0,
+      card ? Number(this.dataset.y ?? 0) : 0,
+      card ? 120 : 1000,
+      card ? 180 : 20000,
+    )
+  })
+})
+
+afterEach(() => {
+  for (const wrapper of wrappers.splice(0)) wrapper.unmount()
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('shared media backdrop ownership', () => {
+  it('bounds sampling to mounted pending cards, not the complete virtual track', async () => {
+    const wrapper = renderBackdrop()
+    await settle()
+    const layer = wrapper.get('.glass-media-backdrop__sampling').element as HTMLElement
+    expect(layer.style.top).toBe('8000px')
+    expect(layer.style.height).toBe('180px')
+    expect(layer.style.clipPath).toContain('M26 0H114A16 16')
+    expect(wrapper.get('.media-card').attributes('data-glass-shared-backdrop')).toBe('true')
+    expect(frames.size).toBe(0)
+  })
+
+  it('hands off only after real reveal, and restores sampling on same-node reuse', async () => {
+    const wrapper = renderBackdrop()
+    await settle()
+    const card = wrapper.get('.media-card').element as HTMLElement
+    card.classList.add('media-card--image-loaded')
+    await settle()
+    expect(card.dataset.glassSharedBackdrop).toBe('true')
+    card.dataset.glassOpticalMode = 'excluded'
+    await settle()
+    expect(card.dataset.glassSharedBackdrop).toBeUndefined()
+    expect(wrapper.find('.glass-media-backdrop__sampling').exists()).toBe(false)
+    delete card.dataset.glassOpticalMode
+    await settle()
+    expect(card.dataset.glassSharedBackdrop).toBe('true')
+  })
+
+  it('removes a hovering or transitioning card from both the ownership and union', async () => {
+    const wrapper = renderBackdrop()
+    await settle()
+    const card = wrapper.get('.media-card').element as HTMLElement
+    card.classList.add('app-hover-lift-card--hovering')
+    await settle()
+    expect(card.dataset.glassSharedBackdrop).toBeUndefined()
+    expect(wrapper.find('.glass-media-backdrop__sampling').exists()).toBe(false)
+    card.classList.remove('app-hover-lift-card--hovering')
+    card.style.transform = 'matrix(1, 0, 0, 1, 0, -2)'
+    await settle()
+    expect(card.dataset.glassSharedBackdrop).toBeUndefined()
+    card.style.transform = 'matrix(1, 0, 0, 1, 0, 0)'
+    card.dispatchEvent(new Event('transitionend', { bubbles: true }))
+    await settle()
+    expect(card.dataset.glassSharedBackdrop).toBe('true')
+  })
+
+  it('updates virtual replacements and releases detached nodes', async () => {
+    const wrapper = renderBackdrop()
+    await settle()
+    const card = wrapper.get('.media-card').element as HTMLElement
+    const next = card.cloneNode(true) as HTMLElement
+    delete next.dataset.glassSharedBackdrop
+    next.dataset.y = '16000'
+    card.replaceWith(next)
+    await settle()
+    expect(card.dataset.glassSharedBackdrop).toBeUndefined()
+    expect(next.dataset.glassSharedBackdrop).toBe('true')
+    expect((wrapper.get('.glass-media-backdrop__sampling').element as HTMLElement).style.top).toBe('16000px')
+  })
+
+  it('tracks four corner radii after theme and resize changes without a scroll loop', async () => {
+    const corners = ref({
+      borderTopLeftRadius: '16px',
+      borderTopRightRadius: '16px',
+      borderBottomRightRadius: '16px',
+      borderBottomLeftRadius: '16px',
+    })
+    const wrapper = mount(GlassMediaBackdrop, {
+      slots: { default: () => h('div', { class: 'media-card', style: corners.value }) },
+      attachTo: document.body,
+    })
+    wrappers.push(wrapper)
+    await settle()
+    corners.value = {
+      borderTopLeftRadius: '8px',
+      borderTopRightRadius: '12px',
+      borderBottomRightRadius: '20px',
+      borderBottomLeftRadius: '4px',
+    }
+    document.documentElement.dataset.themeRadius = 'large'
+    resizeCallbacks.forEach(callback => callback([], {} as ResizeObserver))
+    await settle()
+    const clip = (wrapper.get('.glass-media-backdrop__sampling').element as HTMLElement).style.clipPath
+    expect(clip).toContain('A12 12')
+    expect(clip).toContain('A20 20')
+    expect(clip).toContain('A4 4')
+    expect(clip).toContain('A8 8')
+    window.dispatchEvent(new Event('scroll'))
+    expect(frames.size).toBe(0)
+  })
+
+  it('restores native ownership for non-glass and reduced-transparency modes', async () => {
+    const wrapper = renderBackdrop()
+    await settle()
+    reducedTransparency.value = true
+    await settle()
+    expect(wrapper.find('[data-glass-shared-backdrop]').exists()).toBe(false)
+    expect(wrapper.find('.glass-media-backdrop__sampling').exists()).toBe(false)
+    reducedTransparency.value = false
+    await settle()
+    expect(wrapper.find('[data-glass-shared-backdrop]').exists()).toBe(true)
+    themeName.value = 'light'
+    await settle()
+    expect(wrapper.find('[data-glass-shared-backdrop]').exists()).toBe(false)
+  })
+
+  it('leaves unverified engines and overlays on their existing native path', async () => {
+    state.chromium = false
+    const fallback = renderBackdrop()
+    await settle()
+    expect(fallback.find('[data-glass-shared-backdrop]').exists()).toBe(false)
+    state.chromium = true
+    const overlay = mount(
+      {
+        components: { GlassMediaBackdrop },
+        template:
+          '<div class="v-overlay__content"><GlassMediaBackdrop><div class="media-card" /></GlassMediaBackdrop></div>',
+      },
+      { attachTo: document.body },
+    )
+    wrappers.push(overlay)
+    await settle()
+    expect(overlay.find('[data-glass-shared-backdrop]').exists()).toBe(false)
+  })
+
+  it('keeps content usable when feature detection is unavailable', async () => {
+    vi.stubGlobal('CSS', {})
+    const wrapper = renderBackdrop()
+    await settle()
+    expect(wrapper.find('.media-card').exists()).toBe(true)
+    expect(wrapper.find('[data-glass-shared-backdrop]').exists()).toBe(false)
+    expect(frames.size).toBe(0)
+  })
+
+  it('releases samplers and pending work on KeepAlive deactivation and unmount', async () => {
+    const shown = ref(true)
+    const host = defineComponent({
+      setup: () => () =>
+        h(KeepAlive, null, {
+          default: () =>
+            shown.value ? h(GlassMediaBackdrop, null, { default: () => h('div', { class: 'media-card' }) }) : null,
+        }),
+    })
+    const wrapper = mount(host, { attachTo: document.body })
+    wrappers.push(wrapper)
+    await settle()
+    const card = wrapper.get('.media-card').element as HTMLElement
+    expect(card.dataset.glassSharedBackdrop).toBe('true')
+    shown.value = false
+    await settle()
+    expect(card.dataset.glassSharedBackdrop).toBeUndefined()
+    expect(frames.size).toBe(0)
+    shown.value = true
+    await settle()
+    expect(card.dataset.glassSharedBackdrop).toBe('true')
+    wrapper.unmount()
+    expect(card.dataset.glassSharedBackdrop).toBeUndefined()
+    expect(frames.size).toBe(0)
+  })
+})

--- a/src/components/theme/__tests__/GlassNavbarRefractionDefs.spec.ts
+++ b/src/components/theme/__tests__/GlassNavbarRefractionDefs.spec.ts
@@ -21,6 +21,8 @@ describe('GlassNavbarRefractionDefs', () => {
   let sidebarWidth: number
   let radius: number
   let sidebar: HTMLElement | undefined
+  let focused: boolean
+  let visibility: DocumentVisibilityState
   let transparencyReduced: boolean
   let transparencyChange: ((event: MediaQueryListEvent) => void) | undefined
   let decodePending: Array<{ resolve: () => void; reject: (reason?: unknown) => void }>
@@ -38,6 +40,10 @@ describe('GlassNavbarRefractionDefs', () => {
     transparencyChange = undefined
     decodePending = []
     sidebar = undefined
+    focused = true
+    visibility = 'visible'
+    vi.spyOn(document, 'hasFocus').mockImplementation(() => focused)
+    vi.spyOn(document, 'visibilityState', 'get').mockImplementation(() => visibility)
     shell = document.createElement('div')
     shell.className =
       'layout-wrapper layout-horizontal-nav-active layout-navbar-floating-eligible layout-navbar-away-from-top'
@@ -231,6 +237,62 @@ describe('GlassNavbarRefractionDefs', () => {
     await flushPromises()
     expect(shell.dataset.glassNavbarRefractionReady).toBe('false')
     expect(wrapper.get('feImage').attributes('href')).toBe('neutral')
+  })
+
+  it.each(['blur', 'hidden'] as const)(
+    'does not prepare fallback maps when panel suspension follows %s',
+    async mode => {
+      navbar.dataset.glassPanelRefraction = 'panel-navbar'
+      wrapper = mount(GlassNavbarRefractionDefs)
+      await settle()
+      expect(createGlassNavbarDisplacementMap).not.toHaveBeenCalled()
+
+      if (mode === 'blur') {
+        focused = false
+        window.dispatchEvent(new Event('blur'))
+      } else {
+        visibility = 'hidden'
+        document.dispatchEvent(new Event('visibilitychange'))
+      }
+      delete navbar.dataset.glassPanelRefraction
+      await flushPromises()
+      await settle()
+      expect(createGlassNavbarDisplacementMap).not.toHaveBeenCalled()
+      expect(shell.dataset.glassNavbarRefractionReady).toBe('false')
+
+      focused = true
+      visibility = 'visible'
+      if (mode === 'blur') window.dispatchEvent(new Event('focus'))
+      else document.dispatchEvent(new Event('visibilitychange'))
+      await settle()
+      expect(createGlassNavbarDisplacementMap).toHaveBeenCalledTimes(1)
+      expectReadyForWidth(1423)
+    },
+  )
+
+  it('does not activate a pending decode while the document is hidden', async () => {
+    wrapper = mount(GlassNavbarRefractionDefs)
+    await vi.advanceTimersByTimeAsync(65)
+    expect(decodePending).toHaveLength(1)
+    visibility = 'hidden'
+    document.dispatchEvent(new Event('visibilitychange'))
+    completePendingDecode()
+    await flushPromises()
+    expect(shell.dataset.glassNavbarRefractionReady).toBe('false')
+    expect(wrapper.get('feImage').attributes('href')).toBe('neutral')
+  })
+
+  it('restores a decoded floating map immediately on focus without regenerating it', async () => {
+    wrapper = mount(GlassNavbarRefractionDefs)
+    await settle()
+    focused = false
+    window.dispatchEvent(new Event('blur'))
+    expect(shell.dataset.glassNavbarRefractionReady).toBe('false')
+
+    focused = true
+    window.dispatchEvent(new Event('focus'))
+    expectReadyForWidth(1423)
+    expect(createGlassNavbarDisplacementMap).toHaveBeenCalledTimes(1)
   })
 
   it('keeps independent geometry caches when switching between horizontal and vertical navigation', async () => {

--- a/src/components/theme/__tests__/GlassNavbarRefractionDefs.spec.ts
+++ b/src/components/theme/__tests__/GlassNavbarRefractionDefs.spec.ts
@@ -176,6 +176,63 @@ describe('GlassNavbarRefractionDefs', () => {
     expectReadyForWidth(1423)
   })
 
+  it('skips fallback maps only after the panel material has actually taken over', async () => {
+    shell.className = 'layout-wrapper'
+    shell.dataset.shellMode = 'desktop'
+    navbar.dataset.glassPanelRefraction = 'panel-navbar'
+    mountWithSidebar()
+    sidebar!.dataset.glassPanelRefraction = 'panel-sidebar'
+    await settle()
+
+    expect(createGlassNavbarDisplacementMap).not.toHaveBeenCalled()
+    expect(shell.dataset.glassNavbarRefractionReady).toBe('false')
+    expect(shell.dataset.glassSidebarRefractionReady).toBe('false')
+
+    // 所有权先于解码发布；只有就绪标记能够抑制备用透镜。
+    navbar.dataset.glassPanelOwner = 'panel-navbar'
+    sidebar!.dataset.glassPanelOwner = 'panel-sidebar'
+    delete navbar.dataset.glassPanelRefraction
+    delete sidebar!.dataset.glassPanelRefraction
+    await flushPromises()
+    await settle()
+    expect(createGlassNavbarDisplacementMap).toHaveBeenCalledTimes(2)
+    expectReadyForWidth(1423)
+    expectReadyForSidebar(260)
+  })
+
+  it('reuses decoded fallback maps when panel refraction is suspended', async () => {
+    shell.className = 'layout-wrapper'
+    shell.dataset.shellMode = 'desktop'
+    mountWithSidebar()
+    await settle()
+
+    navbar.dataset.glassPanelRefraction = 'panel-navbar'
+    sidebar!.dataset.glassPanelRefraction = 'panel-sidebar'
+    await flushPromises()
+    expect(shell.dataset.glassNavbarRefractionReady).toBe('false')
+    expect(shell.dataset.glassSidebarRefractionReady).toBe('false')
+
+    delete navbar.dataset.glassPanelRefraction
+    delete sidebar!.dataset.glassPanelRefraction
+    await flushPromises()
+    expectReadyForWidth(1423)
+    expectReadyForSidebar(260)
+    expect(createGlassNavbarDisplacementMap).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not activate a pending fallback after panel takeover', async () => {
+    wrapper = mount(GlassNavbarRefractionDefs)
+    await vi.advanceTimersByTimeAsync(65)
+    expect(decodePending).toHaveLength(1)
+
+    navbar.dataset.glassPanelRefraction = 'panel-navbar'
+    await flushPromises()
+    completePendingDecode()
+    await flushPromises()
+    expect(shell.dataset.glassNavbarRefractionReady).toBe('false')
+    expect(wrapper.get('feImage').attributes('href')).toBe('neutral')
+  })
+
   it('keeps independent geometry caches when switching between horizontal and vertical navigation', async () => {
     mountWithSidebar()
     await settle()

--- a/src/components/theme/__tests__/GlassPanelRefractionDefs.spec.ts
+++ b/src/components/theme/__tests__/GlassPanelRefractionDefs.spec.ts
@@ -534,33 +534,93 @@ describe('GlassPanelRefractionDefs', () => {
     expect(card.style.getPropertyValue('backdrop-filter')).toContain('url(')
   })
 
-  it('uses the stable frosted backplate for fixed navigation instead of navigation backdrop filters', async () => {
+  it.each(['balanced', 'high'] as const)(
+    'keeps %s frosted navbar live while the sidebar samples its backplate',
+    async quality => {
+      resetFixture(false)
+      effectiveSettings.value.glassAppearance = 'frosted'
+      effectiveSettings.value.glassQuality = quality
+      document.documentElement.dataset.glassAppearance = 'frosted'
+      document.documentElement.dataset.glassQuality = quality
+      mountPanel()
+      await settle()
+
+      const layer = shell.querySelector('.glass-fixed-shell-backplate__layer') as HTMLElement
+      const navbar = shell.querySelector('.layout-navbar') as HTMLElement
+      const sidebar = shell.querySelector('.layout-vertical-nav') as HTMLElement
+
+      expect(createGlassPanelBackdropMap).toHaveBeenCalledTimes(1)
+      expect(createGlassPanelBackdropMap).toHaveBeenCalledWith(
+        expect.objectContaining({
+          height: 900,
+          panels: [expect.objectContaining({ height: 800, width: 260 })],
+          width: 1200,
+        }),
+      )
+      expect(layer.style.getPropertyValue('filter')).toContain('url(')
+      expect(navbar.style.getPropertyValue('--glass-panel-filter')).toContain('url(')
+      expect(navbar.style.getPropertyValue('filter')).toBe('')
+      expect(navbar.style.getPropertyValue('backdrop-filter')).toBe('')
+      expect(navbar.hasAttribute('data-glass-panel-refraction')).toBe(true)
+      expect(sidebar.style.getPropertyValue('--glass-panel-filter')).toBe('')
+      expect(createGlassNavbarDisplacementMap).toHaveBeenCalledTimes(2)
+      expect(createGlassNavbarDisplacementMap).toHaveBeenCalledWith(
+        expect.objectContaining({ height: 64, width: 1200, surface: 'panel' }),
+      )
+      expect(card.style.getPropertyValue('backdrop-filter')).toContain('url(')
+      expect(wrapper?.findAll('feGaussianBlur')).toHaveLength(quality === 'high' ? 3 : 0)
+      expect(navbar.style.getPropertyValue('--glass-panel-filter').includes(' blur(')).toBe(quality === 'balanced')
+    },
+  )
+
+  it('does not regenerate the sidebar backplate map when only navbar geometry changes', async () => {
     resetFixture(false)
     effectiveSettings.value.glassAppearance = 'frosted'
-    document.documentElement.dataset.glassAppearance = 'frosted'
     mountPanel()
+    await settle()
+    const navbar = shell.querySelector('.layout-navbar') as HTMLElement
+    const bounds = navbar.getBoundingClientRect()
+    vi.spyOn(navbar, 'getBoundingClientRect').mockReturnValue({ ...bounds, width: 1100, right: 1100 })
+
+    resize?.([], {} as ResizeObserver)
+    await settle()
+
+    expect(createGlassPanelBackdropMap).toHaveBeenCalledTimes(1)
+    expect(createGlassNavbarDisplacementMap).toHaveBeenCalledTimes(3)
+    expect(createGlassNavbarDisplacementMap).toHaveBeenLastCalledWith(
+      expect.objectContaining({ height: 64, width: 1100, surface: 'panel' }),
+    )
+  })
+
+  it('preserves sidebar enhancement if the live frosted navbar map fails to decode', async () => {
+    resetFixture(false)
+    effectiveSettings.value.glassAppearance = 'frosted'
+    mountPanel()
+    await vi.advanceTimersByTimeAsync(65)
+    expect(decodePending).toHaveLength(3)
+    decodePending.splice(1, 1)[0].reject(new Error('navbar image unavailable'))
+    completePendingDecode()
+    await flushPromises()
+
+    const layer = shell.querySelector('.glass-fixed-shell-backplate__layer') as HTMLElement
+    const navbar = shell.querySelector('.layout-navbar') as HTMLElement
+    expect(layer.style.getPropertyValue('filter')).toContain('url(')
+    expect(navbar.style.getPropertyValue('--glass-panel-filter')).toBe('')
+    expect(navbar.hasAttribute('data-glass-panel-refraction')).toBe(false)
+  })
+
+  it('releases both frosted sampling owners when selecting CSS quality', async () => {
+    resetFixture(false)
+    effectiveSettings.value.glassAppearance = 'frosted'
+    mountPanel()
+    await settle()
+    effectiveSettings.value.glassQuality = 'css'
     await settle()
 
     const layer = shell.querySelector('.glass-fixed-shell-backplate__layer') as HTMLElement
     const navbar = shell.querySelector('.layout-navbar') as HTMLElement
-    const sidebar = shell.querySelector('.layout-vertical-nav') as HTMLElement
-
-    expect(createGlassPanelBackdropMap).toHaveBeenCalledTimes(1)
-    expect(createGlassPanelBackdropMap).toHaveBeenCalledWith(
-      expect.objectContaining({
-        height: 900,
-        panels: expect.arrayContaining([
-          expect.objectContaining({ height: 64, width: 1200 }),
-          expect.objectContaining({ height: 800, width: 260 }),
-        ]),
-        width: 1200,
-      }),
-    )
-    expect(layer.style.getPropertyValue('filter')).toContain('url(')
+    expect(layer.style.getPropertyValue('filter')).toBe('')
     expect(navbar.style.getPropertyValue('--glass-panel-filter')).toBe('')
-    expect(sidebar.style.getPropertyValue('--glass-panel-filter')).toBe('')
-    expect(createGlassNavbarDisplacementMap).toHaveBeenCalledTimes(1)
-    expect(card.style.getPropertyValue('backdrop-filter')).toContain('url(')
-    expect(wrapper?.findAll('feGaussianBlur')).toHaveLength(2)
+    expect(shell.querySelectorAll('[data-glass-panel-refraction]')).toHaveLength(0)
   })
 })

--- a/src/composables/__tests__/useGlassOpticalRenderer.spec.ts
+++ b/src/composables/__tests__/useGlassOpticalRenderer.spec.ts
@@ -772,6 +772,97 @@ describe('glass optical surface discovery', () => {
     scope.stop()
   })
 
+  it.each(['fixed', 'scroll'] as const)(
+    'commits matching material uniforms when appearance and quality change together in %s space',
+    async surfaceSpace => {
+      const three = await import('three')
+      const render = vi.spyOn(three.WebGLRenderer.prototype, 'render')
+      const appearance = ref<'clear' | 'frosted' | 'tinted'>('tinted')
+      const quality = ref<'balanced' | 'high'>('high')
+      const scope = effectScope()
+      try {
+        const renderer = scope.run(() =>
+          useGlassOpticalRenderer({
+            active: ref(true),
+            appearance,
+            canvas: ref(document.createElement('canvas')),
+            dynamicsMode: ref('off'),
+            quality,
+            routeKey: ref('/dashboard'),
+            surfaceSpace,
+            tintColor: ref('#8D51F9'),
+            wallpaperUrl: ref('https://example.com/wallpaper.jpg'),
+          }),
+        )
+        await vi.waitFor(() => expect(renderer?.state.value).toBe('ready'))
+        const scene = render.mock.calls.find(([scene]) => getGlassMainSceneMaterial(scene))![0]
+        const uniforms = getGlassMainSceneMaterial(scene)!.uniforms
+        expect(uniforms.uAppearance.value).toBe(1)
+        expect(uniforms.uQuality.value).toBe(1)
+
+        appearance.value = 'frosted'
+        quality.value = 'balanced'
+        await vi.waitFor(() => expect(renderer?.activeWallpaperPreparationKey.value).toContain('frosted:balanced:'))
+        expect(uniforms.uAppearance.value).toBe(2)
+        expect(uniforms.uDynamicsOnly.value).toBe(1)
+        expect(uniforms.uQuality.value).toBe(0)
+        expect(renderer?.state.value).toBe('ready')
+
+        quality.value = 'high'
+        appearance.value = 'clear'
+        await vi.waitFor(() => expect(renderer?.activeWallpaperPreparationKey.value).toContain('plain:high:'))
+        expect(uniforms.uAppearance.value).toBe(0)
+        expect(uniforms.uDynamicsOnly.value).toBe(surfaceSpace === 'scroll' ? 1 : 0)
+        expect(uniforms.uQuality.value).toBe(1)
+      } finally {
+        scope.stop()
+      }
+    },
+  )
+
+  it('retains committed material uniforms when a concurrent appearance and quality reload fails', async () => {
+    const three = await import('three')
+    const render = vi.spyOn(three.WebGLRenderer.prototype, 'render')
+    const appearance = ref<'frosted' | 'tinted'>('tinted')
+    const quality = ref<'balanced' | 'high'>('high')
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const scope = effectScope()
+    try {
+      const renderer = scope.run(() =>
+        useGlassOpticalRenderer({
+          active: ref(true),
+          appearance,
+          canvas: ref(document.createElement('canvas')),
+          dynamicsMode: ref('off'),
+          quality,
+          routeKey: ref('/dashboard'),
+          surfaceSpace: 'fixed',
+          tintColor: ref('#8D51F9'),
+          wallpaperUrl: ref('https://example.com/wallpaper.jpg'),
+        }),
+      )
+      await vi.waitFor(() => expect(renderer?.state.value).toBe('ready'))
+      const scene = render.mock.calls.find(([scene]) => getGlassMainSceneMaterial(scene))![0]
+      const uniforms = getGlassMainSceneMaterial(scene)!.uniforms
+      const key = renderer?.activeWallpaperPreparationKey.value
+      const previous = Object.fromEntries(
+        ['uAppearance', 'uDynamicsOnly', 'uQuality', 'uBackgroundVisibility', 'uSurfaceDensity', 'uTintDensity'].map(
+          key => [key, uniforms[key].value],
+        ),
+      )
+      vi.spyOn(three.TextureLoader.prototype, 'loadAsync').mockRejectedValue(new Error('replacement failed'))
+      appearance.value = 'frosted'
+      quality.value = 'balanced'
+      await vi.waitFor(() => expect(consoleWarn).toHaveBeenCalled())
+      await nextTick()
+      expect(renderer?.activeWallpaperPreparationKey.value).toBe(key)
+      expect(renderer?.state.value).toBe('ready')
+      for (const [key, value] of Object.entries(previous)) expect(uniforms[key].value).toBe(value)
+    } finally {
+      scope.stop()
+    }
+  })
+
   it('re-samples scroll surfaces and material weight on a shared page motion revision', async () => {
     vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(1200)
     vi.spyOn(window, 'innerHeight', 'get').mockReturnValue(800)

--- a/src/composables/__tests__/useGlassOpticalRenderer.spec.ts
+++ b/src/composables/__tests__/useGlassOpticalRenderer.spec.ts
@@ -575,6 +575,53 @@ describe('glass optical surface discovery', () => {
     expect(collectGlassOpticalRects(1200, 800, 'clear')).toEqual([])
   })
 
+  it('clears the full fixed framebuffer before shading the current bounded surfaces', async () => {
+    const three = await import('three')
+    const commands: Array<{ kind: string; value?: unknown }> = []
+    vi.spyOn(three.WebGLRenderer.prototype, 'setScissorTest').mockImplementation(value => {
+      commands.push({ kind: 'scissor-test', value })
+    })
+    vi.spyOn(three.WebGLRenderer.prototype, 'setScissor').mockImplementation((...value) => {
+      commands.push({ kind: 'scissor', value })
+    })
+    vi.spyOn(three.WebGLRenderer.prototype, 'clear').mockImplementation(() => {
+      commands.push({ kind: 'clear' })
+    })
+    vi.spyOn(three.WebGLRenderer.prototype, 'render').mockImplementation(scene => {
+      if (getGlassMainSceneMaterial(scene)) commands.push({ kind: 'render' })
+    })
+    appendOpticalSurface('layout-navbar', { x: 16, y: 16, width: 1100, height: 64 })
+    const scope = effectScope()
+    try {
+      const renderer = scope.run(() =>
+        useGlassOpticalRenderer({
+          active: ref(true),
+          appearance: ref('clear'),
+          canvas: ref(document.createElement('canvas')),
+          quality: ref('high'),
+          dynamicsMode: ref('off'),
+          routeKey: ref('/recommend'),
+          surfaceSpace: 'fixed',
+          tintColor: ref('#8D51F9'),
+          wallpaperUrl: ref('https://example.com/wallpaper.jpg'),
+        }),
+      )
+      await vi.waitFor(() => expect(renderer?.state.value).toBe('ready'))
+      await vi.waitFor(() => expect(commands.some(command => command.kind === 'render')).toBe(true))
+      for (const [index, command] of commands.entries()) {
+        if (command.kind !== 'render') continue
+        expect(commands.slice(index - 4, index)).toEqual([
+          { kind: 'scissor-test', value: false },
+          { kind: 'clear' },
+          { kind: 'scissor', value: expect.any(Array) },
+          { kind: 'scissor-test', value: true },
+        ])
+      }
+    } finally {
+      scope.stop()
+    }
+  })
+
   it('blocks transient subtree input before it can animate an underlying content surface', async () => {
     const three = await import('three')
     const render = vi.spyOn(three.WebGLRenderer.prototype, 'render')

--- a/src/composables/__tests__/useGlassOpticalRenderer.spec.ts
+++ b/src/composables/__tests__/useGlassOpticalRenderer.spec.ts
@@ -178,8 +178,12 @@ function createTouchList(points: Array<{ clientX: number; clientY: number; ident
   }) as unknown as TouchList
 }
 
-/** 构造浏览器在 detached 子树交付前保留的 child-list 移除记录。 */
-function createRemovalRecord(target: Element, removedNodes: Element[]): MutationRecord {
+/** 构造浏览器交付的 child-list 记录，并保留 detached 子树的节点身份。 */
+function createChildListRecord(
+  target: Element,
+  addedNodes: Element[] = [],
+  removedNodes: Element[] = [],
+): MutationRecord {
   const toNodeList = (nodes: Node[]) =>
     Object.assign(nodes, {
       item(index: number) {
@@ -188,7 +192,7 @@ function createRemovalRecord(target: Element, removedNodes: Element[]): Mutation
     }) as unknown as NodeList
 
   return {
-    addedNodes: toNodeList([]),
+    addedNodes: toNodeList(addedNodes),
     attributeName: null,
     attributeNamespace: null,
     nextSibling: null,
@@ -198,6 +202,11 @@ function createRemovalRecord(target: Element, removedNodes: Element[]): Mutation
     target,
     type: 'childList',
   }
+}
+
+/** 构造浏览器在 detached 子树交付前保留的 child-list 移除记录。 */
+function createRemovalRecord(target: Element, removedNodes: Element[]): MutationRecord {
+  return createChildListRecord(target, [], removedNodes)
 }
 
 /** 构造会改变光学表面资格的属性变更记录。 */
@@ -1548,6 +1557,87 @@ describe('glass optical surface discovery', () => {
     expect(renderedRectCounts.at(-1)).toBe(0)
     expect(setRenderTarget).not.toHaveBeenCalled()
     expect(callbacks.size).toBe(0)
+    scope.stop()
+  })
+
+  it('limits fixed redraws to fixed surface mutations', async () => {
+    vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(1200)
+    vi.spyOn(window, 'innerHeight', 'get').mockReturnValue(800)
+    vi.stubGlobal('MutationObserver', MutationObserverTriggerMock)
+    const three = await import('three')
+    const render = vi.spyOn(three.WebGLRenderer.prototype, 'render')
+    const callbacks = new Map<number, FrameRequestCallback>()
+    let frameId = 0
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation(callback => {
+      frameId += 1
+      callbacks.set(frameId, callback)
+
+      return frameId
+    })
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(id => callbacks.delete(id))
+    const appWrapper = document.createElement('div')
+    appWrapper.className = 'app-wrapper'
+    const navbar = document.createElement('aside')
+    navbar.className = 'layout-navbar'
+    setOpticalSurfaceBounds(navbar, { height: 64, width: 600, x: 0, y: 0 })
+    const pageContent = document.createElement('main')
+    pageContent.className = 'layout-page-content'
+    appWrapper.append(navbar, pageContent)
+    document.body.append(appWrapper)
+    const scope = effectScope()
+    const renderer = scope.run(() =>
+      useGlassOpticalRenderer({
+        active: ref(true),
+        appearance: ref('clear'),
+        canvas: ref(document.createElement('canvas')),
+        quality: ref('balanced'),
+        routeKey: ref('/dashboard'),
+        surfaceSpace: 'fixed',
+        tintColor: ref('#8D51F9'),
+        wallpaperUrl: ref('https://example.com/wallpaper.jpg'),
+      }),
+    )
+
+    await vi.waitFor(() => expect(renderer?.state.value).toBe('ready'))
+    flushQueuedAnimationFrames(callbacks)
+    render.mockClear()
+    const mutationObserver = MutationObserverTriggerMock.instances[0]
+    expect(mutationObserver).toBeDefined()
+    const fixedFramesBeforeScrollMutations = renderer?.renderedFrames.value
+
+    const scrollCard = document.createElement('article')
+    scrollCard.className = 'app-hover-lift-card'
+    setOpticalSurfaceBounds(scrollCard, { height: 180, width: 320, x: 40, y: 120 })
+    pageContent.append(scrollCard)
+    mutationObserver?.trigger([createChildListRecord(pageContent, [scrollCard])])
+    expect(render).not.toHaveBeenCalled()
+    expect(callbacks.size).toBe(0)
+
+    scrollCard.dataset.glassOpticalMode = 'excluded'
+    mutationObserver?.trigger([createAttributeRecord(scrollCard)])
+    expect(render).not.toHaveBeenCalled()
+    expect(callbacks.size).toBe(0)
+
+    scrollCard.remove()
+    mutationObserver?.trigger([createRemovalRecord(pageContent, [scrollCard])])
+    expect(render).not.toHaveBeenCalled()
+    expect(callbacks.size).toBe(0)
+    expect(renderer?.renderedFrames.value).toBe(fixedFramesBeforeScrollMutations)
+
+    const replacementNavbar = document.createElement('aside')
+    replacementNavbar.className = 'layout-navbar'
+    setOpticalSurfaceBounds(replacementNavbar, { height: 64, width: 600, x: 120, y: 0 })
+    navbar.remove()
+    appWrapper.append(replacementNavbar)
+    mutationObserver?.trigger([createChildListRecord(appWrapper, [replacementNavbar], [navbar])])
+    flushQueuedAnimationFrames(callbacks)
+
+    expect(render).toHaveBeenCalled()
+    const scene = render.mock.calls.at(-1)?.[0] as Object3D
+    const material = getGlassMainSceneMaterial(scene)
+    if (!material) throw new Error('main optical scene was not rendered')
+    expect(material.uniforms.uRectCount.value).toBe(1)
+    expect(material.uniforms.uRects.value[0].x).toBeCloseTo(120 / 1200)
     scope.stop()
   })
 

--- a/src/composables/useGlassOpticalRenderer.ts
+++ b/src/composables/useGlassOpticalRenderer.ts
@@ -30,6 +30,7 @@ import {
   getGlassOpticalMotionEnergy,
   getGlassOpticalReflectionStrengthScale,
   getGlassOpticalRenderProfile,
+  getGlassOpticalScissor,
   getGlassOpticalTransmissionStrength,
   getGlassScrollBufferSize,
   getGlassOpticalTranslationStrengthScale,
@@ -1964,7 +1965,16 @@ export function useGlassOpticalRenderer(options: UseGlassOpticalRendererOptions)
       resources.renderer.setScissor(0, scissorY, presentationBufferWidth, scissorHeight)
       resources.renderer.clear()
     } else {
+      const scissor = getGlassOpticalScissor(
+        surfaceSlots.map(slot => slot.rect),
+        getCommittedPresentationSize(),
+        { width: presentationBufferWidth, height: presentationBufferHeight },
+      )
+      // 旧位置必须先完整清空；scissor 仅限制片元执行，不能把上一帧的轮廓留在裁剪框外。
       resources.renderer.setScissorTest(false)
+      resources.renderer.clear()
+      resources.renderer.setScissor(scissor.x, scissor.y, scissor.width, scissor.height)
+      resources.renderer.setScissorTest(true)
     }
     resources.renderer.render(resources.scene, resources.camera)
     renderedFrames.value += 1

--- a/src/composables/useGlassOpticalRenderer.ts
+++ b/src/composables/useGlassOpticalRenderer.ts
@@ -475,12 +475,23 @@ function getSurfacePresentationSpace(
   return selector === '.login-card' && document.querySelector('.login-root') ? 'scroll' : defaultSpace
 }
 
-/** 判断新增或移除的 DOM 子树是否会改变光学表面集合。 */
-export function containsGlassOpticalSurface(node: Node) {
-  if (!(node instanceof Element)) return false
-  if (node.matches(SURFACE_SELECTOR_QUERY) && isGlassOpticalElementEligible(node)) return true
+function matchesGlassOpticalSurface(element: Element, surfaceSpace: GlassPresentationSpace | 'all' = 'all') {
+  if (!element.matches(SURFACE_SELECTOR_QUERY) || !isGlassOpticalElementEligible(element)) return false
+  if (surfaceSpace === 'all') return true
 
-  return Array.from(node.querySelectorAll(SURFACE_SELECTOR_QUERY)).some(isGlassOpticalElementEligible)
+  return SURFACE_SELECTORS.some(
+    ({ selector, space }) => element.matches(selector) && getSurfacePresentationSpace(selector, space) === surfaceSpace,
+  )
+}
+
+/** 判断新增或移除的 DOM 子树是否会改变指定呈现空间的光学表面集合。 */
+export function containsGlassOpticalSurface(node: Node, surfaceSpace: GlassPresentationSpace | 'all' = 'all') {
+  if (!(node instanceof Element)) return false
+  if (matchesGlassOpticalSurface(node, surfaceSpace)) return true
+
+  return Array.from(node.querySelectorAll(SURFACE_SELECTOR_QUERY)).some(element =>
+    matchesGlassOpticalSurface(element, surfaceSpace),
+  )
 }
 
 /** 判断 DOM 子树是否包含会约束父表面动态输出的交互裁剪。 */
@@ -3351,7 +3362,49 @@ export function useGlassOpticalRenderer(options: UseGlassOpticalRendererOptions)
     else resizeRenderer()
   }
 
-  /** 只让会改变目标表面集合或圆角几何的 DOM 变更触发重扫。 */
+  /** fixed 过滤依赖已提交的 surface/clip 身份，避免 detached 节点丢失祖先关系后被误判为无关内容。 */
+  function elementTouchesManagedSurface(element: Element) {
+    return (
+      surfaceRegistry.some(
+        surface => surface.key === element || surface.key.contains(element) || element.contains(surface.key),
+      ) ||
+      interactionClipRegistry.some(
+        clip =>
+          clip.key === element ||
+          clip.key.contains(element) ||
+          element.contains(clip.key) ||
+          clip.owner === element ||
+          clip.owner.contains(element) ||
+          element.contains(clip.owner),
+      )
+    )
+  }
+
+  /** scroll 保留完整属性监听；fixed 只接受当前 surface/clip 边界或新 fixed surface。 */
+  function mutationTargetTouchesRenderer(target: Node) {
+    if (presentationSpace === 'scroll') return true
+    if (!(target instanceof Element)) return false
+
+    return elementTouchesManagedSurface(target) || containsGlassOpticalSurface(target, presentationSpace)
+  }
+
+  function containsRendererOpticalSurface(node: Node) {
+    return presentationSpace === 'scroll'
+      ? containsGlassOpticalSurface(node)
+      : containsGlassOpticalSurface(node, presentationSpace)
+  }
+
+  function containsRendererInteractionClip(node: Node) {
+    if (presentationSpace === 'scroll') return containsGlassInteractionClip(node)
+    if (!(node instanceof Element) || !containsGlassInteractionClip(node)) return false
+
+    return (
+      surfaceRegistry.some(surface => surface.key.contains(node)) ||
+      interactionClipRegistry.some(clip => clip.key === node || node.contains(clip.key))
+    )
+  }
+
+  /** 当前呈现空间的表面集合或交互裁剪发生变化时才启动稳定重扫。 */
   function mutationTouchesOpticalSurface(mutations: MutationRecord[]) {
     const removalRecords = mutations.flatMap(mutation => {
       if (mutation.type !== 'childList' || mutation.removedNodes.length === 0 || !(mutation.target instanceof Element))
@@ -3395,7 +3448,7 @@ export function useGlassOpticalRenderer(options: UseGlassOpticalRendererOptions)
     }
 
     return mutations.some(mutation => {
-      if (mutation.type === 'attributes') return true
+      if (mutation.type === 'attributes') return mutationTargetTouchesRenderer(mutation.target)
 
       const removedManagedSurface = [...mutation.removedNodes].some(
         node =>
@@ -3406,6 +3459,9 @@ export function useGlassOpticalRenderer(options: UseGlassOpticalRendererOptions)
       if (removedManagedSurface) return true
 
       const changedNodes = [...mutation.addedNodes, ...mutation.removedNodes]
+      const changedNodesTouchRenderer = changedNodes.some(
+        node => containsRendererOpticalSurface(node) || containsRendererInteractionClip(node),
+      )
 
       // 新增节点按提交后的祖先资格判断；排除子树内部的图片 DOM 变化不需要重扫。
       if (mutation.target instanceof Element && !isGlassOpticalElementEligible(mutation.target)) {
@@ -3417,7 +3473,7 @@ export function useGlassOpticalRenderer(options: UseGlassOpticalRendererOptions)
         return (belongsToManagedSurface || removedFromManagedSurface) && changedNodes.some(containsGlassInteractionClip)
       }
 
-      return changedNodes.some(node => containsGlassOpticalSurface(node) || containsGlassInteractionClip(node))
+      return changedNodesTouchRenderer
     })
   }
 
@@ -3451,7 +3507,8 @@ export function useGlassOpticalRenderer(options: UseGlassOpticalRendererOptions)
           mutation =>
             mutation.attributeName === 'data-glass-panel-owner' &&
             mutation.target instanceof Element &&
-            mutation.target.hasAttribute('data-glass-panel-owner'),
+            mutation.target.hasAttribute('data-glass-panel-owner') &&
+            mutationTargetTouchesRenderer(mutation.target),
         )
       ) {
         // 背景所有权交接无需等待几何稳定采样，避免同一帧出现两套静态材质。

--- a/src/composables/useGlassOpticalRenderer.ts
+++ b/src/composables/useGlassOpticalRenderer.ts
@@ -2599,6 +2599,28 @@ export function useGlassOpticalRenderer(options: UseGlassOpticalRendererOptions)
     )
   }
 
+  /** 同步材质读数；需要替换纹理时只能在有效加载成功后提交。 */
+  function syncAppearanceUniforms() {
+    if (!resources) return
+
+    const materialResponse = getMaterialResponse()
+    resources.uniforms.uAppearance.value = getGlassAppearanceUniformValue(toValue(options.appearance))
+    resources.uniforms.uBackgroundVisibility.value = materialResponse.backgroundVisibility
+    resources.uniforms.uDynamicsOnly.value = usesDynamicsOnly() ? 1 : 0
+    resources.uniforms.uFrostDetailLevel.value = materialResponse.frostDetailLevel
+    resources.uniforms.uSurfaceDensity.value = materialResponse.surfaceDensity
+    resources.uniforms.uTintDensity.value = materialResponse.tintDensity
+  }
+
+  /** 静态质量读数与动态资源的重置分离，允许被最终纹理事务一并提交。 */
+  function syncQualityUniforms() {
+    if (!resources) return
+
+    resources.uniforms.uMaxRefractionPixels.value = getMaxRefractionPixels()
+    resources.uniforms.uQuality.value = toValue(options.quality) === 'high' ? 1 : 0
+    resources.uniforms.uTrailCount.value = hasFluidCapability() ? getRenderProfile().trailCount : 0
+  }
+
   function resizeRenderer() {
     if (!resources || !canPresentFrame()) return
 
@@ -3924,6 +3946,9 @@ export function useGlassOpticalRenderer(options: UseGlassOpticalRendererOptions)
 
     const timestamp = performance.now()
     beforeActivate?.()
+    // 并发配置刷新共用加载代次；获胜事务必须提交完整读数，不能依赖已过期请求的回调。
+    syncAppearanceUniforms()
+    syncQualityUniforms()
     activateLoadedTexture(
       prepared.texture,
       prepared.frostedTarget,
@@ -4279,16 +4304,7 @@ export function useGlassOpticalRenderer(options: UseGlassOpticalRendererOptions)
       const applyAppearance = () => {
         if (!resources || toValue(options.appearance) !== appearance) return
 
-        const materialResponse = getGlassMaterialResponse(
-          appearance,
-          toValue(options.transparencyStrength ?? GLASS_OPTICAL_STRENGTH_DEFAULT),
-        )
-        resources.uniforms.uAppearance.value = getGlassAppearanceUniformValue(appearance)
-        resources.uniforms.uBackgroundVisibility.value = materialResponse.backgroundVisibility
-        resources.uniforms.uDynamicsOnly.value = usesDynamicsOnly() ? 1 : 0
-        resources.uniforms.uFrostDetailLevel.value = materialResponse.frostDetailLevel
-        resources.uniforms.uSurfaceDensity.value = materialResponse.surfaceDensity
-        resources.uniforms.uTintDensity.value = materialResponse.tintDensity
+        syncAppearanceUniforms()
       }
       const wallpaperUrl = toValue(options.wallpaperUrl)
       const quality = toValue(options.quality)
@@ -4337,9 +4353,7 @@ export function useGlassOpticalRenderer(options: UseGlassOpticalRendererOptions)
       const applyQuality = () => {
         if (!resources || toValue(options.quality) !== quality) return
 
-        resources.uniforms.uMaxRefractionPixels.value = getMaxRefractionPixels()
-        resources.uniforms.uQuality.value = quality === 'high' ? 1 : 0
-        resources.uniforms.uTrailCount.value = hasFluidCapability() ? nextProfile.trailCount : 0
+        syncQualityUniforms()
         interactionAnimating = false
         cancelScheduledFrame()
         resetInteractionState()

--- a/src/layouts/default/components/UserProfile.vue
+++ b/src/layouts/default/components/UserProfile.vue
@@ -17,7 +17,6 @@ import { themeManager } from '@/utils/themeManager'
 import { usePWA, type UIMode } from '@/composables/usePWA'
 import { applyStoredTransparencySettings } from '@/composables/useTransparencySettings'
 import {
-  persistPartialThemeCustomizerSettings,
   readThemeCustomizerSettings,
   THEME_CUSTOMIZER_CHANGE_EVENT,
   THEME_CUSTOMIZER_OPEN_EVENT,
@@ -116,7 +115,8 @@ async function checkServiceStatus(): Promise<boolean> {
   try {
     await api.get<null>('system/ping', { timeout: 3000, feedback: 'silent' })
     return true
-  } catch (error) {
+  } catch {
+    // 探测失败表示服务尚未就绪，交由既有轮询间隔重试。
     return false
   }
 }
@@ -325,7 +325,7 @@ const getUIModeIcon = computed(() => {
 })
 
 // 主题相关功能
-const { name: themeName, global: globalTheme } = useTheme()
+const { global: globalTheme } = useTheme()
 const savedTheme = ref(localStorage.getItem('theme') ?? 'glass')
 const currentThemeName = ref(savedTheme.value)
 const themeCustomizerSettings = ref(readThemeCustomizerSettings())
@@ -401,30 +401,6 @@ async function updateTheme() {
   savedTheme.value = currentThemeName.value
   // 保存主题到本地
   saveLocalTheme(currentThemeName.value, globalTheme)
-}
-
-// 切换主题
-async function changeTheme(theme: string) {
-  currentThemeName.value = theme
-  showThemeMenu.value = false
-
-  // 立即更新主题（不再刷新页面）
-  await updateTheme()
-
-  // 如果是透明主题，应用透明度设置
-  if (theme === 'transparent') {
-    applyStoredTransparencySettings()
-  }
-
-  // 保存主题到服务端
-  try {
-    persistPartialThemeCustomizerSettings({ theme: theme as ThemeCustomizerSettings['theme'] })
-    api.post('/user/config/Layout', {
-      theme,
-    })
-  } catch (e) {
-    console.error(e)
-  }
 }
 
 function handleThemeCustomizerSettingsChange(event: Event) {
@@ -515,7 +491,7 @@ async function saveCustomCSS(css: string) {
     customCssDialogController?.close()
     customCssDialogController = null
     $toast.success(t('theme.customCssSaveSuccess'))
-  } catch (e) {
+  } catch {
     console.error(t('theme.customCssSaveFailed'))
   }
 }
@@ -538,7 +514,7 @@ try {
   window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', async () => {
     await updateTheme()
   })
-} catch (e) {
+} catch {
   console.error(t('theme.deviceNotSupport'))
 }
 
@@ -627,7 +603,7 @@ onUnmounted(() => {
       width="15rem"
       location="bottom end"
       offset="14px"
-      class="user-menu"
+      class="user-menu user-profile-menu"
       :close-on-content-click="true"
       scrim
     >
@@ -674,7 +650,14 @@ onUnmounted(() => {
           </VListItem>
 
           <!-- 👉 UI模式设置 - 使用嵌套菜单 -->
-          <VMenu location="end" offset-x width="15rem" v-model="showUIModeMenu" :close-on-content-click="true">
+          <VMenu
+            class="user-profile-menu"
+            location="end"
+            offset-x
+            width="15rem"
+            v-model="showUIModeMenu"
+            :close-on-content-click="true"
+          >
             <template v-slot:activator="{ props: menuProps }">
               <VListItem v-bind="menuProps" class="mb-1 rounded-lg" hover>
                 <template #prepend>
@@ -709,7 +692,14 @@ onUnmounted(() => {
           </VMenu>
 
           <!-- 👉 主题设置 - 使用嵌套菜单 -->
-          <VMenu location="end" offset-x width="15rem" v-model="showThemeMenu" :close-on-content-click="true">
+          <VMenu
+            class="user-profile-menu"
+            location="end"
+            offset-x
+            width="15rem"
+            v-model="showThemeMenu"
+            :close-on-content-click="true"
+          >
             <template v-slot:activator="{ props: menuProps }">
               <VListItem v-bind="menuProps" class="mb-1 rounded-lg" hover>
                 <template #prepend>
@@ -773,7 +763,14 @@ onUnmounted(() => {
           </VMenu>
 
           <!-- 👉 语言设置 - 使用嵌套菜单 -->
-          <VMenu location="end" offset-x width="15rem" v-model="showLanguageMenu" :close-on-content-click="true">
+          <VMenu
+            class="user-profile-menu"
+            location="end"
+            offset-x
+            width="15rem"
+            v-model="showLanguageMenu"
+            :close-on-content-click="true"
+          >
             <template v-slot:activator="{ props: menuProps }">
               <VListItem v-bind="menuProps" class="mb-1 rounded-lg" hover>
                 <template #prepend>

--- a/src/layouts/default/components/__tests__/UserProfile.spec.ts
+++ b/src/layouts/default/components/__tests__/UserProfile.spec.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const profile = readFileSync(resolve('src/layouts/default/components/UserProfile.vue'), 'utf8')
+const styles = readFileSync(resolve('src/styles/themes/glass.scss'), 'utf8')
+
+function getHandoffSelector() {
+  const line = styles.split('\n').find(line => line.trim().startsWith('.v-overlay-container:has('))
+  expect(line).toBeDefined()
+  expect(styles).toContain(`${line}\n    display: none;\n  }`)
+  return line!.trim().slice(0, -1).trim()
+}
+
+describe('UserProfile modal handoff', () => {
+  it('identifies only the avatar menu and its three submenus as source surfaces', () => {
+    const menus = profile.match(/<VMenu\b[^>]*>/g) ?? []
+    expect(menus).toHaveLength(4)
+    expect(menus.every(menu => /class="[^"]*\buser-profile-menu\b/.test(menu))).toBe(true)
+  })
+
+  it('retires source painting only while a dialog is actually active in the same overlay host', () => {
+    const rule = getHandoffSelector()
+    const host = document.createElement('div')
+    host.className = 'v-overlay-container'
+    host.innerHTML = '<div class="v-menu user-profile-menu"></div><div class="v-dialog"></div>'
+    document.body.append(host)
+    try {
+      expect(document.querySelectorAll(rule!)).toHaveLength(0)
+      host.querySelector('.v-dialog')!.classList.add('v-overlay--active')
+      expect(document.querySelectorAll(rule!)).toHaveLength(1)
+      expect(document.querySelector(rule!)?.classList.contains('user-profile-menu')).toBe(true)
+      host.querySelector('.v-dialog')!.classList.remove('v-overlay--active')
+      expect(document.querySelectorAll(rule!)).toHaveLength(0)
+    } finally {
+      host.remove()
+    }
+  })
+
+  it('leaves dialog-owned menus and other overlay hosts alone', () => {
+    const rule = getHandoffSelector()
+    const root = document.createElement('div')
+    root.innerHTML = `
+      <div class="v-overlay-container"><div class="v-dialog v-overlay--active"></div><div class="v-menu"></div></div>
+      <div class="v-overlay-container"><div class="v-menu user-profile-menu"></div></div>
+    `
+    document.body.append(root)
+    try {
+      expect(document.querySelectorAll(rule!)).toHaveLength(0)
+    } finally {
+      root.remove()
+    }
+  })
+})

--- a/src/locales/en-US.ts
+++ b/src/locales/en-US.ts
@@ -225,6 +225,8 @@ export default {
     glassNavbarStyle: 'Navbar Style',
     glassNavbarStyleAdaptive: 'Adaptive',
     glassNavbarStyleClear: 'Clear',
+    glassNavbarStyleHint:
+      'Clear preserves more background detail, while Adaptive puts more emphasis on text clarity; both strengthen readability protection only when scrolling content passes beneath the navbar.',
     glassQuality: 'Quality',
     glassQualityCss: 'Standard',
     glassQualityBalanced: 'Balanced',

--- a/src/locales/en-US.ts
+++ b/src/locales/en-US.ts
@@ -225,8 +225,7 @@ export default {
     glassNavbarStyle: 'Navbar Style',
     glassNavbarStyleAdaptive: 'Adaptive',
     glassNavbarStyleClear: 'Clear',
-    glassNavbarStyleHint:
-      'Clear preserves more background detail, while Adaptive puts more emphasis on text clarity; both strengthen readability protection only when scrolling content passes beneath the navbar.',
+    glassNavbarStyleHint: 'Clear preserves more background detail, while Adaptive puts more emphasis on text clarity.',
     glassQuality: 'Quality',
     glassQualityCss: 'Standard',
     glassQualityBalanced: 'Balanced',

--- a/src/locales/zh-CN.ts
+++ b/src/locales/zh-CN.ts
@@ -215,6 +215,7 @@ export default {
     glassNavbarStyle: '顶栏风格',
     glassNavbarStyleAdaptive: '自适应',
     glassNavbarStyleClear: '通透',
+    glassNavbarStyleHint: '通透保留更多背景细节，自适应更注重文字清晰；两者仅在滚动内容经过顶栏下方时增强阅读保护。',
     glassQuality: '质量',
     glassQualityCss: '标准',
     glassQualityBalanced: '均衡',

--- a/src/locales/zh-CN.ts
+++ b/src/locales/zh-CN.ts
@@ -215,7 +215,7 @@ export default {
     glassNavbarStyle: '顶栏风格',
     glassNavbarStyleAdaptive: '自适应',
     glassNavbarStyleClear: '通透',
-    glassNavbarStyleHint: '通透保留更多背景细节，自适应更注重文字清晰；两者仅在滚动内容经过顶栏下方时增强阅读保护。',
+    glassNavbarStyleHint: '通透保留更多背景细节，自适应更注重文字清晰。',
     glassQuality: '质量',
     glassQualityCss: '标准',
     glassQualityBalanced: '均衡',

--- a/src/locales/zh-TW.ts
+++ b/src/locales/zh-TW.ts
@@ -213,6 +213,7 @@ export default {
     glassNavbarStyle: '頂欄風格',
     glassNavbarStyleAdaptive: '自適應',
     glassNavbarStyleClear: '通透',
+    glassNavbarStyleHint: '通透保留更多背景細節，自適應更著重文字清晰；兩者僅在捲動內容經過頂欄下方時增強閱讀保護。',
     glassQuality: '品質',
     glassQualityCss: '標準',
     glassQualityBalanced: '均衡',

--- a/src/locales/zh-TW.ts
+++ b/src/locales/zh-TW.ts
@@ -213,7 +213,7 @@ export default {
     glassNavbarStyle: '頂欄風格',
     glassNavbarStyleAdaptive: '自適應',
     glassNavbarStyleClear: '通透',
-    glassNavbarStyleHint: '通透保留更多背景細節，自適應更著重文字清晰；兩者僅在捲動內容經過頂欄下方時增強閱讀保護。',
+    glassNavbarStyleHint: '通透保留更多背景細節，自適應更著重文字清晰。',
     glassQuality: '品質',
     glassQualityCss: '標準',
     glassQualityBalanced: '均衡',

--- a/src/pages/__tests__/resource.spec.ts
+++ b/src/pages/__tests__/resource.spec.ts
@@ -4,6 +4,7 @@ import { DEFAULT_PERMISSIONS } from '@/utils/permission'
 import { fireEvent, screen, waitFor, within } from '@testing-library/vue'
 import { renderWithProviders } from '@tests/support/render'
 import { defineComponent, nextTick } from 'vue'
+import { useRoute } from 'vue-router'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
@@ -248,6 +249,32 @@ const pageStubs = {
   VScrollToTopBtn: true,
 }
 
+const DashboardRouteStub = defineComponent({
+  name: 'DashboardRouteStub',
+  template: `
+    <main data-testid="dashboard-window">
+      <div data-testid="dashboard-navbar-below">dashboard content</div>
+    </main>
+  `,
+})
+
+const ResourceRouteLifecycleHarness = defineComponent({
+  name: 'ResourceRouteLifecycleHarness',
+  setup() {
+    return { route: useRoute() }
+  },
+  template: `
+    <RouterView v-slot="{ Component }">
+      <div class="mp-page-route" data-testid="visible-page-window">
+        <KeepAlive :max="24">
+          <component :is="Component" v-if="route.meta.keepAlive" :key="route.path" />
+        </KeepAlive>
+        <component :is="Component" v-if="!route.meta.keepAlive" :key="route.fullPath" />
+      </div>
+    </RouterView>
+  `,
+})
+
 async function renderResource(
   initialRoute: { path: string; query?: Record<string, string> } = { path: '/resource' },
   aiEnabled = false,
@@ -268,6 +295,63 @@ async function renderResource(
     stubActions: false,
     global: { stubs: pageStubs },
   })
+}
+
+async function renderResourceRouteLifecycle(query: Record<string, string>) {
+  const rendered = await renderWithProviders(ResourceRouteLifecycleHarness, {
+    initialRoute: '/',
+    initialState: {
+      globalSettings: {
+        data: { AI_RECOMMEND_ENABLED: false },
+        initialized: true,
+        loading: false,
+      },
+      user: {
+        permissions: { ...DEFAULT_PERMISSIONS, search: true },
+        superUser: false,
+      },
+    },
+    stubActions: false,
+    global: { stubs: pageStubs },
+  })
+
+  rendered.router.addRoute({
+    path: '/resource',
+    component: ResourcePage,
+    meta: { keepAlive: true },
+  })
+  rendered.router.addRoute({
+    path: '/dashboard',
+    component: DashboardRouteStub,
+    meta: { keepAlive: true },
+  })
+  await rendered.router.push({ path: '/resource', query })
+  await rendered.router.isReady()
+  await nextTick()
+
+  return rendered
+}
+
+function installClearHighGlassState() {
+  const root = document.documentElement
+  const previous = {
+    theme: root.dataset.theme,
+    glassAppearance: root.dataset.glassAppearance,
+    glassQuality: root.dataset.glassQuality,
+  }
+
+  root.dataset.theme = 'glass'
+  root.dataset.glassAppearance = 'clear'
+  root.dataset.glassQuality = 'high'
+
+  return () => {
+    if (previous.theme === undefined) delete root.dataset.theme
+    else root.dataset.theme = previous.theme
+    if (previous.glassAppearance === undefined) delete root.dataset.glassAppearance
+    else root.dataset.glassAppearance = previous.glassAppearance
+    if (previous.glassQuality === undefined) delete root.dataset.glassQuality
+    else root.dataset.glassQuality = previous.glassQuality
+  }
 }
 
 async function latestEventSource(expectedCount = 1) {
@@ -1073,6 +1157,93 @@ describe('resource page search flow', () => {
       'search/media/42',
       expect.objectContaining({ params: expect.objectContaining({ media_source: 'themoviedb' }) }),
     )
+  })
+
+  it('keeps an in-flight 25% search out of the visible Dashboard window after route deactivation', async () => {
+    const restoreGlassState = installClearHighGlassState()
+    vi.useFakeTimers()
+
+    try {
+      const rendered = await renderResourceRouteLifecycle({ keyword: '离页渐进搜索', result_type: 'torrent' })
+      const source = await latestEventSource()
+      source.message({
+        items: [createTorrent({ title: '离页前预览结果' })],
+        total_items: 1,
+        type: 'append',
+        value: 25,
+      })
+      await vi.advanceTimersByTimeAsync(1000)
+      await nextTick()
+
+      expect(rendered.router.currentRoute.value.path).toBe('/resource')
+      expect(screen.getByText('25%')).toBeInTheDocument()
+      expect(document.querySelector('.search-progress-card')).toBeInTheDocument()
+
+      await rendered.router.push('/dashboard')
+      await nextTick()
+
+      // KeepAlive 离页只停用页面，后台搜索仍需继续接收 SSE 收尾消息。
+      expect(source.closed).toBe(false)
+      expect(screen.getByTestId('dashboard-window')).toBeInTheDocument()
+      expect(document.querySelector('.search-progress-card')).not.toBeInTheDocument()
+
+      source.message({
+        items: [createTorrent({ title: '离页后最终结果' })],
+        total_items: 1,
+        type: 'done',
+        value: 100,
+      })
+      await vi.advanceTimersByTimeAsync(1000)
+      await nextTick()
+      expect(source.closed).toBe(false)
+      expect(document.querySelector('.search-progress-card')).not.toBeInTheDocument()
+
+      await vi.advanceTimersByTimeAsync(500)
+      await Promise.resolve()
+      await nextTick()
+
+      expect(source.closed).toBe(true)
+      expect(screen.getByTestId('dashboard-window')).toBeInTheDocument()
+      expect(document.querySelector('.search-progress-card')).not.toBeInTheDocument()
+
+      await rendered.router.push('/resource')
+      expect(await screen.findByText('离页后最终结果')).toBeInTheDocument()
+      expect(document.querySelector('.search-progress-card')).not.toBeInTheDocument()
+    } finally {
+      restoreGlassState()
+    }
+  })
+
+  it('keeps a completed static result out of the visible Dashboard window after leaving resource', async () => {
+    const restoreGlassState = installClearHighGlassState()
+
+    try {
+      const rendered = await renderResourceRouteLifecycle({ keyword: '已完成静态结果', result_type: 'torrent' })
+      const source = await latestEventSource()
+      const result = createTorrent({ title: '已完成静态资源' })
+      finishStream(source, [result])
+
+      expect(await screen.findByText('已完成静态资源')).toBeInTheDocument()
+      await waitFor(() => expect(rendered.router.currentRoute.value.query).toEqual({}))
+      expect(document.querySelector('.search-progress-card')).not.toBeInTheDocument()
+
+      await rendered.router.push('/dashboard')
+
+      expect(source.closed).toBe(true)
+      expect(screen.getByTestId('dashboard-window')).toBeInTheDocument()
+      expect(screen.queryByText('已完成静态资源')).not.toBeInTheDocument()
+      expect(document.querySelector('.search-progress-card')).not.toBeInTheDocument()
+
+      await new Promise(resolve => window.setTimeout(resolve, 1600))
+      expect(screen.getByTestId('dashboard-window')).toBeInTheDocument()
+      expect(document.querySelector('.search-progress-card')).not.toBeInTheDocument()
+
+      await rendered.router.push('/resource')
+      expect(await screen.findByText('已完成静态资源')).toBeInTheDocument()
+      expect(document.querySelector('.search-progress-card')).not.toBeInTheDocument()
+    } finally {
+      restoreGlassState()
+    }
   })
 
   it('keeps the query of other routes when a search finishes after navigating away', async () => {

--- a/src/styles/__tests__/glassNavigationReading.spec.ts
+++ b/src/styles/__tests__/glassNavigationReading.spec.ts
@@ -108,9 +108,15 @@ describe('glass navigation reading material', () => {
     }
   })
 
-  it('retains native frosted diffusion without a stable backplate in every quality', () => {
+  it('retains native frosted diffusion for desktop navigation and backplate-free shells in every quality', () => {
     expect(surfaces).toMatch(
-      /:not\(\.layout-fixed-shell-backplate-active\) \.layout-navbar\s*\{\s*backdrop-filter: var\(--glass-sidebar-backdrop-filter\) !important;/u,
+      /:not\(\.layout-fixed-shell-backplate-active\) \.layout-navbar,\s*\.layout-wrapper\[data-shell-mode='desktop'\]:not\(\.layout-window-controls-overlay-shell\)\s*\.layout-navbar:not\(\[data-glass-panel-refraction\]\)\s*\{\s*backdrop-filter: var\(--glass-sidebar-backdrop-filter\) !important;/u,
+    )
+    expect(surfaces).toMatch(
+      /\.layout-wrapper\[data-shell-mode\]:not\(\s*\[data-shell-mode='desktop'\]\s*\)\.layout-fixed-shell-backplate-active/u,
+    )
+    expect(surfaces).toMatch(
+      /\.layout-navbar\[data-glass-panel-refraction\]\s*\{\s*background: transparent !important;\s*backdrop-filter: none !important;\s*-webkit-backdrop-filter: none !important;\s*&::before\s*\{\s*background: var\(--glass-navbar-frosted-background\);\s*backdrop-filter: var\(--glass-panel-filter\) !important;/u,
     )
     const frosted = styles.slice(styles.indexOf('// 稳定背板已持有磨砂'), styles.indexOf('// 滚动表面由原生 backdrop'))
     expect(frosted).not.toContain('--glass-navbar-scrolled-backdrop-filter')

--- a/src/styles/__tests__/glassOverlayMaterial.spec.ts
+++ b/src/styles/__tests__/glassOverlayMaterial.spec.ts
@@ -285,13 +285,13 @@ describe('glass overlay material styles', () => {
     )
   })
 
-  it('keeps Chromium frosted fixed shells on the stable wallpaper backplate', () => {
+  it('keeps Chromium frosted sidebars on the stable wallpaper backplate', () => {
     const styles = readFileSync(resolve(cwd(), 'src/styles/themes/glass.scss'), 'utf8')
     const backplate = readFileSync(resolve(cwd(), 'src/components/theme/GlassFixedShellBackplate.vue'), 'utf8')
 
     expect(styles).toContain('--glass-fixed-shell-backplate-filter: blur(min(var(--glass-blur-raised), 60px))')
     expect(styles).toMatch(
-      /&\[data-glass-appearance='frosted'\]\[data-glass-quality='css'\]\s+body\[data-theme='glass'\][\s\S]*?\.layout-wrapper\.layout-fixed-shell-backplate-active \.layout-vertical-nav::before,[\s\S]*?\.layout-wrapper\.layout-fixed-shell-backplate-active \.layout-navbar,[\s\S]*?backdrop-filter:\s*none\s*!important;/,
+      /&\[data-glass-appearance='frosted'\]\[data-glass-quality='css'\]\s+body\[data-theme='glass'\][\s\S]*?\.layout-wrapper\.layout-fixed-shell-backplate-active \.layout-vertical-nav::before\s*\{[\s\S]*?backdrop-filter:\s*none\s*!important;/,
     )
     expect(styles).toMatch(
       /\[data-glass-appearance='frosted'\]\[data-glass-quality='balanced'\]\s*\{[\s\S]*?--glass-fixed-shell-backplate-filter:\s*var\(--glass-native-surface-backdrop-filter\);/,
@@ -355,7 +355,7 @@ describe('glass overlay material styles', () => {
     expect(styles).not.toContain("url('#glass-sidebar-live-refraction-high') var(--glass-fixed-shell-backdrop-filter)")
     expect(styles).toContain('--glass-sidebar-live-filter: none !important')
     expect(styles).toContain('--glass-fixed-shell-backplate-filter: var(--glass-sidebar-backdrop-filter)')
-    expect(styles).toContain('--glass-navbar-scrolled-backdrop-filter: none')
+    expect(styles).not.toContain('--glass-navbar-scrolled-backdrop-filter: none')
     expect(defs).toContain("readyAttribute: 'data-glass-sidebar-refraction-ready'")
     expect(layout).toContain("'data-glass-navigation-refraction': navbarRefractionMode")
     expect(layout).toContain("'data-glass-navbar-refraction': navbarRefractionMode")

--- a/src/styles/themes/_glass-v3.scss
+++ b/src/styles/themes/_glass-v3.scss
@@ -582,27 +582,49 @@ $-popup-hosts: (
     }
   }
 
-  // Frosted 必须有且仅有一个磨砂所有者；原生回退与稳定背板共用导航而非卡片的扩散参数。
+  // Frosted 顶栏只由一个表面采样；桌面读取滚动正文，移动端保留其稳定背板合同。
   html[data-theme='glass'][data-glass-appearance='frosted'] body[data-theme='glass'] {
     .layout-wrapper[data-shell-mode].layout-navbar-fixed .layout-navbar {
       --glass-navbar-frosted-separation: 0;
 
-      background:
+      --glass-navbar-frosted-background:
         linear-gradient(
           rgba(23, 27, 32, var(--glass-navbar-frosted-separation)),
           rgba(23, 27, 32, var(--glass-navbar-frosted-separation))
         ),
-        var(--glass-v3-card-background) !important;
+        var(--glass-v3-card-background);
+
+      background: var(--glass-navbar-frosted-background) !important;
     }
 
-    .layout-wrapper[data-shell-mode]:not(.layout-fixed-shell-backplate-active) .layout-navbar {
+    .layout-wrapper[data-shell-mode]:not(.layout-fixed-shell-backplate-active) .layout-navbar,
+    .layout-wrapper[data-shell-mode='desktop']:not(.layout-window-controls-overlay-shell)
+      .layout-navbar:not([data-glass-panel-refraction]) {
       backdrop-filter: var(--glass-sidebar-backdrop-filter) !important;
       -webkit-backdrop-filter: var(--glass-sidebar-backdrop-filter) !important;
     }
 
-    .layout-wrapper[data-shell-mode].layout-fixed-shell-backplate-active.layout-navbar-fixed .layout-navbar {
+    .layout-wrapper[data-shell-mode]:not(
+        [data-shell-mode='desktop']
+      ).layout-fixed-shell-backplate-active.layout-navbar-fixed
+      .layout-navbar,
+    .layout-wrapper.layout-window-controls-overlay-shell.layout-fixed-shell-backplate-active.layout-navbar-fixed
+      .layout-navbar {
       backdrop-filter: none !important;
       -webkit-backdrop-filter: none !important;
+    }
+
+    // 透镜保持原有位移和中心扩散；材质、边缘反光与背景滤镜一起由伪元素持有。
+    .layout-wrapper[data-shell-mode='desktop'].layout-navbar-fixed .layout-navbar[data-glass-panel-refraction] {
+      background: transparent !important;
+      backdrop-filter: none !important;
+      -webkit-backdrop-filter: none !important;
+
+      &::before {
+        background: var(--glass-navbar-frosted-background);
+        backdrop-filter: var(--glass-panel-filter) !important;
+        -webkit-backdrop-filter: var(--glass-panel-filter) !important;
+      }
     }
   }
 
@@ -610,12 +632,17 @@ $-popup-hosts: (
     body[data-theme='glass']
     .layout-wrapper[data-shell-mode='desktop'].layout-navbar-fixed.layout-navbar-away-from-top
     .layout-navbar {
-    // 稳定壁纸已经扩散，离顶只增强前后景分离，不重采样整片磨砂或改变侧栏亮度。
+    // 既有材质始终承担扩散，离顶只增强分离，不叠加第二层模糊或改变侧栏亮度。
     --glass-navbar-frosted-separation: 0.08;
 
     box-shadow:
       var(--glass-v3-surface-edge),
       0 12px 30px rgba(0, 0, 0, 0.18) !important;
+
+    &[data-glass-panel-refraction] {
+      // 边缘反光已在采样伪元素上，外壳只承担投影。
+      box-shadow: 0 12px 30px rgba(0, 0, 0, 0.18) !important;
+    }
   }
 
   @supports not ((-webkit-backdrop-filter: blur(1px)) or (backdrop-filter: blur(1px))) {

--- a/src/styles/themes/glass.scss
+++ b/src/styles/themes/glass.scss
@@ -526,14 +526,11 @@ html[data-theme='glass'] {
     }
 
     .layout-wrapper[data-shell-mode='desktop'] > .glass-fixed-shell-backplate--main {
-      // 固定顶栏与侧栏共用同一 L 形稳定背板，扩散参数必须作用于真实承载层。
+      // 侧栏稳定背板的扩散参数作用于真实承载层，顶栏独立读取滚动正文。
       --glass-fixed-shell-backplate-filter: var(--glass-sidebar-backdrop-filter);
     }
 
     .layout-wrapper[data-shell-mode='desktop'].layout-fixed-shell-backplate-active {
-      --glass-navbar-scrolled-backdrop-filter: none;
-
-      .layout-navbar,
       .layout-vertical-nav::before {
         -webkit-backdrop-filter: none !important;
         backdrop-filter: none !important;
@@ -557,12 +554,9 @@ html[data-theme='glass'] {
     }
   }
 
-  // Chromium 磨砂 fixed 层直接渲染稳定壁纸背板，固定功能层不得读取随页面重绘的 document backdrop。
+  // Chromium 磨砂侧栏已有稳定壁纸背板，不再重复读取 document backdrop。
   &[data-glass-appearance='frosted'][data-glass-quality='css'] body[data-theme='glass'] {
-    .layout-wrapper.layout-fixed-shell-backplate-active .layout-vertical-nav::before,
-    .layout-wrapper.layout-fixed-shell-backplate-active .layout-navbar,
-    .layout-wrapper.layout-fixed-shell-backplate-active.layout-horizontal-nav-active.layout-horizontal-nav-scrolled.layout-navbar-fixed
-      .layout-navbar {
+    .layout-wrapper.layout-fixed-shell-backplate-active .layout-vertical-nav::before {
       -webkit-backdrop-filter: none !important;
       backdrop-filter: none !important;
     }
@@ -1579,8 +1573,7 @@ html[data-glass-appearance='frosted']:is(
     [data-glass-quality='high']
   )[data-glass-renderer-state='ready']
   body[data-theme='glass'] {
-  .layout-vertical-nav::before,
-  .layout-navbar {
+  .layout-vertical-nav::before {
     -webkit-backdrop-filter: none !important;
     backdrop-filter: none !important;
   }

--- a/src/styles/themes/glass.scss
+++ b/src/styles/themes/glass.scss
@@ -417,6 +417,11 @@ html[data-theme='glass'] {
     opacity: 1;
   }
 
+  // 缓存海报重入只恢复内容；真实 load 提交前仍保持不可见和原有玻璃占位。
+  .media-card--poster-revisit .v-img__img {
+    transition: none;
+  }
+
   .v-toolbar {
     border-color: var(--glass-border);
     -webkit-backdrop-filter: var(--glass-raised-backdrop-filter);

--- a/src/styles/themes/glass.scss
+++ b/src/styles/themes/glass.scss
@@ -684,6 +684,12 @@ html[data-theme='glass'] {
     background: var(--glass-overlay-scrim);
   }
 
+  // 弹窗实际呈现后才移除来源菜单的绘制，避免双重遮罩和异步加载期间无遮罩的亮帧。
+  // 仅约束头像菜单树，弹窗内新打开的选择菜单仍独立呈现；关闭状态由 VMenu 自身完成。
+  .v-overlay-container:has(> .v-dialog.v-overlay--active) > .user-profile-menu {
+    display: none;
+  }
+
   .v-dialog--fullscreen {
     background-color: transparent !important;
   }

--- a/src/utils/__tests__/fixtures/glass-displacement-fields.json
+++ b/src/utils/__tests__/fixtures/glass-displacement-fields.json
@@ -518,5 +518,44 @@
       "translation": 100
     },
     "sha256": "c2b238e970fc079b0eb344ced8cb87d1d109a5c1dbb5b8f8c0f0904cfe44edd0"
+  },
+  {
+    "geometry": {
+      "width": 1179,
+      "height": 64,
+      "radius": 16,
+      "surface": "panel"
+    },
+    "parameters": {
+      "deformation": 48,
+      "translation": 48
+    },
+    "sha256": "63ff042bbd83f8454ca04da5e30b8c435787709d37632b237c4fac2076c0ddb4"
+  },
+  {
+    "geometry": {
+      "width": 252,
+      "height": 846,
+      "radius": 16,
+      "surface": "panel"
+    },
+    "parameters": {
+      "deformation": 48,
+      "translation": 48
+    },
+    "sha256": "2a62d288e06bd3b93e7b4813a5411788d41e25b9f2eb8ce1ed37922a461cb4b9"
+  },
+  {
+    "geometry": {
+      "width": 60,
+      "height": 846,
+      "radius": 16,
+      "surface": "panel"
+    },
+    "parameters": {
+      "deformation": 48,
+      "translation": 48
+    },
+    "sha256": "11a5ff7bc36d5ff6cc3b3f9617c57751b7a7a1a80f2af70942fe584e8b9190b3"
   }
 ]

--- a/src/utils/__tests__/glassNavbarRefraction.spec.ts
+++ b/src/utils/__tests__/glassNavbarRefraction.spec.ts
@@ -10,6 +10,48 @@ import {
   type GlassNavbarDisplacementGeometry,
 } from '@/utils/glassNavbarRefraction'
 
+type GlassPanelBackdropGeometry = Parameters<typeof createGlassPanelBackdropField>[0]
+
+function roundedRectangleSignedDistanceReference(x: number, y: number, width: number, height: number, radius: number) {
+  const offsetX = Math.abs(x - width / 2) - (width / 2 - radius)
+  const offsetY = Math.abs(y - height / 2) - (height / 2 - radius)
+  const outsideX = Math.max(offsetX, 0)
+  const outsideY = Math.max(offsetY, 0)
+  const outsideDistance = outsideX === 0 && outsideY === 0 ? 0 : Math.hypot(outsideX, outsideY)
+
+  return outsideDistance + Math.min(Math.max(offsetX, offsetY), 0) - radius
+}
+
+// 独立标量合成保护圆角裁剪、覆盖顺序和透明通道契约，避免优化路径与自身比较。
+function createScalarGlassPanelBackdropReference({ width, height, panels, optics }: GlassPanelBackdropGeometry) {
+  const pixelWidth = Number.isFinite(width) ? Math.max(1, Math.round(width)) : 1
+  const pixelHeight = Number.isFinite(height) ? Math.max(1, Math.round(height)) : 1
+  const pixels = new Uint8ClampedArray(pixelWidth * pixelHeight * 4)
+  for (let offset = 0; offset < pixels.length; offset += 4) {
+    pixels[offset] = 128
+    pixels[offset + 1] = 255
+    pixels[offset + 2] = 128
+    pixels[offset + 3] = 255
+  }
+
+  for (const panel of panels) {
+    const field = createGlassNavbarDisplacementField({ ...panel, optics, surface: 'panel' })
+    const left = Math.round(panel.x)
+    const top = Math.round(panel.y)
+    const radius = Math.max(0, Math.min(panel.radius, field.width / 2, field.height / 2))
+    for (let y = Math.max(0, -top); y < Math.min(field.height, pixelHeight - top); y += 1) {
+      for (let x = Math.max(0, -left); x < Math.min(field.width, pixelWidth - left); x += 1) {
+        if (roundedRectangleSignedDistanceReference(x + 0.5, y + 0.5, field.width, field.height, radius) > 0) continue
+        const source = (y * field.width + x) * 4
+        const destination = ((top + y) * pixelWidth + left + x) * 4
+        pixels.set(field.pixels.subarray(source, source + 4), destination)
+      }
+    }
+  }
+
+  return { width: pixelWidth, height: pixelHeight, pixels }
+}
+
 describe('getGlassNavbarOpticalResponse', () => {
   it('prioritizes default reading while retaining the horizontal lens', () => {
     const optics = getGlassNavbarOpticalResponse({ deformation: 48, translation: 48 })
@@ -126,6 +168,88 @@ describe('createGlassNavbarDisplacementField', () => {
     expect(pixelAt(field, 35, 15)[1]).toBe(255)
     expect(pixelAt(field, 45, 15)[1]).toBe(0)
     expect(pixelAt(field, 50, 40)[1]).toBe(255)
+  })
+
+  it.each([
+    {
+      width: 0,
+      height: -4,
+      panels: [{ x: -0.5, y: 0.5, width: 0, height: 0, radius: 99 }],
+    },
+    {
+      width: 3,
+      height: 2,
+      panels: [
+        { x: 0.5, y: 0.5, width: 3, height: 2, radius: 99 },
+        { x: 1.5, y: -0.5, width: 2, height: 1, radius: -4 },
+      ],
+    },
+    {
+      width: 11,
+      height: 9,
+      panels: [
+        { x: -2.5, y: -1.5, width: 8, height: 7, radius: 3.5 },
+        { x: 4.5, y: 2.5, width: 6, height: 6, radius: 1.5 },
+      ],
+    },
+    {
+      width: 13,
+      height: 7,
+      panels: [
+        { x: 13.5, y: 0.5, width: 5, height: 5, radius: 2 },
+        { x: -7.5, y: 1.5, width: 5, height: 4, radius: 2 },
+      ],
+    },
+    {
+      width: 16,
+      height: 12,
+      panels: [
+        { x: 3.5, y: 2.5, width: 8, height: 7, radius: Number.NaN },
+        { x: 4.5, y: 3.5, width: 7, height: 6, radius: 4 },
+      ],
+    },
+    {
+      width: 8,
+      height: 8,
+      panels: [
+        { x: 99, y: 99, width: 4, height: 4, radius: 2 },
+        { x: -99, y: -99, width: 4, height: 4, radius: 2 },
+        { x: 2.5, y: 2.5, width: 4, height: 4, radius: Number.POSITIVE_INFINITY },
+      ],
+    },
+    {
+      width: 5,
+      height: 4,
+      panels: [],
+    },
+    // 窄圆形覆盖奇偶宽度，并把每一行分别贴到背板的上下边界。
+    {
+      width: 18,
+      height: 18,
+      panels: [
+        { x: 0, y: 0, width: 1, height: 1, radius: 0.5 },
+        { x: 2, y: 0, width: 2, height: 2, radius: 1 },
+        { x: 5, y: 0, width: 3, height: 3, radius: 1.5 },
+        { x: 9, y: 0, width: 4, height: 4, radius: 2 },
+        { x: 14, y: 0, width: 5, height: 5, radius: 2.5 },
+        { x: 0, y: 17, width: 1, height: 1, radius: 0.5 },
+        { x: 2, y: 16, width: 2, height: 2, radius: 1 },
+        { x: 5, y: 15, width: 3, height: 3, radius: 1.5 },
+        { x: 9, y: 14, width: 4, height: 4, radius: 2 },
+        { x: 13, y: 13, width: 5, height: 5, radius: 2.5 },
+      ],
+    },
+  ])('matches the independent scalar backdrop reference for $width x $height', geometry => {
+    const input = {
+      ...geometry,
+      optics: getGlassSidebarOpticalResponse({ deformation: 80, translation: 80 }),
+    }
+    const expected = createScalarGlassPanelBackdropReference(input)
+    const actual = createGlassPanelBackdropField(input)
+
+    expect(actual.width).toBe(expected.width)
+    expect(actual.height).toBe(expected.height)
+    expect([...actual.pixels]).toEqual([...expected.pixels])
   })
 
   it.each([

--- a/src/utils/__tests__/glassOptics.spec.ts
+++ b/src/utils/__tests__/glassOptics.spec.ts
@@ -19,6 +19,7 @@ import {
   getGlassOpticalPresetKey,
   getGlassOpticalReflectionStrengthScale,
   getGlassOpticalRenderProfile,
+  getGlassOpticalScissor,
   getGlassOpticalTransparency,
   getGlassOpticalTransmissionStrength,
   getGlassOpticalSurfaceTransitionWeights,
@@ -36,6 +37,46 @@ import {
 import { describe, expect, it } from 'vitest'
 
 describe('glass optics geometry', () => {
+  it('bounds fixed shading with the outward feather in bottom-origin buffer coordinates', () => {
+    expect(
+      getGlassOpticalScissor(
+        [{ x: 16, y: 16, width: 1168, height: 64 }],
+        { width: 1200, height: 800 },
+        { width: 1800, height: 1200 },
+      ),
+    ).toEqual({ x: 21, y: 1077, width: 1758, height: 102 })
+  })
+
+  it('keeps all surfaces in the union and clips against the framebuffer', () => {
+    expect(
+      getGlassOpticalScissor(
+        [
+          { x: -10, y: -5, width: 1220, height: 64 },
+          { x: 8, y: 64, width: 250, height: 750 },
+        ],
+        { width: 1200, height: 800 },
+        { width: 1800, height: 1200 },
+      ),
+    ).toEqual({ x: 0, y: 0, width: 1800, height: 1200 })
+  })
+
+  it('rounds fractional low-resolution edges outwards', () => {
+    expect(
+      getGlassOpticalScissor(
+        [{ x: 15.75, y: 8.25, width: 320.5, height: 63.5 }],
+        { width: 1000, height: 800 },
+        { width: 750, height: 600 },
+      ),
+    ).toEqual({ x: 10, y: 544, width: 244, height: 52 })
+  })
+
+  it('does not shade absent, zero-sized or fully offscreen surfaces', () => {
+    for (const rects of [[], [{ x: 0, y: 0, width: 0, height: 64 }], [{ x: 1205, y: 805, width: 80, height: 80 }]]) {
+      const scissor = getGlassOpticalScissor(rects, { width: 1200, height: 800 }, { width: 1200, height: 800 })
+      expect(scissor.width * scissor.height).toBe(0)
+    }
+  })
+
   it('caps the renderer buffer independently from device pixel ratio', () => {
     expect(getGlassOpticalBufferSize(3456, 2234, false)).toEqual({ height: 931, width: 1440 })
     expect(getGlassOpticalBufferSize(390, 844, true)).toEqual({ height: 844, width: 390 })

--- a/src/utils/__tests__/mediaPosterPresentationCache.spec.ts
+++ b/src/utils/__tests__/mediaPosterPresentationCache.spec.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  clearMediaPosterPresentationCache,
+  forgetMediaPosterReveal,
+  rememberMediaPosterReveal,
+  wasMediaPosterRevealed,
+} from '../mediaPosterPresentationCache'
+
+describe('media poster presentation cache', () => {
+  beforeEach(clearMediaPosterPresentationCache)
+
+  it('records only explicitly completed nonempty sources', () => {
+    expect(wasMediaPosterRevealed('/poster.jpg')).toBe(false)
+    rememberMediaPosterReveal('')
+    expect(wasMediaPosterRevealed('')).toBe(false)
+    rememberMediaPosterReveal('/poster.jpg')
+    expect(wasMediaPosterRevealed('/poster.jpg')).toBe(true)
+    expect(wasMediaPosterRevealed('/other.jpg')).toBe(false)
+  })
+
+  it('forgets a failed source without changing other sources', () => {
+    rememberMediaPosterReveal('/a.jpg')
+    rememberMediaPosterReveal('/b.jpg')
+    forgetMediaPosterReveal('/a.jpg')
+    expect(wasMediaPosterRevealed('/a.jpg')).toBe(false)
+    expect(wasMediaPosterRevealed('/b.jpg')).toBe(true)
+  })
+
+  it('bounds the retained metadata and keeps recently reused sources', () => {
+    for (let i = 0; i < 512; i++) rememberMediaPosterReveal(`/poster-${i}.jpg`)
+    expect(wasMediaPosterRevealed('/poster-0.jpg')).toBe(true)
+    rememberMediaPosterReveal('/poster-512.jpg')
+    expect(wasMediaPosterRevealed('/poster-1.jpg')).toBe(false)
+    expect(wasMediaPosterRevealed('/poster-0.jpg')).toBe(true)
+    clearMediaPosterPresentationCache()
+    expect(wasMediaPosterRevealed('/poster-0.jpg')).toBe(false)
+  })
+})

--- a/src/utils/glassNavbarRefraction.ts
+++ b/src/utils/glassNavbarRefraction.ts
@@ -161,11 +161,11 @@ export function createGlassNavbarDisplacementField({
     pixels[offset + 3] = 255
   }
 
-  // 中心越过圆角和两轴平移渐入带后，RGBA 恒定；仅批量填充这一区域，边带仍按完整公式计算。
+  // 中心越过圆角和两轴平移渐入带后，RGBA 恒定；非恒定区域仍按完整公式计算。
   const bodyStart = Math.ceil(Math.max(pixelRadius, maximumBand + 64) - 0.5)
   const bodyEnd = pixelWidth - bodyStart
   const hasConstantBody = surface === 'panel' && bodyEnd > bodyStart && pixelHeight > bodyStart * 2
-  const pixelWords = hasConstantBody ? new Uint32Array(pixels.buffer) : null
+  const pixelWords = surface === 'panel' ? new Uint32Array(pixels.buffer) : null
   // 从字节视图取得填充值，与目标视图共享平台字节序，不依赖大小端假设。
   const bodyWord = new Uint32Array(
     new Uint8ClampedArray([
@@ -175,13 +175,33 @@ export function createGlassNavbarDisplacementField({
       255,
     ]).buffer,
   )[0]
+  // 长竖面越过两端过渡后，整行结果不再随 y 改变；复用整行仍保留侧边逐像素精度。
+  const repeatRowStart = Math.ceil(
+    Math.max(pixelRadius + 1, maximumBand + 64, pixelWidth / 2 + maximumBand * 2 + 1) - 0.5,
+  )
+  const repeatRowEnd = pixelHeight - repeatRowStart
 
   for (let y = 0; y < pixelHeight; y += 1) {
-    const constantBodyRow = pixelWords && y >= bodyStart && y < pixelHeight - bodyStart
+    if (pixelWords && y > repeatRowStart && y < repeatRowEnd) {
+      pixelWords.copyWithin(y * pixelWidth, repeatRowStart * pixelWidth, (repeatRowStart + 1) * pixelWidth)
+      continue
+    }
+    const constantBodyRow = hasConstantBody && y >= bodyStart && y < pixelHeight - bodyStart
+    const edgeY = Math.min(y + 0.5, pixelHeight - y - 0.5)
+    // 越过圆角、横向平移渐入和直边权重后，同一行的距离与法线均不再依赖 x。
+    // 多留一个像素覆盖法线差分的半像素邻域，短行仍逐点计算。
+    const repeatStart = Math.ceil(Math.max(pixelRadius + 1, maximumBand + 64, edgeY + maximumBand * 2 + 1) - 0.5)
+    const repeatEnd = pixelWidth - repeatStart
+    const fillStart = pixelWords ? (constantBodyRow ? bodyStart : repeatStart + 1) : -1
+    const fillEnd = constantBodyRow ? bodyEnd : repeatEnd
     for (let x = 0; x < pixelWidth; x += 1) {
-      if (constantBodyRow && x === bodyStart) {
-        pixelWords.fill(bodyWord, y * pixelWidth + bodyStart, y * pixelWidth + bodyEnd)
-        x = bodyEnd - 1
+      if (pixelWords && x === fillStart && fillEnd > x) {
+        pixelWords.fill(
+          constantBodyRow ? bodyWord : pixelWords[y * pixelWidth + repeatStart],
+          y * pixelWidth + x,
+          y * pixelWidth + fillEnd,
+        )
+        x = fillEnd - 1
         continue
       }
       const sampleX = x + 0.5
@@ -190,7 +210,6 @@ export function createGlassNavbarDisplacementField({
       const distanceInside = -signedDistance
       // 长直边允许更厚的透镜；向圆角与法线交汇轴渐缩，避免高曲率区产生聚焦尖点。
       const edgeX = Math.min(sampleX, pixelWidth - sampleX)
-      const edgeY = Math.min(sampleY, pixelHeight - sampleY)
       const straightWeight = smoothstep(Math.min(1, Math.abs(edgeX - edgeY) / (maximumBand * 2 || 1)))
       const cornerBand = Math.min(maximumBand, pixelRadius)
       // 矩形角点没有圆弧法线；固定带宽交给四条直边的轴向剖面处理，避免角点成为采样断点。

--- a/src/utils/glassNavbarRefraction.ts
+++ b/src/utils/glassNavbarRefraction.ts
@@ -313,24 +313,59 @@ export function createGlassPanelBackdropField({ width, height, panels, optics }:
   const pixelWidth = normalizePixelSize(width)
   const pixelHeight = normalizePixelSize(height)
   const pixels = new Uint8ClampedArray(pixelWidth * pixelHeight * 4)
-  for (let offset = 0; offset < pixels.length; offset += 4) {
-    pixels[offset] = DISPLACEMENT_NEUTRAL_CHANNEL
-    pixels[offset + 1] = 255
-    pixels[offset + 2] = DISPLACEMENT_NEUTRAL_CHANNEL
-    pixels[offset + 3] = 255
-  }
+  const pixelWords = new Uint32Array(pixels.buffer)
+  // 从字节视图取得填充值，与目标视图共享平台字节序，不依赖大小端假设。
+  const neutralWord = new Uint32Array(
+    new Uint8ClampedArray([DISPLACEMENT_NEUTRAL_CHANNEL, 255, DISPLACEMENT_NEUTRAL_CHANNEL, 255]).buffer,
+  )[0]
+  pixelWords.fill(neutralWord)
   for (const panel of panels) {
     const field = createGlassNavbarDisplacementField({ ...panel, optics, surface: 'panel' })
     const left = Math.round(panel.x)
     const top = Math.round(panel.y)
     const radius = Math.max(0, Math.min(panel.radius, field.width / 2, field.height / 2))
-    for (let y = Math.max(0, -top); y < Math.min(field.height, pixelHeight - top); y += 1) {
-      for (let x = Math.max(0, -left); x < Math.min(field.width, pixelWidth - left); x += 1) {
-        if (roundedRectangleSignedDistance(x + 0.5, y + 0.5, field.width, field.height, radius) > 0) continue
-        const source = (y * field.width + x) * 4
-        const destination = ((top + y) * pixelWidth + left + x) * 4
-        pixels.set(field.pixels.subarray(source, source + 4), destination)
+    const sourceTop = Math.max(0, -top)
+    const sourceBottom = Math.min(field.height, pixelHeight - top)
+    const sourceLeft = Math.max(0, -left)
+    const sourceRight = Math.min(field.width, pixelWidth - left)
+    if (!(sourceTop < sourceBottom && sourceLeft < sourceRight)) continue
+    for (let y = sourceTop; y < sourceBottom; y += 1) {
+      let spanStart = 0
+      let spanEnd = field.width
+
+      // NaN 半径的 `signedDistance > 0` 判定为 false，因此该输入保持整行复制语义。
+      if (!Number.isNaN(radius)) {
+        // 圆角扫描线的行中点必在内部，左右半行各自单调，可二分连续区间的两端。
+        const isInside = (x: number) =>
+          roundedRectangleSignedDistance(x + 0.5, y + 0.5, field.width, field.height, radius) <= 0
+        let searchStart = 0
+        let searchEnd = field.width
+        while (searchStart < searchEnd) {
+          const middle = Math.floor((searchStart + searchEnd) / 2)
+          if (isInside(middle)) searchEnd = middle
+          else searchStart = middle + 1
+        }
+        spanStart = searchStart
+        spanEnd = spanStart
+
+        if (spanStart < field.width) {
+          searchEnd = field.width
+          while (searchStart < searchEnd) {
+            const middle = Math.floor((searchStart + searchEnd) / 2)
+            if (isInside(middle)) searchStart = middle + 1
+            else searchEnd = middle
+          }
+          spanEnd = searchStart
+        }
       }
+
+      const copyStart = Math.max(spanStart, sourceLeft)
+      const copyEnd = Math.min(spanEnd, sourceRight)
+      if (copyEnd <= copyStart) continue
+
+      const source = (y * field.width + copyStart) * 4
+      const destination = ((top + y) * pixelWidth + left + copyStart) * 4
+      pixels.set(field.pixels.subarray(source, source + (copyEnd - copyStart) * 4), destination)
     }
   }
   return { width: pixelWidth, height: pixelHeight, pixels }

--- a/src/utils/glassOptics.ts
+++ b/src/utils/glassOptics.ts
@@ -757,3 +757,35 @@ export function normalizeGlassOpticalRect(rect: GlassOpticalRect, viewportWidth:
     ] as const,
   }
 }
+
+/**
+ * 将已提交表面的并集映射到 drawing buffer 裁剪框，不改变纹理采样坐标或表面几何。
+ * shader 的圆角蒙版向外羽化 1.5 CSS px；保留 2px 并向外取整，覆盖缩放后的边缘像素。
+ */
+export function getGlassOpticalScissor(
+  rects: readonly Pick<GlassOpticalRect, 'x' | 'y' | 'width' | 'height'>[],
+  presentation: { width: number; height: number },
+  buffer: { width: number; height: number },
+) {
+  const scaleX = buffer.width / Math.max(1, presentation.width)
+  const scaleY = buffer.height / Math.max(1, presentation.height)
+  let left = buffer.width
+  let bottom = buffer.height
+  let right = 0
+  let top = 0
+
+  for (const rect of rects) {
+    if (rect.width <= 0 || rect.height <= 0) continue
+    left = Math.min(left, Math.floor((rect.x - 2) * scaleX))
+    right = Math.max(right, Math.ceil((rect.x + rect.width + 2) * scaleX))
+    bottom = Math.min(bottom, Math.floor((presentation.height - rect.y - rect.height - 2) * scaleY))
+    top = Math.max(top, Math.ceil((presentation.height - rect.y + 2) * scaleY))
+  }
+
+  left = Math.max(0, Math.min(buffer.width, left))
+  bottom = Math.max(0, Math.min(buffer.height, bottom))
+  right = Math.max(left, Math.min(buffer.width, right))
+  top = Math.max(bottom, Math.min(buffer.height, top))
+
+  return { x: left, y: bottom, width: right - left, height: top - bottom }
+}

--- a/src/utils/mediaPosterPresentationCache.ts
+++ b/src/utils/mediaPosterPresentationCache.ts
@@ -1,0 +1,33 @@
+// 只记忆本标签页内已完整呈现的地址，不持有图片/DOM，也不替代浏览器的真实加载状态。
+const revealedPosters = new Set<string>()
+const MAX_REVEALED_POSTERS = 512
+
+/** 查询并刷新最近使用顺序；调用方只能据此省略重复入场，不能提前判定图片已加载。 */
+export function wasMediaPosterRevealed(src: string): boolean {
+  if (!revealedPosters.delete(src)) return false
+
+  revealedPosters.add(src)
+  return true
+}
+
+/** 当前图片完成可见覆盖后登记，长列表按最近使用顺序淘汰，避免随浏览页数增长。 */
+export function rememberMediaPosterReveal(src: string) {
+  if (!src) return
+
+  revealedPosters.delete(src)
+  revealedPosters.add(src)
+  if (revealedPosters.size > MAX_REVEALED_POSTERS) {
+    const oldest = revealedPosters.values().next().value
+    if (oldest !== undefined) revealedPosters.delete(oldest)
+  }
+}
+
+/** 加载失败时取消呈现记忆，后续同地址重试仍按首次成功处理。 */
+export function forgetMediaPosterReveal(src: string) {
+  revealedPosters.delete(src)
+}
+
+/** 释放当前标签页的海报呈现记忆。 */
+export function clearMediaPosterPresentationCache() {
+  revealedPosters.clear()
+}

--- a/src/views/discover/MediaCardListView.vue
+++ b/src/views/discover/MediaCardListView.vue
@@ -4,15 +4,18 @@ import type { MediaInfo } from '@/api/types'
 import MediaCard from '@/components/cards/MediaCard.vue'
 import ProgressiveCardGrid from '@/components/misc/ProgressiveCardGrid.vue'
 import NoDataFound from '@/components/states/NoDataFound.vue'
+import GlassMediaBackdrop from '@/components/theme/GlassMediaBackdrop.vue'
 import { useI18n } from 'vue-i18n'
 
 const { t } = useI18n()
 
 const props = defineProps({
+  /** 发现源的分页接口路径。 */
   apipath: {
     type: String,
     required: true,
   },
+  /** 发现筛选参数；当前页码由列表生命周期补充。 */
   params: Object as PropType<Record<string, unknown>>,
 })
 
@@ -165,17 +168,13 @@ async function fetchData({ done }: { done: (status: 'empty' | 'error' | 'loading
         </VBtn>
       </div>
     </template>
-    <ProgressiveCardGrid
-      v-if="dataList.length > 0"
-      :items="dataList"
-      :item-aspect-ratio="1.5"
-      :get-item-key="getMediaIdentity"
-      tabindex="0"
-    >
-      <template #default="{ item }">
-        <MediaCard :media="item" />
-      </template>
-    </ProgressiveCardGrid>
+    <GlassMediaBackdrop v-if="dataList.length > 0">
+      <ProgressiveCardGrid :items="dataList" :item-aspect-ratio="1.5" :get-item-key="getMediaIdentity" tabindex="0">
+        <template #default="{ item }">
+          <MediaCard :media="item" />
+        </template>
+      </ProgressiveCardGrid>
+    </GlassMediaBackdrop>
     <NoDataFound v-if="dataList.length === 0 && isRefreshed" error-code="404" :error-title="t('common.noData')" />
   </VInfiniteScroll>
 </template>


### PR DESCRIPTION
## 变更概述

本 PR 以已冻结的玻璃主题版本为基线，收敛导航、侧栏、卡片和弹层的玻璃合成路径，并补充顶栏风格提示文案：

- 优化固定玻璃表面的片元范围、位移场行/跨度复用、材质 uniform 提交和 fallback 生命周期。
- 共享发现页媒体卡片的原生背景采样，复用海报呈现状态，并延迟挂载不可见的卡片详情操作区。
- 修正磨砂桌面顶栏对实时内容的采样，以及弹层出现时来源菜单的交接，避免两层来源同时合成。
- 保留三种材质、三档质量、导航参数语义和已有交互；顶栏提示明确说明“通透保留更多背景细节，自适应更注重文字清晰”。

## 性能证据

在 Frosted / High、相同 160 个媒体条目、相同图片字节、接口响应约 200ms、图片响应约 2000ms 的受控输入下，恢复旧的逐卡原生采样后再切换到共享采样：加载及底部收敛阶段的最大 `requestAnimationFrame` 间隔由约 750ms 降至 57.9ms，恢复共享实现后为 58.1ms。该结果说明共享采样收益不是后端响应偶然变快造成的。

另外，位移场局部 CPU 中位耗时由 13.1ms 降至 5.2–7.1ms；背板合成在垂直布局中由 17ms 降至 6ms、折叠布局中由 10ms 降至 3ms，输出像素逐字节一致。发现页隐藏详情区从常驻 84 个降为未展开时 0 个，但目前没有稳定的整页帧时间降幅，因此不将其表述为确定的端到端收益。

## 验证边界

- 上述 `requestAnimationFrame` 数据不是 GPU 帧时间；没有据此声称 GPU 降低 92%。
- 该对照不是旧版本与新版本的完整端到端跑分，后端、图片源和浏览器缓存仍需在实际部署中分别观察。
- 冻结链已通过相关 focused 测试、类型检查、受影响文件 lint、格式检查和 `git diff --check`；rebase 后提交范围与冻结链逐项等价。
- 首次打开或 F5 后弹层响应、暖回滚长帧、F5/Tab 合成过程、滚动转浮动连续性和三档实际视觉回报仍属于后续 Goal，不包含在本 PR 的冻结交付结论中。

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at feeea0b09f2af2e40124b2344678b3c9fcda0e34

- 限定固定玻璃表面着色范围
- 顶栏改为采样实时正文内容
- 共享发现页媒体卡片背景采样
- 海报重访跳过淡入仍等待加载
- 悬停时才挂载卡片详情操作
- 弹窗激活时交接头像菜单绘制
- 保留非 Chromium 与降透明回退路径
<!-- pr-agent-summary:end -->
