### PR TITLE
fix(transfer): submit selected histories as one batch

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -2265,11 +2265,15 @@ export interface TransferForm {
 }
 
 // 手动整理请求
-export interface ManualTransferPayload extends Omit<TransferForm, 'fileitem'> {
+export interface ManualTransferPayload extends Omit<TransferForm, 'fileitem' | 'logid'> {
   // 文件项
   fileitem?: FileItem
   // 多选文件批量请求
   fileitems?: FileItem[]
+  // 单条整理历史请求
+  logid?: number
+  // 多选整理历史批量请求
+  logids?: number[]
 }
 
 // 手动整理目的路径匹配请求

--- a/src/components/dialog/ReorganizeDialog.vue
+++ b/src/components/dialog/ReorganizeDialog.vue
@@ -1098,7 +1098,13 @@ function getBatchItemsLabel(items: FileItem[]) {
 }
 
 // 构造整理请求
-function createTransferPayload(options: { item?: FileItem; items?: FileItem[]; logid?: number; preview?: boolean }) {
+function createTransferPayload(options: {
+  item?: FileItem
+  items?: FileItem[]
+  logid?: number
+  logids?: number[]
+  preview?: boolean
+}) {
   const sourceItem = options.item ?? (options.items?.length ? options.items[0] : ({} as FileItem))
   const normalizedMediaId = normalizeOptionalText(transferForm.media_id)
   const payload: ManualTransferPayload = {
@@ -1124,6 +1130,12 @@ function createTransferPayload(options: { item?: FileItem; items?: FileItem[]; l
       // 文件集合请求以 fileitems 为准，避免残留 fileitem 状态把请求误导成目录语义。
       delete payload.fileitem
     }
+  }
+  if (options.logids?.length) {
+    payload.logids = options.logids
+    // 历史集合请求以 logids 为准，必须保留完整专辑上下文。
+    delete payload.fileitem
+    delete payload.logid
   }
   if (options.preview) payload.preview = true
   return payload
@@ -1379,11 +1391,12 @@ async function previewTransfer() {
     }
 
     if (props.logids?.length) {
+      const historyIds = [...props.logids]
       tasks.push(
-        ...props.logids.map(async logid => {
+        (async () => {
           try {
             const result = await requestManualTransfer<ManualTransferPreviewData>(
-              createTransferPayload({ logid, preview: true }),
+              createTransferPayload({ logids: historyIds, preview: true }),
             )
             mergePreviewData(mergedPreviewData, result)
           } catch (err: unknown) {
@@ -1392,12 +1405,12 @@ async function previewTransfer() {
             mergePreviewData(
               mergedPreviewData,
               createFailedPreviewData({
-                source: `历史记录 ${logid}`,
+                source: t('dialog.reorganize.multipleItemsTitle', { count: historyIds.length }),
                 message: errorMessage,
               }),
             )
           }
-        }),
+        })(),
       )
     }
 
@@ -1457,11 +1470,17 @@ async function handleTransferBatch(items: FileItem[], background: boolean = fals
   }
 }
 
-// 整理日志
-async function handleTransferLog(logid: number, background: boolean = false) {
+// 将选中的整理历史作为同一个媒体批次提交。
+async function handleTransferLogs(logids: number[], background: boolean = false) {
   try {
-    await requestManualTransfer<null>(createTransferPayload({ logid }), background)
-    if (background) $toast.success(`历史记录 ${logid} 已加入整理队列！`)
+    await requestManualTransfer<null>(createTransferPayload({ logids }), background)
+    if (background) {
+      $toast.success(
+        t('dialog.reorganize.successMessage', {
+          name: t('dialog.reorganize.multipleItemsTitle', { count: logids.length }),
+        }),
+      )
+    }
     return true
   } catch (error: unknown) {
     console.log(error)
@@ -1542,9 +1561,7 @@ async function transfer(background: boolean = false) {
         // 为日志整理任务开启进度监听
         startLoadingProgress('filetransfer')
       }
-      for (const logid of props.logids) {
-        allSucceeded = (await handleTransferLog(logid, background)) && allSucceeded
-      }
+      allSucceeded = (await handleTransferLogs(props.logids, background)) && allSucceeded
     }
 
     if (allSucceeded) emit('done')

--- a/src/components/dialog/__tests__/ReorganizeDialog.spec.ts
+++ b/src/components/dialog/__tests__/ReorganizeDialog.spec.ts
@@ -645,7 +645,7 @@ describe('ReorganizeDialog payloads and lifecycle', () => {
     expect(mocks.progressControllers[1].stop).toHaveBeenCalledTimes(1)
   })
 
-  it('submits each historical record with reorganize semantics', async () => {
+  it('submits selected historical records as one batch with reorganize semantics', async () => {
     const bodies: unknown[] = []
     server.use(
       http.post(new URL('transfer/manual', API_BASE_URL).href, async ({ request }) => {
@@ -662,24 +662,16 @@ describe('ReorganizeDialog payloads and lifecycle', () => {
     await waitFor(() => expect(onDone).toHaveBeenCalledTimes(1))
     expect(bodies).toEqual([
       expect.objectContaining({
-        fileitem: {},
         from_history: false,
-        logid: 41,
-        reorganize: true,
-        target_path: null,
-        target_storage: null,
-      }),
-      expect.objectContaining({
-        fileitem: {},
-        from_history: false,
-        logid: 42,
+        logids: [41, 42],
         reorganize: true,
         target_path: null,
         target_storage: null,
       }),
     ])
-    expect(mocks.toastSuccess).toHaveBeenNthCalledWith(1, '历史记录 41 已加入整理队列！')
-    expect(mocks.toastSuccess).toHaveBeenNthCalledWith(2, '历史记录 42 已加入整理队列！')
+    expect(bodies[0]).not.toHaveProperty('fileitem')
+    expect(bodies[0]).not.toHaveProperty('logid')
+    expect(mocks.toastSuccess).toHaveBeenCalledTimes(1)
   })
 
   it('updates synchronous progress from SSE and always stops it after success', async () => {
@@ -1087,7 +1079,7 @@ describe('ReorganizeDialog payloads and lifecycle', () => {
 
     expect(onClose).toHaveBeenCalledTimes(1)
     await waitFor(() => expect(bodies).toHaveLength(1))
-    expect(bodies[0]).toEqual(expect.objectContaining({ from_history: true, logid: 41 }))
+    expect(bodies[0]).toEqual(expect.objectContaining({ from_history: true, logids: [41] }))
   })
 })
 
@@ -1157,6 +1149,47 @@ describe('ReorganizeDialog preview', () => {
     expect(mocks.toastWarning).toHaveBeenCalledWith('成功 1，失败 1')
     expect(mocks.toastError).not.toHaveBeenCalled()
     expect(onDone).not.toHaveBeenCalled()
+  })
+
+  it('previews selected historical records in one batch request', async () => {
+    const payloads: unknown[] = []
+    server.use(
+      http.post(new URL('transfer/manual', API_BASE_URL).href, async ({ request }) => {
+        payloads.push(await request.json())
+        return HttpResponse.json(
+          previewResponse([
+            {
+              source: '/downloads/七里香/01.flac',
+              target: '/library/Album/周杰伦/七里香 (2004)/01.flac',
+              success: true,
+              title: '七里香 (2004)',
+              type: '音乐',
+            },
+            {
+              source: '/downloads/七里香/02.flac',
+              target: '/library/Album/周杰伦/七里香 (2004)/02.flac',
+              success: true,
+              title: '七里香 (2004)',
+              type: '音乐',
+            },
+          ]),
+        )
+      }),
+    )
+    const user = userEvent.setup()
+    await renderDialog({ logids: [41, 42] })
+
+    await user.click(screen.getByRole('button', { name: '预览' }))
+
+    expect(await screen.findByText('七里香 (2004)')).toBeInTheDocument()
+    expect(screen.getByText('总数 2')).toBeInTheDocument()
+    expect(payloads).toEqual([
+      expect.objectContaining({
+        logids: [41, 42],
+        preview: true,
+        reorganize: true,
+      }),
+    ])
   })
 
   it('merges and deduplicates preview results from separate source requests', async () => {


### PR DESCRIPTION
## Summary
- send selected transfer history IDs in one manual-transfer request
- preview and execute a music album as one batch instead of one request per track
- preserve album-level recognition, deduplication, classification, and grouped history behavior

## Verification
- ReorganizeDialog.spec.ts: 30 passed
- changed-file ESLint: passed
- changed-file Prettier: passed
- live MoviePilot Docker verification: 20 selected history rows deduplicated to 10 tracks, 10/10 successful, grouped as 七里香 (2004), routed to Album without 未分类