### PR TITLE
fix(history): prevent keep-alive route bounce

### DIFF
--- a/src/views/reorganize/TransferHistoryView.vue
+++ b/src/views/reorganize/TransferHistoryView.vue
@@ -12,7 +12,7 @@ import type {
 import ReorganizeDialog from '@/components/dialog/ReorganizeDialog.vue'
 import TransferQueueDialog from '@/components/dialog/TransferQueueDialog.vue'
 import ProgressDialog from '@/components/dialog/ProgressDialog.vue'
-import { useRoute, useRouter } from 'vue-router'
+import { onBeforeRouteLeave, useRoute, useRouter } from 'vue-router'
 import { useDisplay } from 'vuetify'
 import { formatFileSize } from '@/@core/utils/formatters'
 import { useI18n } from 'vue-i18n'
@@ -62,6 +62,7 @@ let syncingRouteQuery = false
 let fetchDataRequestSeed = 0
 let mobileFetchDataRequestSeed = 0
 let componentUnmounted = false
+let historyViewActive = true
 
 // 组合式输入法状态
 const isComposing = ref(false)
@@ -481,14 +482,14 @@ const debouncedReloadMobileSearchPage = debounce(() => {
 
 // 切换页签
 watch([() => currentPage.value, () => itemsPerPage.value], () => {
-  if (syncingRouteQuery || !isDesktop.value) return
+  if (!historyViewActive || syncingRouteQuery || !isDesktop.value) return
 
   debouncedReloadPage()
 })
 
 // 搜索监听
 watch([() => search.value, () => isComposing.value], () => {
-  if (syncingRouteQuery || isComposing.value) return
+  if (!historyViewActive || syncingRouteQuery || isComposing.value) return
 
   if (isMobile.value) {
     debouncedReloadMobileSearchPage()
@@ -502,7 +503,7 @@ watch([() => search.value, () => isComposing.value], () => {
 watch(
   () => statusFilter.value,
   () => {
-    if (syncingRouteQuery) return
+    if (!historyViewActive || syncingRouteQuery) return
     if (isMobile.value) {
       void reloadMobileSearchPage()
       return
@@ -515,7 +516,7 @@ watch(
 watch(
   () => group.value,
   () => {
-    if (syncingRouteQuery || !isDesktop.value) return
+    if (!historyViewActive || syncingRouteQuery || !isDesktop.value) return
 
     void reloadPage()
   },
@@ -525,7 +526,7 @@ watch(
 watch(
   () => route.query,
   () => {
-    if (route.path !== '/history') return
+    if (!historyViewActive || route.path !== '/history') return
     if (isDesktop.value) {
       void refreshDataFromRouteQuery()
     } else {
@@ -538,7 +539,7 @@ watch(
 
 // 响应桌面与移动端断点切换，进入对应布局后刷新对应数据源。
 watch(isDesktop, desktop => {
-  if (route.path !== '/history') return
+  if (!historyViewActive || route.path !== '/history') return
   if (desktop) {
     void refreshDataFromRouteQuery()
   } else {
@@ -659,6 +660,7 @@ function hasMusicAlbumGroup(items: TransferHistoryDisplayItem[]) {
 
 // 获取历史记录数据，keep-alive 重新进入时可静默刷新，避免表格出现重新加载感。
 async function fetchData(page = currentPage.value, count = itemsPerPage.value, options: { silent?: boolean } = {}) {
+  if (!historyViewActive) return
   const requestSeed = ++fetchDataRequestSeed
   const shouldShowLoading = !options.silent
   if (shouldShowLoading) {
@@ -674,7 +676,7 @@ async function fetchData(page = currentPage.value, count = itemsPerPage.value, o
         ...(statusFilter.value === 'all' ? {} : { status: statusFilter.value === 'success' }),
       },
     })
-    if (requestSeed !== fetchDataRequestSeed) return
+    if (!historyViewActive || requestSeed !== fetchDataRequestSeed) return
 
     const list = Array.isArray(result.list) ? result.list : []
 
@@ -691,7 +693,7 @@ async function fetchData(page = currentPage.value, count = itemsPerPage.value, o
     totalItems.value = ensureNumber(result.total, 0)
     updateSearchHintList(list)
 
-    if (isDesktop.value && route.query.grouped === undefined && hasMusicAlbumGroup(displayList)) {
+    if (historyViewActive && isDesktop.value && route.query.grouped === undefined && hasMusicAlbumGroup(displayList)) {
       group.value = true
     }
 
@@ -943,7 +945,9 @@ async function syncStateFromRouteQuery() {
 
 // 根据地址栏中的查询参数刷新历史列表。
 async function refreshDataFromRouteQuery(options: { silent?: boolean } = {}) {
+  if (!historyViewActive) return
   await syncStateFromRouteQuery()
+  if (!historyViewActive) return
   await fetchData(currentPage.value, itemsPerPage.value, options)
 }
 
@@ -1389,13 +1393,13 @@ function createHistoryUrl(resetPage = false, page = resetPage ? 1 : currentPage.
 
 // 重载页面，先更新路由，再由路由监听统一拉取列表数据。
 async function reloadPage(resetPage = false) {
-  if (route.path !== '/history') return
+  if (!historyViewActive || route.path !== '/history') return
   await router.push(createHistoryUrl(resetPage))
 }
 
 // 移动端搜索同样以 URL 为持久事实源，刷新和断点切换后可恢复同一查询。
 async function reloadMobileSearchPage() {
-  if (route.path !== '/history') return
+  if (!historyViewActive || route.path !== '/history') return
   await router.push(createHistoryUrl(true))
 }
 
@@ -1842,6 +1846,7 @@ onMounted(() => {
 })
 
 onActivated(() => {
+  historyViewActive = true
   if (!hasActivatedOnce.value) {
     hasActivatedOnce.value = true
     return
@@ -1854,20 +1859,33 @@ onActivated(() => {
   }
 })
 
-// 页面由 KeepAlive 缓存时不会卸载；离开后必须停止路由回写并作废在途请求。
-onDeactivated(() => {
+// 路由离开先于 KeepAlive 失活；必须在离开守卫阶段关闭回写窗口，避免在途请求抢回历史页。
+function deactivateHistoryView() {
+  historyViewActive = false
   fetchDataRequestSeed++
   mobileFetchDataRequestSeed++
   debouncedReloadPage.cancel()
   debouncedReloadSearchPage.cancel()
   debouncedReloadMobileSearchPage.cancel()
+  loading.value = false
+  mobileLoading.value = false
+}
+
+// 组件测试和独立复用时可能不在 RouterView 记录内；仅由正式 history 路由注册离开守卫。
+if (route.matched.some(record => record.path === '/history')) {
+  onBeforeRouteLeave(() => {
+    deactivateHistoryView()
+  })
+}
+
+// 页面由 KeepAlive 缓存时不会卸载；失活钩子负责兜底非路由驱动的缓存切换。
+onDeactivated(() => {
+  deactivateHistoryView()
 })
 
 onUnmounted(() => {
   componentUnmounted = true
-  debouncedReloadPage.cancel()
-  debouncedReloadSearchPage.cancel()
-  debouncedReloadMobileSearchPage.cancel()
+  deactivateHistoryView()
   stopAiRedoProgress()
   closeProgressDialog()
   aiRedoProgressDialogController?.close()

--- a/src/views/reorganize/__tests__/TransferHistoryView.spec.ts
+++ b/src/views/reorganize/__tests__/TransferHistoryView.spec.ts
@@ -7,7 +7,8 @@ import TransferHistoryView from '@/views/reorganize/TransferHistoryView.vue'
 import { fireEvent, screen, waitFor } from '@testing-library/vue'
 import { renderWithProviders } from '@tests/support/render'
 import { flushPromises } from '@vue/test-utils'
-import { computed, defineComponent, h, nextTick, ref, unref, type PropType } from 'vue'
+import { computed, defineComponent, h, KeepAlive, nextTick, ref, unref, type PropType } from 'vue'
+import { RouterView } from 'vue-router'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const transferHistorySource = readFileSync(resolve(cwd(), 'src/views/reorganize/TransferHistoryView.vue'), 'utf8')
@@ -404,6 +405,54 @@ async function renderHistory(initialRoute = '/history') {
         superUser: true,
       },
     },
+  })
+}
+
+async function renderHistoryRoute(initialRoute = '/history', downloadingBeforeEnter?: () => Promise<void>) {
+  const RouterHost = defineComponent({
+    name: 'HistoryRouterHost',
+    setup: () => () =>
+      h(RouterView, null, {
+        default: ({ Component }: { Component: object }) =>
+          h(KeepAlive, null, { default: () => (Component ? h(Component) : null) }),
+      }),
+  })
+  const DownloadingRoute = defineComponent({
+    name: 'DownloadingTestRoute',
+    setup: () => () => h('div', '下载管理'),
+  })
+
+  return renderWithProviders(RouterHost, {
+    global: {
+      stubs: {
+        ProgressiveCardGrid: ProgressiveGridStub,
+        VCombobox: SearchStub,
+        VDataTableVirtual: HistoryTableStub,
+        VImg: ImageStub,
+        VInfiniteScroll: InfiniteScrollStub,
+        IconBtn: IconButtonStub,
+        VList: PassthroughStub,
+        VListItem: ListItemStub,
+        VListItemTitle: ListItemTitleStub,
+        VMenu: PassthroughStub,
+        VPageContentTitle: true,
+        VPagination: EmptyStub,
+        VSelect: EmptyStub,
+      },
+    },
+    initialRoute,
+    initialState: {
+      globalSettings: { data: { AI_AGENT_ENABLE: true, GLOBAL_IMAGE_CACHE: false } },
+      user: { permissions: ['manage'], superUser: true },
+    },
+    routes: [
+      { path: '/history', component: TransferHistoryView, meta: { keepAlive: true } },
+      {
+        path: '/downloading',
+        component: DownloadingRoute,
+        ...(downloadingBeforeEnter ? { beforeEnter: downloadingBeforeEnter } : {}),
+      },
+    ],
   })
 }
 
@@ -935,6 +984,42 @@ describe('TransferHistoryView', () => {
     const { router } = await renderHistory('/history?itemsPerPage=50&currentPage=1&grouped=true')
     await flushPromises()
     await router.push('/downloading')
+    await flushPromises()
+
+    expect(router.currentRoute.value.path).toBe('/downloading')
+  })
+
+  it('invalidates a history request as soon as route navigation starts', async () => {
+    const historyRequest = createDeferred<ReturnType<typeof historyResponse>>()
+    const navigationEntered = createDeferred<void>()
+    const finishNavigation = createDeferred<void>()
+    mocks.apiGet.mockImplementation((path: string) => {
+      if (path === 'storage/options') return Promise.resolve(storageResponse())
+      return historyRequest.promise
+    })
+
+    const { router } = await renderHistoryRoute('/history', async () => {
+      navigationEntered.resolve()
+      await finishNavigation.promise
+    })
+    const navigation = router.push('/downloading')
+    await navigationEntered.promise
+
+    historyRequest.resolve(
+      historyResponse([
+        createHistory(1, 'Hotel California', {
+          dest: '/media/Eagles/Hotel California (1976)/01 - Hotel California.dsf',
+          type: '音乐',
+        }),
+        createHistory(2, 'New Kid in Town', {
+          dest: '/media/Eagles/Hotel California (1976)/02 - New Kid in Town.dsf',
+          type: '音乐',
+        }),
+      ]),
+    )
+    await flushPromises()
+    finishNavigation.resolve()
+    await navigation
     await flushPromises()
 
     expect(router.currentRoute.value.path).toBe('/downloading')

--- a/tests/support/render.ts
+++ b/tests/support/render.ts
@@ -4,7 +4,13 @@ import { createTestingPinia } from '@pinia/testing'
 import { render } from '@testing-library/vue'
 import { setActivePinia } from 'pinia'
 import { defineComponent, h, type Component } from 'vue'
-import { createMemoryHistory, createRouter, type RouteLocationRaw, type RouteMeta } from 'vue-router'
+import {
+  createMemoryHistory,
+  createRouter,
+  type RouteLocationRaw,
+  type RouteMeta,
+  type RouteRecordRaw,
+} from 'vue-router'
 import { vi } from 'vitest'
 
 type TestingLibraryRenderOptions = NonNullable<Parameters<typeof render>[1]>
@@ -14,6 +20,7 @@ export interface RenderWithProvidersOptions extends Omit<TestingLibraryRenderOpt
   initialRoute?: RouteLocationRaw
   initialRouteMeta?: RouteMeta
   initialState?: Record<string, Record<string, unknown>>
+  routes?: RouteRecordRaw[]
   stubActions?: boolean
 }
 
@@ -29,12 +36,13 @@ export async function renderWithProviders(component: Component, options: RenderW
     initialRoute = '/',
     initialRouteMeta = {},
     initialState = {},
+    routes,
     stubActions = true,
     ...renderOptions
   } = options
   const router = createRouter({
     history: createMemoryHistory(),
-    routes: [{ path: '/:pathMatch(.*)*', component: EmptyRoute, meta: initialRouteMeta }],
+    routes: routes ?? [{ path: '/:pathMatch(.*)*', component: EmptyRoute, meta: initialRouteMeta }],
   })
   await router.push(initialRoute)
   i18n.global.locale.value = 'zh-CN'


### PR DESCRIPTION
Summary:
- Stop cached transfer-history watchers from synchronizing URL state after leaving the history route.
- Cancel pending desktop/mobile debounced reloads and invalidate in-flight requests on deactivation.
- Add a regression test covering navigation from history to downloading.

TransferHistoryView is kept alive. Its global route-query watcher remained active after sidebar navigation, interpreted the destination route's empty query as history filter state, and pushed the browser back to the history route.

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 0689b40fab6540f4b58a4c029832458a8a0a9411

- 修复缓存历史页导航回跳
  - 路由离开即停用查询同步与写入
  - 作废在途请求并取消防抖刷新
- 仅激活时处理历史数据刷新
  - 防止失活组件更新加载状态
- 新增导航期间在途请求回归测试
- 扩展测试渲染工具自定义路由支持
<!-- pr-agent-summary:end -->
