### PR TITLE
fix(plugin): 停用唯一分身时不再误报默认调用目标警告

### DIFF
--- a/src/components/dialog/PluginInstanceManageDialog.vue
+++ b/src/components/dialog/PluginInstanceManageDialog.vue
@@ -97,6 +97,17 @@ function isCurrentInstance(row: InstanceRow): boolean {
   return Boolean(currentId) && isSameInstance(row.instanceId, currentId)
 }
 
+/**
+ * 判断停用某一行分身之后，插件是否仍然「有分身」。
+ *
+ * 只有停用后仍「有分身」时，未点名实例的调用才会因为没有默认目标而直接失败；
+ * 只有本体、没有分身时调用直接落到本体，不受此约束。停用的行本身要从「停用后
+ * 剩余」里排除，已经停用的行不在 rows（在册清单）里，本体不算分身。
+ */
+function hasOtherClonesAfterDisabling(row: InstanceRow): boolean {
+  return rows.value.some(other => !other.isHost && !isSameInstance(other.instanceId, row.instanceId))
+}
+
 /** 把 ISO 时间转换为 datetime-local 输入框可直接使用的本地时间字符串。 */
 function toDatetimeLocalValue(iso?: string | null): string {
   if (!iso) return ''
@@ -464,7 +475,7 @@ watch(targetPluginId, () => {
                 <div class="text-body-2 text-medium-emphasis">{{ t('plugin.instanceDisableClearsPlacements') }}</div>
                 <div class="text-body-2 text-medium-emphasis">{{ t('plugin.instanceDisableLeavesList') }}</div>
                 <VAlert
-                  v-if="row.isDefaultTarget"
+                  v-if="row.isDefaultTarget && hasOtherClonesAfterDisabling(row)"
                   type="warning"
                   variant="tonal"
                   density="compact"

--- a/src/components/dialog/__tests__/PluginInstanceManageDialog.spec.ts
+++ b/src/components/dialog/__tests__/PluginInstanceManageDialog.spec.ts
@@ -201,6 +201,43 @@ describe('PluginInstanceManageDialog', () => {
     expect(screen.getByText('业务参数与展示信息仍在，启用即恢复')).toBeInTheDocument()
   })
 
+  it('停用的分身是唯一分身时，即使它是默认调用目标也不警告调用会失败', async () => {
+    // 停用后只剩本体，调用直接落到本体，不受「未点名实例的调用会失败」约束
+    mocks.getInstalledPlugins.mockResolvedValue([
+      installedPlugins[0],
+      { ...installedPlugins[1], is_default_target: true },
+    ])
+    await renderDialog()
+
+    await fireEvent.click(await screen.findByTestId('instance-disable-DemoPluginwork'))
+
+    expect(screen.queryByText('它是当前的默认调用目标，停用后没有点名实例的调用会失败，直到重新指定。')).toBeNull()
+  })
+
+  it('停用的分身是默认调用目标、但还有其他在册分身时，警告调用会失败', async () => {
+    const multiCloneOverview: PluginInstanceLogLevelOverview = {
+      plugin_id: 'DemoPlugin',
+      instances: [
+        overview.instances[0],
+        overview.instances[1],
+        { instance_id: 'DemoPluginwork2', configured_level: null, expires_at: null, effective_level: 'INFO' },
+      ],
+    }
+    mocks.getPluginInstanceLogLevels.mockResolvedValue(multiCloneOverview)
+    mocks.getInstalledPlugins.mockResolvedValue([
+      installedPlugins[0],
+      { ...installedPlugins[1], is_default_target: true },
+      { id: 'DemoPluginwork2', plugin_name: '备用分身', is_instance: true, source_plugin_id: 'DemoPlugin' },
+    ])
+    await renderDialog()
+
+    await fireEvent.click(await screen.findByTestId('instance-disable-DemoPluginwork'))
+
+    expect(
+      screen.getByText('它是当前的默认调用目标，停用后没有点名实例的调用会失败，直到重新指定。'),
+    ).toBeInTheDocument()
+  })
+
   it('刚停用的实例可以当场再启用', async () => {
     await renderDialog()
     await fireEvent.click(await screen.findByTestId('instance-disable-DemoPluginwork'))


### PR DESCRIPTION
修 #779 的评审意见（pullrequestreview-5190240077）。

停用确认框此前只按「这一行是不是当前默认调用目标」决定要不要警告「停用后未点名实例的调用会失败」，
没有考虑停用之后这个插件还剩不剩分身。

当默认目标恰好是**唯一**那个分身时，停用后只剩本体。按后端契约，只有本体、没有分身时不受默认目标约束，
调用直接落到本体。此时仍然警告会让用户误判停用的影响。

正确的触发条件是「停用之后仍然存在其他在册分身」。新增 `hasOtherClonesAfterDisabling`，
把即将停用的那一行从剩余判断里排除，本体不计入分身；已停用的行本就不在后端返回的在册清单里。

复现用例先在修复前跑红（警告仍被显示），修复后转绿，另补一条「还有其他分身时仍要警告」的对照用例。

验证：`vitest run` 3325 用例全绿（相对基线 +2）、`vue-tsc --noEmit` 无错、
`eslint --max-warnings=0` 无错无警告。

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 2ae72085be37ef82e801b7aeee58c3e46b83fe00

- 修正唯一分身停用时的默认目标误警告
- 停用后仍有其他分身才提示调用失败
- 补充唯一及多分身场景测试
- 不影响后端接口与既有配置行为
<!-- pr-agent-summary:end -->
