### PR TITLE
fix(music): clarify manual search candidates

### DIFF
--- a/src/components/dialog/AddDownloadDialog.vue
+++ b/src/components/dialog/AddDownloadDialog.vue
@@ -155,6 +155,8 @@ const mediaType = ref<DownloadMediaType>(
 
 const isMusicSelection = computed(() => mediaType.value === '音乐' || isMusicMediaSource(mediaSource.value))
 
+const mediaSearchHint = computed(() => props.title || props.torrent?.title || props.media?.title || '')
+
 const musicEntityOptions = computed(() => [
   { title: t('setting.cache.musicType.recording'), value: 'recording' },
   { title: t('setting.cache.musicType.album'), value: 'album' },
@@ -506,7 +508,8 @@ onMounted(() => {
       <MediaIdSelector
         v-model="mediaId"
         :type="mediaSource"
-        :music-types="isMusicSelection ? ['recording', 'album'] : undefined"
+        :music-types="isMusicSelection ? [musicType] : undefined"
+        :initial-keyword="isMusicSelection ? mediaSearchHint : undefined"
         @select="handleMediaSelected"
         @close="mediaSelectorDialog = false"
       />

--- a/src/components/dialog/ReorganizeDialog.vue
+++ b/src/components/dialog/ReorganizeDialog.vue
@@ -251,6 +251,14 @@ const defaultMusicEntity = computed<'album' | 'recording'>(() =>
   normalizedItems.value.length > 0 && normalizedItems.value.every(item => item.type === 'dir') ? 'album' : 'recording',
 )
 
+// 使用当前目录或文件名预填媒体搜索，保留艺术家和年份线索以区分同名专辑。
+const mediaSearchHint = computed(() => {
+  if (normalizedItems.value.length !== 1) return ''
+  const path = normalizedItems.value[0]?.path || ''
+  const name = path.split(/[\\/]/).filter(Boolean).at(-1) || ''
+  return normalizedItems.value[0]?.type === 'dir' ? name : name.replace(/\.[^.]+$/, '')
+})
+
 // 分页
 const previewPage = ref(1)
 const previewPageSize = ref(20)
@@ -2126,7 +2134,8 @@ onUnmounted(() => {
         @close="mediaSelectorDialog = false"
         @select="handleMediaSelected"
         :type="mediaSource"
-        :music-types="['recording', 'album']"
+        :music-types="transferForm.type_name === '音乐' ? [transferForm.music_type || defaultMusicEntity] : undefined"
+        :initial-keyword="transferForm.type_name === '音乐' ? mediaSearchHint : undefined"
       />
     </VDialog>
   </VDialog>

--- a/src/components/dialog/ScrapeDialog.vue
+++ b/src/components/dialog/ScrapeDialog.vue
@@ -47,8 +47,14 @@ const mediaSource = ref<MediaDataSource>(getDefaultMediaSource())
 const mediaId = ref<string | null>(null)
 const musicType = ref<Exclude<MusicEntityType, 'artist'>>('recording')
 const mediaSelectorDialog = ref(false)
-const scrapeMusicTypes: MusicEntityType[] = ['recording', 'album']
 const isMusicSelection = computed(() => mediaType.value === '音乐' || isMusicMediaSource(mediaSource.value))
+
+const mediaSearchHint = computed(() => {
+  if (props.items.length !== 1) return ''
+  const path = props.items[0]?.path || ''
+  const name = path.split(/[\\/]/).filter(Boolean).at(-1) || ''
+  return props.items[0]?.type === 'dir' ? name : name.replace(/\.[^.]+$/, '')
+})
 
 const dialogVisible = computed({
   get: () => props.modelValue,
@@ -224,7 +230,8 @@ watch(mediaType, type => {
       <MediaIdSelector
         v-model="mediaId"
         :type="mediaSource"
-        :music-types="scrapeMusicTypes"
+        :music-types="isMusicSelection ? [musicType] : undefined"
+        :initial-keyword="isMusicSelection ? mediaSearchHint : undefined"
         @close="mediaSelectorDialog = false"
         @select="handleMediaSelected"
       />

--- a/src/components/misc/MediaIdSelector.vue
+++ b/src/components/misc/MediaIdSelector.vue
@@ -10,6 +10,7 @@ const { t } = useI18n()
 const props = defineProps<{
   type: MediaDataSource
   musicTypes?: MusicEntityType[]
+  initialKeyword?: string
 }>()
 
 interface MediaSelectorItem {
@@ -25,6 +26,10 @@ interface MediaSelectorItem {
   type?: string
   // 音乐实体类型
   music_type?: MusicEntityType
+  // MusicBrainz Release Group 主类型
+  album_type?: string
+  // MusicBrainz Release Group 副类型
+  secondary_types?: string[]
 }
 
 // update:modelValue 事件
@@ -33,7 +38,7 @@ const emit = defineEmits(['update:modelValue', 'select', 'close'])
 const items = ref<MediaSelectorItem[]>([])
 
 // 搜索词
-const keyword = ref('')
+const keyword = ref(props.initialKeyword?.trim() || '')
 
 // 加载中
 const loading = ref(false)
@@ -69,6 +74,7 @@ async function searchMedias() {
         page: 1,
         count: 20,
         media_source: props.type,
+        ...(props.musicTypes?.length === 1 ? { music_type: props.musicTypes[0] } : {}),
       },
     })
 
@@ -84,15 +90,29 @@ async function searchMedias() {
       const mediaId = item.media_id?.toString().trim()
       if (!mediaId) continue
       const musicAlbum = item.music_type === 'album' || item.album === item.title ? undefined : item.album
+      const musicEntityLabels: Partial<Record<MusicEntityType, string>> = {
+        recording: t('music.entityRecording'),
+        album: t('music.entityAlbum'),
+        artist: t('music.entityArtist'),
+      }
+      const musicLabels = [
+        item.music_type ? musicEntityLabels[item.music_type] : undefined,
+        item.album_type,
+        ...(item.secondary_types || []),
+      ].filter(Boolean)
       items.value.push({
         id: mediaId,
         poster: getW500Image(item.cover_url || item.poster_path),
         type: item.type,
         music_type: item.music_type,
+        album_type: item.album_type,
+        secondary_types: item.secondary_types,
         title: item.year ? `${item.title}（${item.year}）` : item.title || '',
         overview:
           item.type === '音乐'
-            ? `<span class="text-primary">${item.type}</span> ${[item.artist, musicAlbum].filter(Boolean).join(' · ')}`
+            ? `<span class="text-primary">${musicLabels.join(' · ') || item.type}</span> ${[item.artist, musicAlbum]
+                .filter(Boolean)
+                .join(' · ')}`
             : `<span class="text-primary">${item.type}</span> ${item.overview || ''}`,
       })
     }
@@ -105,11 +125,23 @@ async function searchMedias() {
 
 // 加载时聚焦搜索框
 onMounted(() => {
+  if (keyword.value) void searchMedias()
   // 500ms后聚焦
   setTimeout(() => {
     inputKeyword.value?.focus()
   }, 500)
 })
+
+watch(
+  () => props.initialKeyword,
+  value => {
+    const nextKeyword = value?.trim() || ''
+    if (nextKeyword === keyword.value) return
+    keyword.value = nextKeyword
+    items.value = []
+    if (nextKeyword) void searchMedias()
+  },
+)
 </script>
 
 <template>

--- a/src/components/misc/MediaIdSelector.vue
+++ b/src/components/misc/MediaIdSelector.vue
@@ -43,6 +43,9 @@ const keyword = ref(props.initialKeyword?.trim() || '')
 // 加载中
 const loading = ref(false)
 
+// 只允许最后一次搜索更新列表，避免预填请求覆盖用户随后提交的新关键词。
+let searchRequestId = 0
+
 // ref
 const inputKeyword = ref<HTMLElement | null>(null)
 
@@ -63,6 +66,7 @@ function getW500Image(url = '') {
 async function searchMedias() {
   const searchKeyword = keyword.value.trim()
   if (!searchKeyword) return
+  const requestId = ++searchRequestId
 
   // 调用API搜索词条
   try {
@@ -77,6 +81,8 @@ async function searchMedias() {
         ...(props.musicTypes?.length === 1 ? { music_type: props.musicTypes[0] } : {}),
       },
     })
+
+    if (requestId !== searchRequestId) return
 
     // 清空
     items.value = []
@@ -117,9 +123,9 @@ async function searchMedias() {
       })
     }
   } catch (e) {
-    console.error(e)
+    if (requestId === searchRequestId) console.error(e)
   } finally {
-    loading.value = false
+    if (requestId === searchRequestId) loading.value = false
   }
 }
 
@@ -137,6 +143,7 @@ watch(
   value => {
     const nextKeyword = value?.trim() || ''
     if (nextKeyword === keyword.value) return
+    searchRequestId += 1
     keyword.value = nextKeyword
     items.value = []
     if (nextKeyword) void searchMedias()

--- a/src/components/misc/MediaIdSelector.vue
+++ b/src/components/misc/MediaIdSelector.vue
@@ -144,6 +144,7 @@ watch(
     const nextKeyword = value?.trim() || ''
     if (nextKeyword === keyword.value) return
     searchRequestId += 1
+    loading.value = false
     keyword.value = nextKeyword
     items.value = []
     if (nextKeyword) void searchMedias()

--- a/src/components/misc/MediaIdSelector.vue
+++ b/src/components/misc/MediaIdSelector.vue
@@ -139,15 +139,16 @@ onMounted(() => {
 })
 
 watch(
-  () => props.initialKeyword,
-  value => {
-    const nextKeyword = value?.trim() || ''
-    if (nextKeyword === keyword.value) return
+  () => [props.initialKeyword?.trim() || '', props.type, props.musicTypes?.join(',') || ''] as const,
+  ([nextKeyword, nextType, nextMusicTypes], [previousKeyword, previousType, previousMusicTypes]) => {
+    const keywordChanged = nextKeyword !== previousKeyword && nextKeyword !== keyword.value
+    const scopeChanged = nextType !== previousType || nextMusicTypes !== previousMusicTypes
+    if (!keywordChanged && !scopeChanged) return
     searchRequestId += 1
     loading.value = false
-    keyword.value = nextKeyword
+    if (keywordChanged) keyword.value = nextKeyword
     items.value = []
-    if (nextKeyword) void searchMedias()
+    if (keyword.value) void searchMedias()
   },
 )
 </script>

--- a/src/components/misc/__tests__/MediaIdSelector.spec.ts
+++ b/src/components/misc/__tests__/MediaIdSelector.spec.ts
@@ -269,6 +269,75 @@ describe('MediaIdSelector layout', () => {
     await waitFor(() => expect(fieldProgress()).toHaveStyle({ height: '0px' }))
   })
 
+  it('invalidates old results and searches again when the music entity scope changes', async () => {
+    let resolveAlbumSearch: (value: Array<Record<string, unknown>>) => void = () => undefined
+    const albumSearch = new Promise<Array<Record<string, unknown>>>(resolve => {
+      resolveAlbumSearch = resolve
+    })
+    mocks.apiGet.mockReturnValueOnce(albumSearch).mockResolvedValueOnce([
+      {
+        artist: 'Eagles',
+        media_id: 'recording-1',
+        media_source: 'musicbrainz',
+        music_type: 'recording',
+        title: 'Hotel California recording',
+        type: '音乐',
+      },
+    ])
+
+    const view = await renderWithProviders(MediaIdSelector, {
+      props: {
+        initialKeyword: 'Hotel California',
+        musicTypes: ['album'],
+        type: 'musicbrainz',
+      },
+      global: {
+        stubs: {
+          VDialogCloseBtn: {
+            props: ['innerClass'],
+            template: '<button type="button" :class="innerClass"><slot /></button>',
+          },
+        },
+      },
+    })
+
+    await waitFor(() => expect(mocks.apiGet).toHaveBeenCalledTimes(1))
+    await view.rerender({
+      initialKeyword: 'Hotel California',
+      musicTypes: ['recording'],
+      type: 'musicbrainz',
+    })
+
+    expect(await screen.findByText('Hotel California recording')).toBeInTheDocument()
+    expect(mocks.apiGet).toHaveBeenLastCalledWith('media/search', {
+      params: {
+        count: 20,
+        media_source: 'musicbrainz',
+        music_type: 'recording',
+        page: 1,
+        title: 'Hotel California',
+        type: 'music',
+      },
+    })
+
+    resolveAlbumSearch([
+      {
+        album_type: 'Album',
+        artist: 'Eagles',
+        media_id: 'album-1',
+        media_source: 'musicbrainz',
+        music_type: 'album',
+        title: 'Stale Hotel California album',
+        type: '音乐',
+      },
+    ])
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(screen.queryByText('Stale Hotel California album')).not.toBeInTheDocument()
+    expect(screen.getByText('Hotel California recording')).toBeInTheDocument()
+  })
+
   it('does not infer a primary identity from auxiliary provider IDs', async () => {
     mocks.apiGet.mockResolvedValue([
       {

--- a/src/components/misc/__tests__/MediaIdSelector.spec.ts
+++ b/src/components/misc/__tests__/MediaIdSelector.spec.ts
@@ -1,5 +1,5 @@
 import MediaIdSelector from '@/components/misc/MediaIdSelector.vue'
-import { fireEvent, screen } from '@testing-library/vue'
+import { fireEvent, screen, waitFor } from '@testing-library/vue'
 import { renderWithProviders } from '@tests/support/render'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -179,6 +179,64 @@ describe('MediaIdSelector layout', () => {
       item.textContent?.trim(),
     )
     expect(subtitles).toEqual(['专辑 · Single · Live Eagles', '专辑 · Album Eagles'])
+  })
+
+  it('keeps newer manual search results when the initial search finishes later', async () => {
+    let resolveInitialSearch: (value: MediaInfo[]) => void = () => undefined
+    const initialSearch = new Promise<MediaInfo[]>(resolve => {
+      resolveInitialSearch = resolve
+    })
+    mocks.apiGet.mockReturnValueOnce(initialSearch).mockResolvedValueOnce([
+      {
+        album_type: 'Album',
+        artist: 'Eagles',
+        media_id: 'new-result',
+        media_source: 'musicbrainz',
+        music_type: 'album',
+        title: 'Hotel California',
+        type: '音乐',
+        year: 1976,
+      },
+    ])
+
+    await renderWithProviders(MediaIdSelector, {
+      props: {
+        initialKeyword: 'Hotel California',
+        musicTypes: ['album'],
+        type: 'musicbrainz',
+      },
+      global: {
+        stubs: {
+          VDialogCloseBtn: {
+            props: ['innerClass'],
+            template: '<button type="button" :class="innerClass"><slot /></button>',
+          },
+        },
+      },
+    })
+
+    await waitFor(() => expect(mocks.apiGet).toHaveBeenCalledTimes(1))
+    const input = screen.getByPlaceholderText('输入媒体名称')
+    await fireEvent.update(input, 'Eagles - Hotel California (1976)')
+    await fireEvent.keyDown(input, { key: 'Enter' })
+    expect(await screen.findByText('Hotel California（1976）')).toBeInTheDocument()
+
+    resolveInitialSearch([
+      {
+        album_type: 'Single',
+        artist: 'Cover Artist',
+        media_id: 'old-result',
+        media_source: 'musicbrainz',
+        music_type: 'album',
+        title: 'Stale Hotel California',
+        type: '音乐',
+      },
+    ])
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(screen.queryByText('Stale Hotel California')).not.toBeInTheDocument()
+    expect(screen.getByText('Hotel California（1976）')).toBeInTheDocument()
   })
 
   it('does not infer a primary identity from auxiliary provider IDs', async () => {

--- a/src/components/misc/__tests__/MediaIdSelector.spec.ts
+++ b/src/components/misc/__tests__/MediaIdSelector.spec.ts
@@ -182,8 +182,8 @@ describe('MediaIdSelector layout', () => {
   })
 
   it('keeps newer manual search results when the initial search finishes later', async () => {
-    let resolveInitialSearch: (value: MediaInfo[]) => void = () => undefined
-    const initialSearch = new Promise<MediaInfo[]>(resolve => {
+    let resolveInitialSearch: (value: Array<Record<string, unknown>>) => void = () => undefined
+    const initialSearch = new Promise<Array<Record<string, unknown>>>(resolve => {
       resolveInitialSearch = resolve
     })
     mocks.apiGet.mockReturnValueOnce(initialSearch).mockResolvedValueOnce([

--- a/src/components/misc/__tests__/MediaIdSelector.spec.ts
+++ b/src/components/misc/__tests__/MediaIdSelector.spec.ts
@@ -111,7 +111,74 @@ describe('MediaIdSelector layout', () => {
     const subtitles = Array.from(container.querySelectorAll('.v-list-item-subtitle')).map(item =>
       item.textContent?.trim(),
     )
-    expect(subtitles).toEqual(['音乐 周杰伦', '音乐 周杰伦 · 叶惠美'])
+    expect(subtitles).toEqual(['专辑 周杰伦', '单曲 周杰伦 · 叶惠美'])
+  })
+
+  it('prefills album searches, scopes the API request, and exposes release-group types', async () => {
+    mocks.apiGet.mockResolvedValue([
+      {
+        album_type: 'Single',
+        artist: 'Eagles',
+        media_id: 'live-single',
+        media_source: 'musicbrainz',
+        music_type: 'album',
+        secondary_types: ['Live'],
+        title: 'Hotel California',
+        type: '音乐',
+      },
+      {
+        album_type: 'Album',
+        artist: 'Eagles',
+        media_id: 'studio-album',
+        media_source: 'musicbrainz',
+        music_type: 'album',
+        title: 'Hotel California',
+        type: '音乐',
+        year: 1976,
+      },
+      {
+        artist: 'Eagles',
+        media_id: 'recording-1',
+        media_source: 'musicbrainz',
+        music_type: 'recording',
+        title: 'Hotel California',
+        type: '音乐',
+      },
+    ])
+
+    const { container } = await renderWithProviders(MediaIdSelector, {
+      props: {
+        initialKeyword: 'Eagles - Hotel California (1976)',
+        musicTypes: ['album'],
+        type: 'musicbrainz',
+      },
+      global: {
+        stubs: {
+          VDialogCloseBtn: {
+            props: ['innerClass'],
+            template: '<button type="button" :class="innerClass"><slot /></button>',
+          },
+        },
+      },
+    })
+
+    expect(await screen.findByText('Hotel California（1976）')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('输入媒体名称')).toHaveValue('Eagles - Hotel California (1976)')
+    expect(mocks.apiGet).toHaveBeenCalledWith('media/search', {
+      params: {
+        count: 20,
+        media_source: 'musicbrainz',
+        music_type: 'album',
+        page: 1,
+        title: 'Eagles - Hotel California (1976)',
+        type: 'music',
+      },
+    })
+    expect(screen.queryByText('单曲 Eagles')).not.toBeInTheDocument()
+    const subtitles = Array.from(container.querySelectorAll('.v-list-item-subtitle')).map(item =>
+      item.textContent?.trim(),
+    )
+    expect(subtitles).toEqual(['专辑 · Single · Live Eagles', '专辑 · Album Eagles'])
   })
 
   it('does not infer a primary identity from auxiliary provider IDs', async () => {

--- a/src/components/misc/__tests__/MediaIdSelector.spec.ts
+++ b/src/components/misc/__tests__/MediaIdSelector.spec.ts
@@ -239,6 +239,36 @@ describe('MediaIdSelector layout', () => {
     expect(screen.getByText('Hotel California（1976）')).toBeInTheDocument()
   })
 
+  it('ends loading when a pending initial search is cancelled', async () => {
+    mocks.apiGet.mockReturnValue(new Promise(() => undefined))
+
+    const view = await renderWithProviders(MediaIdSelector, {
+      props: {
+        initialKeyword: 'Hotel California',
+        musicTypes: ['album'],
+        type: 'musicbrainz',
+      },
+      global: {
+        stubs: {
+          VDialogCloseBtn: {
+            props: ['innerClass'],
+            template: '<button type="button" :class="innerClass"><slot /></button>',
+          },
+        },
+      },
+    })
+
+    const fieldProgress = () => view.container.querySelector('.v-field__loader .v-progress-linear')
+    await waitFor(() => expect(fieldProgress()).toHaveStyle({ height: '2px' }))
+    await view.rerender({
+      initialKeyword: '',
+      musicTypes: ['album'],
+      type: 'musicbrainz',
+    })
+
+    await waitFor(() => expect(fieldProgress()).toHaveStyle({ height: '0px' }))
+  })
+
   it('does not infer a primary identity from auxiliary provider IDs', async () => {
     mocks.apiGet.mockResolvedValue([
       {


### PR DESCRIPTION
## 问题

音乐手动整理选择“专辑”时，前端仍允许 Recording 与 Release Group 混合搜索，结果只显示泛化的“音乐”标签，无法辨认 Album、Single 或 Live；用户还需要重新输入目录中的艺人、专辑和年份。

## 修改

- 搜索请求跟随当前音乐实体，只查询单曲或专辑
- 从当前音乐目录/文件名预填并自动执行搜索，保留艺人和年份线索
- 结果明确展示单曲/专辑实体，以及 MusicBrainz 的 Album、Single、Live 等主副类型
- 下载、刮削和手动整理入口统一采用相同行为

## 验证

- `vitest`：MediaIdSelector、ReorganizeDialog、AddDownloadDialog、ScrapeDialog 共 58 项通过
- changed-file ESLint 通过
- changed-file Prettier 检查通过

全量 `vue-tsc` 的 4 个错误可在未修改的上游 v3 基线复现，均位于 `ClassificationRuleEditor.vue`，与本 PR 无关。

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 73b6ba6792f622d3b4c508ed197d04432dce5f2f

- 按当前音乐实体限定手动搜索
- 自动预填路径、标题并发起搜索
- 展示专辑主类型与副类型
- 防止过期请求覆盖最新结果
- 补充筛选、预填及竞态测试
- 非音乐媒体搜索行为保持兼容
<!-- pr-agent-summary:end -->
