### PR TITLE
fix(history): prevent keep-alive route bounce

### DIFF
--- a/src/views/reorganize/TransferHistoryView.vue
+++ b/src/views/reorganize/TransferHistoryView.vue
@@ -525,6 +525,7 @@ watch(
 watch(
   () => route.query,
   () => {
+    if (route.path !== '/history') return
     if (isDesktop.value) {
       void refreshDataFromRouteQuery()
     } else {
@@ -537,6 +538,7 @@ watch(
 
 // 响应桌面与移动端断点切换，进入对应布局后刷新对应数据源。
 watch(isDesktop, desktop => {
+  if (route.path !== '/history') return
   if (desktop) {
     void refreshDataFromRouteQuery()
   } else {
@@ -1387,11 +1389,13 @@ function createHistoryUrl(resetPage = false, page = resetPage ? 1 : currentPage.
 
 // 重载页面，先更新路由，再由路由监听统一拉取列表数据。
 async function reloadPage(resetPage = false) {
+  if (route.path !== '/history') return
   await router.push(createHistoryUrl(resetPage))
 }
 
 // 移动端搜索同样以 URL 为持久事实源，刷新和断点切换后可恢复同一查询。
 async function reloadMobileSearchPage() {
+  if (route.path !== '/history') return
   await router.push(createHistoryUrl(true))
 }
 
@@ -1848,6 +1852,15 @@ onActivated(() => {
   } else if (isMobile.value && !mobileLoading.value) {
     resetMobileHistory()
   }
+})
+
+// 页面由 KeepAlive 缓存时不会卸载；离开后必须停止路由回写并作废在途请求。
+onDeactivated(() => {
+  fetchDataRequestSeed++
+  mobileFetchDataRequestSeed++
+  debouncedReloadPage.cancel()
+  debouncedReloadSearchPage.cancel()
+  debouncedReloadMobileSearchPage.cancel()
 })
 
 onUnmounted(() => {

--- a/src/views/reorganize/__tests__/TransferHistoryView.spec.ts
+++ b/src/views/reorganize/__tests__/TransferHistoryView.spec.ts
@@ -919,6 +919,27 @@ describe('TransferHistoryView', () => {
     expect(router.currentRoute.value.query.grouped).toBeUndefined()
   })
 
+  it('does not restore the history route after navigation changes the global query', async () => {
+    const tracks = [
+      createHistory(1, 'Hotel California', {
+        dest: '/media/Eagles/Hotel California (1976)/01 - Hotel California.dsf',
+        src: '/downloads/Eagles - Hotel California/01 - Hotel California.dsf',
+        type: '音乐',
+      }),
+    ]
+    mocks.apiGet.mockImplementation((path: string) => {
+      if (path === 'storage/options') return Promise.resolve(storageResponse())
+      return Promise.resolve(historyResponse(tracks))
+    })
+
+    const { router } = await renderHistory('/history?itemsPerPage=50&currentPage=1&grouped=true')
+    await flushPromises()
+    await router.push('/downloading')
+    await flushPromises()
+
+    expect(router.currentRoute.value.path).toBe('/downloading')
+  })
+
   it('loads mobile pages with deduplication and reports empty when the last page is exhausted', async () => {
     mocks.desktop = false
     const firstPage = Array.from({ length: 25 }, (_, index) => createHistory(index + 1, `记录 ${index + 1}`))


### PR DESCRIPTION
## 问题
媒体整理页启用 KeepAlive 后，离开 `/history` 仍会响应全局 `route.query` 变化。跳转到下载管理等页面时，缓存视图会刷新历史数据并重新写入 `/history`，导致路由短暂跳转后自动返回。

## 修复
- 非 `/history` 路由不再响应历史页查询参数及断点监听
- 历史路由回写前再次确认当前路径
- KeepAlive 停用时取消防抖任务并作废在途请求
- 增加从带分组参数的历史页跳转到下载管理的回归测试

## 验证
- `vitest run src/views/reorganize/__tests__/TransferHistoryView.spec.ts`：45 tests passed
- 修改文件 ESLint 通过
- changed-file Prettier 检查通过

本地完整 `vue-tsc --noEmit` 仍显示基线已有的 `ClassificationRuleEditor.vue` 四处隐式 any，本 PR 未修改该文件。

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at e43ef922995f9eacdeb638d9950d79a428cb6910

- 修复 KeepAlive 历史页路由回跳
  - 非 `/history` 时停止查询同步与断点刷新
  - 停止路由回写并取消延迟任务
  - 作废离页后的在途数据请求
- 新增跳转下载页回归测试
- 兼容性：仅限制离开历史页后的副作用
- 风险：固定 `/history` 路径依赖路由配置
<!-- pr-agent-summary:end -->
